### PR TITLE
First round of alert stabilization

### DIFF
--- a/UnitTests/IOconfAlertTests.cs
+++ b/UnitTests/IOconfAlertTests.cs
@@ -1,0 +1,91 @@
+﻿using CA_DataUploaderLib.IOconf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class IOconfAlertTests
+    {
+        [DataRow("Alert;MyName;=;123", 123d)]
+        [DataRow("Alert;MyName;=;193.123", 193.123d)]
+        [DataRow("Alert;MyName;>;123", 123.00012d)]
+        [DataRow("Alert;MyName;>;123", 124d)]
+        [DataRow("Alert;MyName;>=;123", 123d)]
+        [DataRow("Alert;MyName;nan", double.NaN)]
+        [DataRow("Alert;MyName;int", 123d)]
+        [DataRow("Alert;MyName;int", 122d)]
+        [DataRow("Alert;MyName;int", 100000d)]
+        [DataRow("Alert;MyName;int", 10000000d)]
+        [DataRow("Alert;MyName;int", 1d)]
+        [DataRow("Alert;MyName;int", -1d)]
+        [DataRow("Alert;MyName;int", -10000000d)]
+        [DataTestMethod]
+        public void AlertTriggers(string row, double value) 
+        {
+            var alert = new IOconfAlert(row, 0);
+            Assert.IsTrue(alert.CheckValue(value));
+        }
+
+        [DataRow("Alert;MyName;=;123", 122d, 123d)]
+        [DataRow("Alert;MyName;=;193.123", 193.122d, 193.123d)]
+        [DataRow("Alert;MyName;>;123", 123d, 123.00012d)]
+        [DataRow("Alert;MyName;>;123", 123d, 124d)]
+        [DataRow("Alert;MyName;>=;123", 122.999d, 123d)]
+        [DataRow("Alert;MyName;<=;123", 123.001d, 123d)]
+        [DataRow("Alert;MyName;<=;123", 123.001d, 122d)]
+        [DataRow("Alert;MyName;<;123", 123.001d, 122d)]
+        [DataRow("Alert;MyName;!=;123", 123d, 122.999d)]
+        [DataRow("Alert;MyName;nan", 123d, double.NaN)]
+        [DataRow("Alert;MyName;=;123", double.NaN, 123d)]
+        [DataTestMethod]
+        public void AlertTriggersWhenOldValueDidNotMatch(string row, double oldValue, double value)
+        {
+            var alert = new IOconfAlert(row, 0);
+            alert.CheckValue(oldValue);
+            Assert.IsTrue(alert.CheckValue(value));
+        }
+
+        [DataRow("Alert;MyName;=;123", 122d, 123d, " MyName = 123 (123)")]
+        [DataRow("Alert;MyName;>;123", 123d, 123.00012d, " MyName > 123 (123.00012)")]
+        [DataRow("Alert;MyName;nan", 123d, double.NaN, " MyName is not a number (NaN)")]
+        [DataRow("Alert;MyName;int", 123.123d, 123d, " MyName is an integer (123)")]
+        [DataTestMethod]
+        public void AlertReturnsExpectedMessageAfterCheckingValueTwice(string row, double oldValue, double value, string expectedMessage)
+        {
+            var alert = new IOconfAlert(row, 0);
+            alert.CheckValue(oldValue);
+            alert.CheckValue(value);
+            Assert.AreEqual(expectedMessage, alert.Message);
+        }
+
+        [DataRow("Alert;MyName;=;123", 123d, 123d)]
+        [DataRow("Alert;MyName;=;193.123", 193.123d, 193.123d)]
+        [DataRow("Alert;MyName;>;123", 124d, 123.00012d)]
+        [DataRow("Alert;MyName;>;123", 123.001d, 124d)]
+        [DataRow("Alert;MyName;>=;123", 123d, 123d)]
+        [DataRow("Alert;MyName;<=;123", 122.999d, 123d)]
+        [DataRow("Alert;MyName;<=;123", 122d, 122d)]
+        [DataRow("Alert;MyName;<;123", 121d, 122d)]
+        [DataRow("Alert;MyName;nan", double.NaN, double.NaN)]
+        [DataTestMethod]
+        public void AlertDoesNotTriggersWhenOldValueMatched(string row, double oldValue, double value)
+        {
+            var alert = new IOconfAlert(row, 0);
+            alert.CheckValue(oldValue);
+            Assert.IsFalse(alert.CheckValue(value));
+        }
+
+        [DataRow("Alert;MyName;=;")]
+        [DataRow("Alert;MyName;=")]
+        [DataRow("Alert;MyName;>;abc")]
+        [DataRow("Alert;MyName")]
+        [DataRow("Alert;MyName;<=;123,2")]//thousands separator is not allowed so this does not get interpreted as 1232
+        [DataTestMethod]
+        public void AlertRejectsInvalidConfiguration(string row)
+        {
+            var ex = Assert.ThrowsException<Exception>(() => new IOconfAlert(row, 0));
+            Assert.AreEqual($"IOconfAlert: wrong format: {row}", ex.Message);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CALogTests.cs" />
+    <Compile Include="IOconfAlertTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServerUploaderTests.cs" />
     <Compile Include="SerialPortTests.cs" />


### PR DESCRIPTION
- fixed: 123,2 was being interpreted as 1232 (thousands separator are not allowed anymore)
- fixed: alert message contained all values of all calls to CheckValue (now it only contains the last one)
- fixed: NaN and int were not allowed to be case insensitive as intended
- alert now reports wrong format if there is no comparison
- alert now reports wrong format if there is no value
- added initial set of unit tests for IOconfAlert (note it does not cover code in ServerUploader)