### PR TITLE
fixed issue where temporary invalid values affect heating control

### DIFF
--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -45,7 +45,7 @@ namespace CA_DataUploaderLib
                 return false;  // has been turned off for less than 10 seconds. 
 
             var twoSecAgo = DateTime.UtcNow.AddSeconds(-2);
-            var validSensors = _ovenSensors.Select(s => s.Clone()).Where(x => x.TimeStamp > twoSecAgo && x.Value < 10000);
+            var validSensors = _ovenSensors.Select(s => s.Clone()).Where(x => x.TimeStamp > twoSecAgo && x.Value < 10000).ToList();
             if (!validSensors.Any())
                 return false;  // no valid oven sensors 
 
@@ -59,7 +59,7 @@ namespace CA_DataUploaderLib
         public bool MustTurnOff()
         {
             var twoSecAgo = DateTime.UtcNow.AddSeconds(-2);
-            var validSensors = _ovenSensors.Select(s => s.Clone()).Where(x => x.TimeStamp > twoSecAgo && x.Value < 10000);
+            var validSensors = _ovenSensors.Select(s => s.Clone()).Where(x => x.TimeStamp > twoSecAgo && x.Value < 10000).ToList();
             var timeoutResult = CheckInvalidValuesTimeout(validSensors.Any(), 2000);
             if (timeoutResult.HasValue)
                 return timeoutResult.Value;

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -17,8 +17,8 @@ namespace CA_DataUploaderLib
         private double _offTemperature = 0;
         private double _lastTemperature = 0;
         private DateTime _startTime;
-        private List<HeaterElement> _heaters = new List<HeaterElement>();
-        private List<string> _ovenHistory = new List<string>();
+        private readonly List<HeaterElement> _heaters = new List<HeaterElement>();
+        private readonly List<string> _ovenHistory = new List<string>();
         protected CommandHandler _cmd;
 
         public HeatingController(BaseSensorBox caThermalBox, CommandHandler cmd)
@@ -126,7 +126,7 @@ namespace CA_DataUploaderLib
 
         public bool Heater(List<string> args)
         {
-            var heater = _heaters.SingleOrDefault(x => x.name() == args[1].ToLower());
+            var heater = _heaters.SingleOrDefault(x => x.Name() == args[1].ToLower());
             if (heater == null)
                 return false;
 
@@ -233,13 +233,13 @@ namespace CA_DataUploaderLib
                     if (heater.Current.Value <= CurrentZeroNoiseLevel && heater.IsOn && heater.LastOn.AddSeconds(2) < DateTime.UtcNow)
                     {
                         HeaterOn(heater);
-                        CALog.LogData(LogID.A, $"on.={heater.name()}-{heater.MaxSensorTemperature().ToString("N0")}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
+                        CALog.LogData(LogID.A, $"on.={heater.Name()}-{heater.MaxSensorTemperature():N0}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
                     }
 
                     if (heater.Current.Value > CurrentZeroNoiseLevel && !heater.IsOn && heater.LastOff.AddSeconds(2) < DateTime.UtcNow)
                     {
                         HeaterOff(heater);
-                        CALog.LogData(LogID.A, $"off.={heater.name()}-{heater.MaxSensorTemperature().ToString("N0")}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
+                        CALog.LogData(LogID.A, $"off.={heater.Name()}-{heater.MaxSensorTemperature():N0}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
                     }
                 }
             }
@@ -299,11 +299,11 @@ namespace CA_DataUploaderLib
         public IEnumerable<SensorSample> GetPower()
         {
             var powerValues = _heaters.Select(x => x.Current.Clone());
-            var states =_heaters.Select(x => new SensorSample(x.name() + "_On/Off", x.IsOn ? 1.0 : 0.0));
+            var states =_heaters.Select(x => new SensorSample(x.Name() + "_On/Off", x.IsOn ? 1.0 : 0.0));
             var values = powerValues.Concat(states);
             if (_logLevel == CALogLevel.Debug)
             {
-                var loopTimes = _heaters.Select(x => new SensorSample(x.name() + "_LoopTime", x.Current.ReadSensor_LoopTime));
+                var loopTimes = _heaters.Select(x => new SensorSample(x.Name() + "_LoopTime", x.Current.ReadSensor_LoopTime));
                 return values.Concat(loopTimes);
             }
 
@@ -321,15 +321,15 @@ namespace CA_DataUploaderLib
         public List<VectorDescriptionItem> GetVectorDescriptionItems()
         {
             var list = _heaters.Select(x => new VectorDescriptionItem("double", x.Current.Name, DataTypeEnum.Input)).ToList();
-            list.AddRange(_heaters.Select(x => new VectorDescriptionItem("double", x.name() + "_On/Off", DataTypeEnum.Output)));
+            list.AddRange(_heaters.Select(x => new VectorDescriptionItem("double", x.Name() + "_On/Off", DataTypeEnum.Output)));
             if (_logLevel == CALogLevel.Debug)
             {
-                list.AddRange(_heaters.Select(x => new VectorDescriptionItem("double", x.name() + "_LoopTime", DataTypeEnum.State)));
+                list.AddRange(_heaters.Select(x => new VectorDescriptionItem("double", x.Name() + "_LoopTime", DataTypeEnum.State)));
                 list.Add(new VectorDescriptionItem("double", "off_temperature", DataTypeEnum.State));
                 list.Add(new VectorDescriptionItem("double", "last_temperature", DataTypeEnum.State));
             }
 
-            CALog.LogInfoAndConsoleLn(LogID.A, $"{list.Count.ToString().PadLeft(2)} datapoints from HeatingController");
+            CALog.LogInfoAndConsoleLn(LogID.A, $"{list.Count,2} datapoints from HeatingController");
             return list;
         }
 

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -31,10 +31,9 @@ namespace CA_DataUploaderLib
             var sensors = caThermalBox.GetAutoUpdatedValues().ToList();
             foreach (var heater in heaters)
             {
-                var maxSensor = oven.SingleOrDefault(x => x.HeatingElement.Name == heater.Name && x.IsMaxTemperatureSensor)?.TypeK.Name;
-                var ovenSensor = oven.SingleOrDefault(x => x.HeatingElement.Name == heater.Name && !x.IsMaxTemperatureSensor)?.TypeK.Name;
+                var ovenSensor = oven.SingleOrDefault(x => x.HeatingElement.Name == heater.Name)?.TypeK.Name;
                 int area = oven.SingleOrDefault(x => x.HeatingElement.Name == heater.Name && x.OvenArea > 0)?.OvenArea??-1;
-                _heaters.Add(new HeaterElement(area, heater, sensors.Where(x => x.Input.Name == maxSensor), sensors.Where(x => x.Input.Name == ovenSensor)));
+                _heaters.Add(new HeaterElement(area, heater, sensors.Where(x => x.Input.Name == ovenSensor)));
             }
 
             if (!_heaters.Any())

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -7,7 +7,7 @@ namespace CA_DataUploaderLib.IOconf
 {
     public static class IOconfFile
     {
-        private static List<IOconfRow> Table = new List<IOconfRow>();
+        private static readonly List<IOconfRow> Table = new List<IOconfRow>();
         public static string RawFile { get; private set; }
 
         static IOconfFile()
@@ -29,7 +29,7 @@ namespace CA_DataUploaderLib.IOconf
             // remove empty lines and commented out lines
             var lines2 = lines.Where(x => !x.Trim().StartsWith("//") && x.Trim().Length > 2).Select(x => x.Trim()).ToList();
             lines2.ForEach(x => Table.Add(CreateType(x, lines.IndexOf(x))));
-            CheckRules(lines2);
+            CheckRules();
         }
 
         private static IOconfRow CreateType(string row, int lineNum)
@@ -67,7 +67,7 @@ namespace CA_DataUploaderLib.IOconf
             }
         }
 
-        private static void CheckRules(List<string> lines)
+        private static void CheckRules()
         {
             // no two rows can have the same type,name combination. 
             var groups = Table.GroupBy(x => x.UniqueKey());

--- a/CA_DataUploaderLib/IOconf/IOconfHeater.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfHeater.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace CA_DataUploaderLib.IOconf
 {
@@ -7,15 +6,13 @@ namespace CA_DataUploaderLib.IOconf
     {
         public IOconfHeater(string row, int lineNum) : base(row, lineNum, "Heater")
         {
-            format = "Heater;Name;BoxName;[port number]";
+            format = "Heater;Name;BoxName;port number;MaxTemperature";
 
             var list = ToList();
-            if (!int.TryParse(list[4], out MaxTemperature)) throw new Exception("IOconfHeater: missing max temperature: " + row);
-            if (list.Count > 5 && !int.TryParse(list[5], out MaxOnInterval)) throw new Exception("IOconfHeater: bad max on interfal: " + row);
+            if (list.Count < 5 || !int.TryParse(list[4], out MaxTemperature)) throw new Exception("IOconfHeater: missing max temperature: " + row);
         }
 
         public int MaxTemperature;
-        public int MaxOnInterval = 30;
 
         public IOconfInput AsConfInput()
         {

--- a/CA_DataUploaderLib/IOconf/IOconfOven.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOven.cs
@@ -10,19 +10,17 @@ namespace CA_DataUploaderLib.IOconf
             format = "Oven;Area;HeatingElement;TypeK";
 
             var list = ToList();
-            if (list[1].ToLower() == "max") 
-                OvenArea = 0;
-            else if (!int.TryParse(list[1], out OvenArea)) 
+            if (!int.TryParse(list[1], out OvenArea)) 
                 throw new Exception($"IOconfOven: wrong OvenArea number: {row} {format}");
+            if (OvenArea < 1)
+                throw new Exception("Oven area must be a number bigger or equal to 1");
             
             HeatingElement = IOconfFile.GetHeater().Single(x => x.Name == list[2]);
             TypeK = IOconfFile.GetTypeK().Single(x => x.Name == list[3]);
         }
 
-        public int OvenArea; // oven area 0 = max temperature sensor. 
+        public int OvenArea;
         public IOconfHeater HeatingElement;
         public IOconfTypeK TypeK;
-
-        public bool IsMaxTemperatureSensor { get { return OvenArea == 0; } }
     }
 }


### PR DESCRIPTION
- removed "heaterSensors" (oven "max" in IOConf)
- removed MaxOnInterval for heaters in IOconf as it was only used with "heaterSensors"
- HeaterElement wait 2 seconds to turn off on invalid values