### PR TITLE
failure conditions improvements

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -250,7 +250,7 @@ namespace CA_DataUploaderLib
                 {
                     CALog.LogErrorAndConsoleLn(LogID.A, $"{Title} stale value detected for port: {item.Input.Name}{Environment.NewLine}{msSinceLastRead} milliseconds since last read - closing serial port to restablish connection");
                     item.ReadSensor_LoopTime = 0;
-                    reconnectLimitExceeded |= item.Input.Map.Board.SafeReopen(expectedHeaderLines);
+                    reconnectLimitExceeded |= !item.Input.Map.Board.SafeReopen(expectedHeaderLines);
                     failPorts.Add(item.Input.Name);
                 }
             }

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -7,6 +7,7 @@ using System.Text;
 using CA_DataUploaderLib.IOconf;
 using System.Text.RegularExpressions;
 using Humanizer;
+using System.Diagnostics;
 
 namespace CA_DataUploaderLib
 {
@@ -21,6 +22,7 @@ namespace CA_DataUploaderLib
 
         protected List<IOconfInput> _config;
         protected List<MCUBoard> _boards = new List<MCUBoard>();
+        protected int expectedHeaderLines = 8;
 
         public BaseSensorBox() { }
 
@@ -62,6 +64,14 @@ namespace CA_DataUploaderLib
             }
 
             return list;
+        }
+
+        public IEnumerable<double> GetValues()
+        {
+            var values = GetAllDatapoints().Select(s => s.Value);
+            return _logLevel == CALogLevel.Debug ?
+                values.Concat(GetFrequencyAndFilterCount()) :
+                values;
         }
 
         public virtual List<VectorDescriptionItem> GetVectorDescriptionItems()
@@ -122,7 +132,7 @@ namespace CA_DataUploaderLib
             return _values.Values.Average(x => x.ReadSensor_LoopTime);
         }
 
-        protected string _matchPattern = @"-?\d{1,10}(,\d{3})*(\.\d+)?";  // this will match any integer or decimal number. (but not scientific notation)
+        private static Regex _startsWithDigitRegex = new Regex(@"^\s*(-|\d+)\s*");
 
         protected void LoopForever()
         {
@@ -141,8 +151,12 @@ namespace CA_DataUploaderLib
                     foreach (var board in _boards)
                     {
                         var hadDataAvailable = false;
+                        var timeInLoop = Stopwatch.StartNew();
                         // we read all lines available (boards typically write a line every 100 ms)
-                        while (board.SafeHasDataInReadBuffer())
+                        // we make sure to exit if 2 seconds pass in the loop, to allow failure counting when error data is continuously returned by the board.
+                        // we use time instead of attempts as SafeHasDataInReadBuffer can continuously report there is data when a partial line is returned by a board that stalls,
+                        // which then consistently times out in SafeReadLine, making each loop iteration 2 seconds.
+                        while (board.SafeHasDataInReadBuffer() && timeInLoop.ElapsedMilliseconds < 2000)
                         {
                             hadDataAvailable = true;
                             exBoard = board; // only used in exception
@@ -150,11 +164,19 @@ namespace CA_DataUploaderLib
                             numbers.Clear();
                             row = board.SafeReadLine(); // tries to read a full line for up to MCUBoard.ReadTimeout
 
-                            if (Regex.IsMatch(row.Trim(), @"^(-|\d+)"))  // check that row starts with digit. 
+                            if (_startsWithDigitRegex.IsMatch(row))  // check that row starts with digit. 
                             {
-                                values = row.Split(",".ToCharArray()).Select(x => x.Trim()).Where(x => x.Length > 0).ToList();
-                                numbers = values.Select(x => double.Parse(x, CultureInfo.InvariantCulture)).ToList();
-                                ProcessLine(numbers, board);
+                                try
+                                {
+                                    values = row.Split(",".ToCharArray()).Select(x => x.Trim()).Where(x => x.Length > 0).ToList();
+                                    numbers = values.Select(x => double.Parse(x, CultureInfo.InvariantCulture)).ToList();
+                                    ProcessLine(numbers, board);
+                                }
+                                catch (Exception)
+                                {
+                                    CALog.LogErrorAndConsoleLn(LogID.B, "Failed handling board response " + board.ToString() + " line: " + row);
+                                    throw;
+                                }
                             }
                             else
                             {
@@ -215,12 +237,11 @@ namespace CA_DataUploaderLib
             CALog.LogInfoAndConsoleLn(LogID.A, $"Exiting {Title}.LoopForever() " + DateTime.Now.Subtract(start).Humanize(5));
         }
 
-        private int _failCount = 0;
-
         private void CheckFails()
         {
             List<string> failPorts = new List<string>();
             int maxDelay = 2000;
+            bool reconnectLimitExceeded = false;
             foreach (var item in _values.Values)
             {
                 maxDelay = (item.Input.Name.ToLower().Contains("luminox")) ? 10000 : 2000;
@@ -229,17 +250,16 @@ namespace CA_DataUploaderLib
                 {
                     CALog.LogErrorAndConsoleLn(LogID.A, $"{Title} stale value detected for port: {item.Input.Name}{Environment.NewLine}{msSinceLastRead} milliseconds since last read - closing serial port to restablish connection");
                     item.ReadSensor_LoopTime = 0;
-                    item.Input.Map.Board.SafeReopen();
-                    _failCount++;
+                    reconnectLimitExceeded |= item.Input.Map.Board.SafeReopen(expectedHeaderLines);
                     failPorts.Add(item.Input.Name);
                 }
             }
 
-            if (_failCount > 200)
+            if (reconnectLimitExceeded)
             {
                 _cmd.Execute("escape");
                 _running = false;
-                CALog.LogErrorAndConsoleLn(LogID.A, $"Shutting down: {Title} unable to read from port: {string.Join(", ", failPorts)}{Environment.NewLine}Failed {_failCount} times read operations in a row where latest valid read was more than {maxDelay} seconds old");
+                CALog.LogErrorAndConsoleLn(LogID.A, $"Shutting down: {Title} unable to read from port: {string.Join(", ", failPorts)}{Environment.NewLine}Reconnection limit exceeded, latest valid read was more than {maxDelay} seconds old");
             }
         }
 

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -228,13 +228,13 @@ namespace CA_DataUploaderLib
                     if (heater.Current.TimeoutValue == 0 && heater.IsOn && heater.LastOn.AddSeconds(2) < DateTime.UtcNow)
                     {
                         HeaterOn(heater);
-                        CALog.LogData(LogID.A, $"on.={heater.MaxSensorTemperature().ToString("N0")}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
+                        CALog.LogData(LogID.A, $"on.={heater.name()}-{heater.MaxSensorTemperature().ToString("N0")}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
                     }
 
                     if (heater.Current.TimeoutValue > 0 && !heater.IsOn && heater.LastOff.AddSeconds(2) < DateTime.UtcNow)
                     {
                         HeaterOff(heater);
-                        CALog.LogData(LogID.A, $"off.={heater.MaxSensorTemperature().ToString("N0")}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
+                        CALog.LogData(LogID.A, $"off.={heater.name()}-{heater.MaxSensorTemperature().ToString("N0")}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
                     }
                 }
             }

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -293,12 +293,24 @@ namespace CA_DataUploaderLib
 
         public IEnumerable<double> GetPower()
         {
-            if(_logLevel == CALogLevel.Debug)
+            var powerValues = _heaters.Select(x => x.Current.TimeoutValue);
+            var states =_heaters.Select(x => x.IsOn ? 1.0 : 0.0);
+            var values = powerValues.Concat(states);
+            if (_logLevel == CALogLevel.Debug)
             {
-                return _heaters.SelectMany(x => new double[] { x.Current.TimeoutValue, x.IsOn ? 1.0 : 0.0, x.Current.ReadSensor_LoopTime } );
+                IEnumerable<double> loopTimes = _heaters.Select(x => x.Current.ReadSensor_LoopTime);
+                return values.Concat(loopTimes);
             }
 
-            return _heaters.SelectMany(x => new double[] { x.Current.TimeoutValue, x.IsOn ? 1.0 : 0.0 } );
+            return values;
+        }
+
+        /// <summary>
+        /// Gets all the values in the order specified by <see cref="GetVectorDescriptionItems"/>.
+        /// </summary>
+        public IEnumerable<double> GetValues()
+        {
+            return GetPower().Concat(GetStates());
         }
 
         public List<VectorDescriptionItem> GetVectorDescriptionItems()

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -182,7 +182,7 @@ namespace CA_DataUploaderLib
                         if (DateTime.UtcNow.Subtract(heater.Current.TimeStamp).TotalMilliseconds > 2000)
                         {
                             heater.Current.ReadSensor_LoopTime = 0;
-                            reconnectLimitExceeded |= heater._ioconf.Map.Board.SafeReopen();
+                            reconnectLimitExceeded |= !heater._ioconf.Map.Board.SafeReopen();
                         }
                     }
 

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -284,7 +284,7 @@ namespace CA_DataUploaderLib
                     {
                         var line = ReadLine().Trim();
                         lines.Add(line);
-                        if (_startsWithNumberRegex.IsMatch(line))
+                        if (_startsWithNumberRegex.IsMatch(line) && i > 0) // making sure we skip the first one, as it is something a partial line (perhaps from the last read before the restart, although pi buffer is cleared).
                         { // we are past the header.
                             break;
                         }

--- a/CA_DataUploaderLib/SwitchBoardBase.cs
+++ b/CA_DataUploaderLib/SwitchBoardBase.cs
@@ -32,7 +32,7 @@ namespace CA_DataUploaderLib
                 {
                     _debugQueue.Enqueue(lines);
 
-                    if (DateTime.UtcNow.Subtract(_lastTimeStamp).TotalMilliseconds > 500)
+                    if (_lastTimeStamp > DateTime.MinValue && DateTime.UtcNow.Subtract(_lastTimeStamp).TotalMilliseconds > 500)
                     {
                         CALog.LogData(LogID.B, $"ReadInputFromSwitchBoxes: '{string.Join("§", _debugQueue)}'{Environment.NewLine}");
                         _debugQueue.Clear();

--- a/CA_DataUploaderLib/SwitchBoardBase.cs
+++ b/CA_DataUploaderLib/SwitchBoardBase.cs
@@ -74,7 +74,6 @@ namespace CA_DataUploaderLib
             catch (Exception ex)
             {
                 CALog.LogException(LogID.B, ex);
-                // box.SafeClose();  // I don't know if this will solve the problem. 
             }
             
             return new List<double>();  // empty list

--- a/CA_DataUploaderLib/SwitchBoardBase.cs
+++ b/CA_DataUploaderLib/SwitchBoardBase.cs
@@ -1,5 +1,5 @@
-﻿using CA_DataUploaderLib.IOconf;
-using System;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -9,30 +9,36 @@ namespace CA_DataUploaderLib
 {
     public static class SwitchBoardBase
     {
-        private const string _SwitchBoxPattern = "P1=(\\d\\.\\d\\d)A P2=(\\d\\.\\d\\d)A P3=(\\d\\.\\d\\d)A P4=(\\d\\.\\d\\d)A";
-        private static Match _LatestRead = null;
-        private static DateTime _lastTimeStamp = DateTime.MinValue;
-        private static Queue<string> _debugQueue = new Queue<string>();
-        private static CALogLevel _logLevel = CALogLevel.None;
-
+        private static readonly ConcurrentDictionary<MCUBoard, SwitchBoardValues> Values = new ConcurrentDictionary<MCUBoard, SwitchBoardValues>();
         public static List<double> ReadInputFromSwitchBoxes(MCUBoard box)
         {
             if (box == null)
-                return new List<double>(); // empty
+                return new List<double>();
 
-            if (_logLevel == CALogLevel.None)
-                _logLevel = IOconfFile.GetOutputLevel();
+            var values = Values.GetOrAdd(box, b => new SwitchBoardValues(b));
+            lock (values)
+                return values.ReadInputFromSwitchBoxes();
+        }
 
-            string lines = string.Empty;
-            try
+        private class SwitchBoardValues
+        {
+            private const string _SwitchBoxPattern = "P1=(\\d\\.\\d\\d)A P2=(\\d\\.\\d\\d)A P3=(\\d\\.\\d\\d)A P4=(\\d\\.\\d\\d)A";
+            private static readonly Regex _switchBoxCurrentsRegex = new Regex(_SwitchBoxPattern);
+            private readonly MCUBoard box;
+            private Match _lastValidRead = null;
+            private DateTime _lastValidReadTime = DateTime.MinValue;
+            private Queue<string> _debugQueue = new Queue<string>();
+
+            public SwitchBoardValues(MCUBoard box) => this.box = box;
+
+            public List<double> ReadInputFromSwitchBoxes()
             {
-                // try to read some text. 
-                lines = box.SafeReadExisting();
-                lock (_debugQueue)
+                try
                 {
+                    string lines = box.SafeReadExisting();
                     _debugQueue.Enqueue(lines);
 
-                    if (_lastTimeStamp > DateTime.MinValue && DateTime.UtcNow.Subtract(_lastTimeStamp).TotalMilliseconds > 500)
+                    if (LastReadIsOlderThan(milliseconds: 500))
                     {
                         CALog.LogData(LogID.B, $"ReadInputFromSwitchBoxes: '{string.Join("§", _debugQueue)}'{Environment.NewLine}");
                         _debugQueue.Clear();
@@ -42,26 +48,20 @@ namespace CA_DataUploaderLib
                     {
                         _debugQueue.Dequeue();
                     }
-                }
 
-                // see if it matches the BoxPattern.
-                Match match = Regex.Match(lines, _SwitchBoxPattern);
-
-                lock (_SwitchBoxPattern)
-                {
-                    // if match, then store this value for later unsucessful reads. 
+                    Match match = _switchBoxCurrentsRegex.Match(lines);
                     if (match.Success && match.Groups.Count > 4)
                     {
-                        _LatestRead = match;
-                        _lastTimeStamp = DateTime.UtcNow;
+                        _lastValidRead = match;
+                        _lastValidReadTime = DateTime.UtcNow;
                     }
                     else
                     {
-                        if (_LatestRead == null)
+                        if (_lastValidRead == null)
                             return new List<double>();
 
-                        if (_lastTimeStamp.AddSeconds(2) > DateTime.UtcNow) // if it is less than 2 seconds old, then return last read. 
-                            match = _LatestRead;
+                        if (!LastReadIsOlderThan(milliseconds: 2000))
+                            match = _lastValidRead;
                     }
 
                     if (match.Success && match.Groups.Count > 4)
@@ -70,13 +70,16 @@ namespace CA_DataUploaderLib
                             .Select(x => double.Parse(x.Value, CultureInfo.InvariantCulture)).ToList();
                     }
                 }
+                catch (Exception ex)
+                {
+                    CALog.LogException(LogID.B, ex);
+                }
+
+                return new List<double>();  // empty list
             }
-            catch (Exception ex)
-            {
-                CALog.LogException(LogID.B, ex);
-            }
-            
-            return new List<double>();  // empty list
+
+            private bool LastReadIsOlderThan(int milliseconds) =>
+                _lastValidReadTime > DateTime.MinValue && DateTime.UtcNow.Subtract(_lastValidReadTime).TotalMilliseconds > milliseconds;
         }
     }
 }


### PR DESCRIPTION
- Fixed scenario where BaseSensorBox would keep trying to finish reading a partial line returned by a stalled board (for at least 200 seconds until the safelimit of MCUBoard kicks in)
- BaseSensorBox now logs unhandled board responses
- BaseSensorBox and HeatingController no longer try to reconnect multiple times to the same board
- Added BaseSensorBox.GetValues that has simple values that match debug configurations of GetVectorDescriptionItems
- SafeReopen no longer bubbles up the already logged exceptions. As this is already a reconnection due to errors action + it already tracks a retry limit, there is not much additional the calling code can do with it. We already hit a case where time outs exceptions of it were being mixed with something else.
- fixed unexpected switchboard log when starting
- fixed: alerts were using a login token that expired in 15 mins (used sliding expiration on alerts, so it only happened once there were 15 mins without alerts). Now signed alerts are used instead, like we do for vectors.
- Showing/logging extra info upload errors
- Fixed year of the alerts timestamps