### PR TITLE
Fixed #10: ServerUploader has issues handling Math

### DIFF
--- a/CA_DataUploaderLib/IOconf/IOconfMath.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMath.cs
@@ -24,8 +24,8 @@ namespace CA_DataUploaderLib.IOconf
             }
         }
 
-        public string Name { get; set; }
-        private Expression expression;
+        public string Name { get; }
+        private readonly Expression expression;
 
         // https://www.codeproject.com/Articles/18880/State-of-the-Art-Expression-Evaluation
         // uses NCalc 2 for .NET core. 

--- a/CA_DataUploaderLib/MathVectorExpansion.cs
+++ b/CA_DataUploaderLib/MathVectorExpansion.cs
@@ -1,0 +1,51 @@
+﻿using CA_DataUploaderLib.IOconf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CA_DataUploaderLib
+{
+    public class MathVectorExpansion
+    {
+        private VectorDescription _vectorDescriptionWithoutMath;
+        public VectorDescription VectorDescription { get; }
+        private List<IOconfMath> _mathStatements;
+
+        public MathVectorExpansion(VectorDescription vectorDescription) : this(vectorDescription, IOconfFile.GetMath) { }
+        public MathVectorExpansion(VectorDescription vectorDescription, Func<IEnumerable<IOconfMath>> getMath)
+        {
+            _vectorDescriptionWithoutMath = vectorDescription;
+            _mathStatements = getMath().ToList();
+            VectorDescription = vectorDescription.WithExtraItems(_mathStatements.Select(m => new VectorDescriptionItem("double", m.Name, DataTypeEnum.State)));
+        }
+
+        /// <param name="vector">The vector to expand.</param>
+        /// <remarks>
+        /// The vector must match the order and amount of entries specified in <see cref="MathVectorExpansion(VectorDescription)"/>.
+        /// This method and class does not track changes to the <see cref="IOconfFile"/>, use a new instance if needed.
+        /// </remarks>
+        public void Expand(List<double> vector)
+        {
+            if (vector.Count() != _vectorDescriptionWithoutMath.Length)
+                throw new ArgumentException($"wrong vector length (input, expected): {vector.Count} <> {_vectorDescriptionWithoutMath.Length}");
+
+            var dic = GetVectorDictionary(vector);
+            foreach (var math in _mathStatements)
+            {
+                vector.Add(math.Calculate(dic));
+            }
+        }
+
+        private Dictionary<string, object> GetVectorDictionary(List<double> vector)
+        {
+            var dic = new Dictionary<string, object>(_vectorDescriptionWithoutMath._items.Count);
+            int i = 0;
+            foreach (var item in _vectorDescriptionWithoutMath._items)
+            {
+                dic.Add(item.Descriptor, vector[i++]);
+            }
+
+            return dic;
+        }
+    }
+}

--- a/CA_DataUploaderLib/VectorDescription.cs
+++ b/CA_DataUploaderLib/VectorDescription.cs
@@ -12,13 +12,19 @@ namespace CA_DataUploaderLib
         public string Hardware;
         public string Software;
         public string IOconf;
-        public int Length { get { return _items.Count(); } }
+        public int Length { get { return _items.Count; } }
 
         public VectorDescription() { }
         public VectorDescription(List<VectorDescriptionItem> items, string hardware, string software) { _items = items; Hardware = hardware; Software = software; }
+
         public string GetVectorItemDescriptions() { return string.Join(Environment.NewLine, _items.Select(x => x.Descriptor)); }
         public string GetVectorItemTypes() { return string.Join(Environment.NewLine, _items.Select(x => x.DataType)); }
         public string GetVectorInputOutput() { return string.Join(Environment.NewLine, _items.Select(x => x.DirectionType.ToString())); }
+
+        /// <summary>Returns a copy of the vector description with additional entries</summary>
+        /// <remarks>While this leaves the current instance unmodified, we are pretending the entries are immutable for now.</remarks>
+        public VectorDescription WithExtraItems(IEnumerable<VectorDescriptionItem> extraEntries) =>
+            new VectorDescription(_items.Concat(extraEntries).ToList(), Hardware, Software);
 
         public override string ToString()
         {

--- a/UnitTests/IOconfMathTests.cs
+++ b/UnitTests/IOconfMathTests.cs
@@ -45,7 +45,7 @@ namespace UnitTests
             Assert.AreEqual(expectedResult, math.Calculate(new Dictionary<string, object> { { "MyValue", value }}));
         }
 
-        [DataTestMethod]
+        [TestMethod]
         public void RejectsExpressionWithThousandsSeparator()
         {
             var ex = Assert.ThrowsException<Exception>(() => new IOconfMath("Math;MyName;MyValue + 123,222", 0));

--- a/UnitTests/MathVectorExpansionTests.cs
+++ b/UnitTests/MathVectorExpansionTests.cs
@@ -1,0 +1,58 @@
+﻿using CA_DataUploaderLib;
+using CA_DataUploaderLib.IOconf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class MathVectorExpansionTests
+    {
+        [TestMethod]
+        public void VectorDescriptionIncludesMath()
+        {
+            IEnumerable<IOconfMath> GetTestMath() => new[] { new IOconfMath("Math;MyMath;MyName + 2", 2) };
+            var items = new List<VectorDescriptionItem> { new VectorDescriptionItem("MyType", "MyName", DataTypeEnum.Input) };
+            var math = new MathVectorExpansion(new VectorDescription(items, "my hardware", "my software"), GetTestMath);
+            Assert.AreEqual("MyName" + Environment.NewLine + "MyMath", math.VectorDescription.GetVectorItemDescriptions());
+        }
+
+        [TestMethod]
+        public void ExpandsVector()
+        {
+            IEnumerable<IOconfMath> GetTestMath() => new[] { new IOconfMath("Math;MyMath;MyName + 2", 2) };
+            var items = new List<VectorDescriptionItem> { new VectorDescriptionItem("MyType", "MyName", DataTypeEnum.Input) };
+            var math = new MathVectorExpansion(new VectorDescription(items, "my hardware", "my software"), GetTestMath);
+            var values = new List<double> { 0.2 };
+            math.Expand(values);
+            CollectionAssert.AreEqual(new[] { 0.2, 2.2 }, values);
+        }
+
+        [TestMethod]
+        public void RejectsUnexpectedVectorLength()
+        {
+            IEnumerable<IOconfMath> GetTestMath() => new[] { new IOconfMath("Math;MyMath;MyName + 2", 2) };
+            var items = new List<VectorDescriptionItem> { new VectorDescriptionItem("MyType", "MyName", DataTypeEnum.Input) };
+            var math = new MathVectorExpansion(new VectorDescription(items, "my hardware", "my software"), GetTestMath);
+            var values = new List<double> { 0.2, 3 };
+            var ex = Assert.ThrowsException<ArgumentException>(() => math.Expand(values));
+            Assert.AreEqual("wrong vector length (input, expected): 2 <> 1", ex.Message);
+        }
+
+        [TestMethod]
+        public void IgnoresIOConfMathChanges()
+        {
+            var ioconfEntries = new[] { new IOconfMath("Math;MyMath;MyName + 2", 2) };
+            IEnumerable<IOconfMath> GetTestMath() => ioconfEntries;
+            var items = new List<VectorDescriptionItem> { new VectorDescriptionItem("MyType", "MyName", DataTypeEnum.Input) };
+            var math = new MathVectorExpansion(new VectorDescription(items, "my hardware", "my software"), GetTestMath);
+            var values = new List<double> { 0.2 };
+
+            ioconfEntries = new[] { new IOconfMath("Math;MyMath;MyName + 2", 2), new IOconfMath("Math;MyMath2;MyName + 3", 2) };
+            math.Expand(values);
+
+            CollectionAssert.AreEqual(new[] { 0.2, 2.2 }, values, "only the single math statement sent to the constructor must be used");
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -40,9 +40,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-	  <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-	  <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-	  <PackageReference Include="System.IO.Ports" Version="4.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="System.IO.Ports" Version="4.7.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
@@ -50,6 +50,7 @@
     <Compile Include="CALogTests.cs" />
     <Compile Include="IOconfMathTests.cs" />
     <Compile Include="IOconfAlertTests.cs" />
+    <Compile Include="MathVectorExpansionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServerUploaderTests.cs" />
     <Compile Include="SerialPortTests.cs" />


### PR DESCRIPTION
- Introduced MathVectorExpansion and added unit tests for the math expansion.
- Fixed: vector expansion throws an exception trying to find math values before they are added
- The vector expansion now enforces the original vector length (instead of allowing extra math statements)