### PR TITLE
Logging additional info about sensor box responses

### DIFF
--- a/CA_DataUploaderLib/CALog.cs
+++ b/CA_DataUploaderLib/CALog.cs
@@ -43,6 +43,12 @@ namespace CA_DataUploaderLib
             WriteToFile(logID, msg + Environment.NewLine);
         }
 
+        public static void LogInfoAndConsoleLn(LogID logID, string msg, Exception ex)
+        {
+            Console.WriteLine(msg);
+            WriteToFile(logID, msg + Environment.NewLine + ex.ToString() + Environment.NewLine);
+        }
+
         public static void LogColor(LogID logID, ConsoleColor color, string msg)
         {
             var temp = Console.ForegroundColor;

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -253,12 +253,17 @@ namespace CA_DataUploaderLib
                 lock (this)
                 {
                     if (IsOpen)
+                    {
+                        CALog.LogData(LogID.B, $"(Reopen) Closing port {PortName} {productType} {serialNumber}");
                         Close();
-
-                    Thread.Sleep(500);
+                        Thread.Sleep(500);
+                    }
+                    
+                    CALog.LogData(LogID.B, $"(Reopen) opening port {PortName} {productType} {serialNumber}");
                     Open();
-
                     Thread.Sleep(500);
+
+                    CALog.LogData(LogID.B, $"(Reopen) skipping {expectedHeaderLines} header lines for port {PortName} {productType} {serialNumber} ");
                     bytesToRead500ms = BytesToRead;
                     for (int i = 0; i < expectedHeaderLines; i++)
                     {


### PR DESCRIPTION
Extra responses logging in BaseSensorBox:
- logs unhandled responses (non number lines)
- logs cycles where no data was received
- logs exception info when reading on the 10 retries

Logging extra info about reopening of the connection