### PR TITLE
Fix wrong line endings in bash file in windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+#keep linux line endings in bash scripts
+*.sh		text eol=lf


### PR DESCRIPTION
Note this does not get retroactively applied to existing check outs.

One way to re-apply it, is to git remove the files and then undo the change:
git rm *.sh
git reset *.sh
git checkout .