### PR TITLE
Fixed #19 board reconnect not skipping the header

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -213,7 +213,7 @@ namespace CA_DataUploaderLib
                 {
                     CALog.LogErrorAndConsoleLn(LogID.A, $"{Title} stale value detected for port: {item.Input.Name}{Environment.NewLine}{msSinceLastRead} milliseconds since last read - closing serial port to restablish connection");
                     item.ReadSensor_LoopTime = 0;
-                    item.Input.Map.Board.SafeClose();
+                    item.Input.Map.Board.SafeReopen();
                     _failCount++;
                     failPorts.Add(item.Input.Name);
                 }

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -182,7 +182,7 @@ namespace CA_DataUploaderLib
                         if (DateTime.UtcNow.Subtract(heater.Current.TimeStamp).TotalMilliseconds > 2000)
                         {
                             heater.Current.ReadSensor_LoopTime = 0;
-                            heater._ioconf.Map.Board.SafeClose();
+                            heater._ioconf.Map.Board.SafeReopen();
                             failCount++;
                         }
                     }

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -255,7 +255,7 @@ namespace CA_DataUploaderLib
                     if (IsOpen)
                         Close();
 
-                    Thread.Sleep(200);
+                    Thread.Sleep(500);
                     Open();
 
                     Thread.Sleep(500);

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using CA_DataUploaderLib.IOconf;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace CA_DataUploaderLib
 {
@@ -36,7 +37,7 @@ namespace CA_DataUploaderLib
 
         public string mcuFamily = null;
         public const string mcuFamilyHeader = "MCU Family: ";
-
+        private readonly Regex _startsWithNumberRegex = new Regex(@"^(-|\d+)");
         public bool UnableToRead = true;
 
         public DateTime PortOpenTimeStamp;
@@ -229,6 +230,54 @@ namespace CA_DataUploaderLib
         public string ToStringSimple(string seperator)
         {
             return $"{PortName}{seperator}{serialNumber}{seperator}{productType}";
+        }
+
+        /// <summary>
+        /// Reopens the connection skipping the header.
+        /// </summary>
+        /// <param name="headerLines">The amount of header lines expected.</param>
+        /// <returns>The skipped header lines</returns>
+        /// <remarks>
+        /// This method assumes only value lines start with numbers, 
+        /// so it considers such a line to be past the header.
+        /// 
+        /// A log entry to <see cref="LogID.B"/> is added with the skipped header 
+        /// and the bytes in the receive buffer 500ms after the port was opened again.
+        /// </remarks>
+        public void SafeReopen(int expectedHeaderLines = 8)
+        {
+            var lines = new List<string>();
+            var bytesToRead500ms = 0;
+            try
+            {
+                lock (this)
+                {
+                    if (IsOpen)
+                        Close();
+
+                    Thread.Sleep(200);
+                    Open();
+
+                    Thread.Sleep(500);
+                    bytesToRead500ms = BytesToRead;
+                    for (int i = 0; i < expectedHeaderLines; i++)
+                    {
+                        var line = ReadLine().Trim();
+                        lines.Add(line);
+                        if (_startsWithNumberRegex.IsMatch(line))
+                        { // we are past the header.
+                            break;
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                CALog.LogData(LogID.B, $"Failure reopening port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header {lines}");
+                throw;
+            }
+
+            CALog.LogData(LogID.B, $"Reopened port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header {lines}");
         }
 
         private void ReadSerialNumber()

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -271,20 +271,23 @@ namespace CA_DataUploaderLib
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                CALog.LogData(LogID.B, $"Failure reopening port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header {lines}");
+                CALog.LogErrorAndConsoleLn(
+                    LogID.B, 
+                    $"Failure reopening port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header lines '{string.Join("§",lines)}'",
+                    ex);
                 throw;
             }
 
-            CALog.LogData(LogID.B, $"Reopened port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header {lines}");
+            CALog.LogData(LogID.B, $"Reopened port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header lines '{string.Join("§", lines)}'");
         }
 
         private void ReadSerialNumber()
         {
             // CALog.LogColor(LogID.A, ConsoleColor.Green, Environment.NewLine + "Sending Serial request");
             WriteLine("Serial");
-            var stop = DateTime.Now.AddSeconds(2);
+            var stop = DateTime.Now.AddSeconds(5);
             while (IsEmpty() && DateTime.Now < stop)
             {
 


### PR DESCRIPTION
* It now gives more time during the reconnect for the board to respond.
* We now give up to 5 seconds to read the serial during board initialization on the initial setup (boxes that rely on responding to the Serial command tend to need more time for this i.e. because of the values lines being otherwise generated).