### PR TITLE
removed old alert format + nan/integer support

### DIFF
--- a/UnitTests/IOconfAlertTests.cs
+++ b/UnitTests/IOconfAlertTests.cs
@@ -7,22 +7,14 @@ namespace UnitTests
     [TestClass]
     public class IOconfAlertTests
     {
-        [DataRow("Alert;MyName;Sensorx;=;123", 123d)]
-        [DataRow("Alert;MyName;Sensorx;=;193.123", 193.123d)]
-        [DataRow("Alert;MyName;Sensorx;>;123", 123.00012d)]
-        [DataRow("Alert;MyName;Sensorx;>;123", 124d)]
-        [DataRow("Alert;MyName;Sensorx;>=;123", 123d)]
-        [DataRow("Alert;MyName;Sensorx;nan", double.NaN)]
-        [DataRow("Alert;MyName;Sensorx;int", 123d)]
-        [DataRow("Alert;MyName;Sensorx;int", 122d)]
-        [DataRow("Alert;MyName;Sensorx;int", 100000d)]
-        [DataRow("Alert;MyName;Sensorx;int", 10000000d)]
-        [DataRow("Alert;MyName;Sensorx;int", 1d)]
-        [DataRow("Alert;MyName;Sensorx;int", -1d)]
-        [DataRow("Alert;MyName;Sensorx;int", -10000000d)]
-        [DataRow("Alert;MyName;Sensorx;<=;123", 123d)]
-        [DataRow("Alert;MyName;Sensorx;<=;123", 122d)]
-        [DataRow("Alert;MyName;Sensorx;<;123", 122d)]
+        [DataRow("Alert;MyName;Sensorx=123", 123d)]
+        [DataRow("Alert;MyName;Sensorx=193.123", 193.123d)]
+        [DataRow("Alert;MyName;Sensorx>123", 123.00012d)]
+        [DataRow("Alert;MyName;Sensorx>123", 124d)]
+        [DataRow("Alert;MyName;Sensorx>=23", 123d)]
+        [DataRow("Alert;MyName;Sensorx<=123", 123d)]
+        [DataRow("Alert;MyName;Sensorx<=123", 122d)]
+        [DataRow("Alert;MyName;Sensorx<123", 122d)]
         [DataRow("Alert;MyName;Sensorx < 123", 122d)]
         [DataTestMethod]
         public void AlertTriggers(string row, double value) 
@@ -31,20 +23,19 @@ namespace UnitTests
             Assert.IsTrue(alert.CheckValue(value));
         }
 
-        [DataRow("Alert;MyName;Sensorx;=;123", 122d, 123d)]
-        [DataRow("Alert;MyName;Sensorx;=;193.123", 193.122d, 193.123d)]
-        [DataRow("Alert;MyName;Sensorx;>;123", 123d, 123.00012d)]
-        [DataRow("Alert;MyName;Sensorx;>;123", 123d, 124d)]
-        [DataRow("Alert;MyName;Sensorx;>=;123", 122.999d, 123d)]
-        [DataRow("Alert;MyName;Sensorx;<=;123", 123.001d, 123d)]
-        [DataRow("Alert;MyName;Sensorx;<=;123", 123.001d, 122d)]
-        [DataRow("Alert;MyName;Sensorx;<;123", 123.001d, 122d)]
-        [DataRow("Alert;MyName;Sensorx;!=;123", 123d, 122.999d)]
-        [DataRow("Alert;MyName;Sensorx;nan", 123d, double.NaN)]
-        [DataRow("Alert;MyName;Sensorx;=;123", double.NaN, 123d)]
-        [DataRow("Alert;MyName;Sensorx;>;123", double.NaN, 123.00012d)]
-        [DataRow("Alert;MyName;Sensorx;>=;123", double.NaN, 123d)]
-        [DataRow("Alert;MyName;Sensorx;<=;123", double.NaN, 122d)]
+        [DataRow("Alert;MyName;Sensorx = 123", 122d, 123d)]
+        [DataRow("Alert;MyName;Sensorx = 193.123", 193.122d, 193.123d)]
+        [DataRow("Alert;MyName;Sensorx > 123", 123d, 123.00012d)]
+        [DataRow("Alert;MyName;Sensorx > 123", 123d, 124d)]
+        [DataRow("Alert;MyName;Sensorx >= 123", 122.999d, 123d)]
+        [DataRow("Alert;MyName;Sensorx <= 123", 123.001d, 123d)]
+        [DataRow("Alert;MyName;Sensorx <= 123", 123.001d, 122d)]
+        [DataRow("Alert;MyName;Sensorx < 123", 123.001d, 122d)]
+        [DataRow("Alert;MyName;Sensorx != 123", 123d, 122.999d)]
+        [DataRow("Alert;MyName;Sensorx = 123", double.NaN, 123d)]
+        [DataRow("Alert;MyName;Sensorx > 123", double.NaN, 123.00012d)]
+        [DataRow("Alert;MyName;Sensorx >= 123", double.NaN, 123d)]
+        [DataRow("Alert;MyName;Sensorx <= 123", double.NaN, 122d)]
         [DataTestMethod]
         public void AlertTriggersWhenOldValueDidNotMatch(string row, double oldValue, double value)
         {
@@ -53,10 +44,8 @@ namespace UnitTests
             Assert.IsTrue(alert.CheckValue(value));
         }
 
-        [DataRow("Alert;MyName;Sensorx;=;123", 122d, 123d, " MyName (Sensorx) = 123 (123)")]
-        [DataRow("Alert;MyName;Sensorx;>;123", 123d, 123.00012d, " MyName (Sensorx) > 123 (123.00012)")]
-        [DataRow("Alert;MyName;Sensorx;nan", 123d, double.NaN, " MyName (Sensorx) is not a number (NaN)")]
-        [DataRow("Alert;MyName;Sensorx;int", 123.123d, 123d, " MyName (Sensorx) is an integer (123)")]
+        [DataRow("Alert;MyName;Sensorx = 123", 122d, 123d, " MyName (Sensorx) = 123 (123)")]
+        [DataRow("Alert;MyName;Sensorx > 123", 123d, 123.00012d, " MyName (Sensorx) > 123 (123.00012)")]
         [DataTestMethod]
         public void AlertReturnsExpectedMessageAfterCheckingValueTwice(string row, double oldValue, double value, string expectedMessage)
         {
@@ -66,22 +55,14 @@ namespace UnitTests
             Assert.AreEqual(expectedMessage, alert.Message);
         }
 
-        [DataRow("Alert;MyName;Sensorx;=;123", 123d, 123d)]
-        [DataRow("Alert;MyName;Sensorx;=;193.123", 193.123d, 193.123d)]
-        [DataRow("Alert;MyName;Sensorx;>;123", 124d, 123.00012d)]
-        [DataRow("Alert;MyName;Sensorx;>;123", 123.001d, 124d)]
-        [DataRow("Alert;MyName;Sensorx;>=;123", 123d, 123d)]
-        [DataRow("Alert;MyName;Sensorx;<=;123", 122.999d, 123d)]
-        [DataRow("Alert;MyName;Sensorx;<=;123", 122d, 122d)]
-        [DataRow("Alert;MyName;Sensorx;<;123", 121d, 122d)]
-        [DataRow("Alert;MyName;Sensorx;nan", double.NaN, double.NaN)]
-        [DataRow("Alert;MyName;Sensorx;int", 124d, 123d)]
-        [DataRow("Alert;MyName;Sensorx;int", 123d, 122d)]
-        [DataRow("Alert;MyName;Sensorx;int", 99999d, 100000d)]
-        [DataRow("Alert;MyName;Sensorx;int", 9999999d, 10000000d)]
-        [DataRow("Alert;MyName;Sensorx;int", 0d, 1d)]
-        [DataRow("Alert;MyName;Sensorx;int", -2d, -1d)]
-        [DataRow("Alert;MyName;Sensorx;int", -9999999d, -10000000d)]
+        [DataRow("Alert;MyName;Sensorx=123", 123d, 123d)]
+        [DataRow("Alert;MyName;Sensorx=193.123", 193.123d, 193.123d)]
+        [DataRow("Alert;MyName;Sensorx>123", 124d, 123.00012d)]
+        [DataRow("Alert;MyName;Sensorx>123", 123.001d, 124d)]
+        [DataRow("Alert;MyName;Sensorx>=123", 123d, 123d)]
+        [DataRow("Alert;MyName;Sensorx<=123", 122.999d, 123d)]
+        [DataRow("Alert;MyName;Sensorx<=123", 122d, 122d)]
+        [DataRow("Alert;MyName;Sensorx<123", 121d, 122d)]
         [DataTestMethod]
         public void AlertDoesNotTriggersWhenOldValueMatched(string row, double oldValue, double value)
         {
@@ -90,16 +71,17 @@ namespace UnitTests
             Assert.IsFalse(alert.CheckValue(value));
         }
 
-        [DataRow("Alert;MyName;Sensorx;=;")]
-        [DataRow("Alert;MyName;Sensorx;=")]
-        [DataRow("Alert;MyName;Sensorx;>;abc")]
+        [DataRow("Alert;MyName;Sensorx;=;123", DisplayName = "old format - no longer supported")]
+        [DataRow("Alert;MyName;Sensorx = ")]
+        [DataRow("Alert;MyName;Sensorx =")]
+        [DataRow("Alert;MyName;Sensorx > abc")]
         [DataRow("Alert;MyName;Sensorx")]
-        [DataRow("Alert;MyName;Sensorx;<=;123,2")]//thousands separator is not allowed so this does not get interpreted as 1232
+        [DataRow("Alert;MyName;Sensorx <= 123,2")]//thousands separator is not allowed so this does not get interpreted as 1232
         [DataTestMethod]
         public void AlertRejectsInvalidConfiguration(string row)
         {
             var ex = Assert.ThrowsException<Exception>(() => new IOconfAlert(row, 0));
-            Assert.AreEqual($"IOconfAlert: wrong format: {row}", ex.Message);
+            Assert.AreEqual($"IOconfAlert: wrong format: {row}. Format: Alert;Name;SensorName comparisson value. Supported comparissons: =,!=, >, <, >=, <=", ex.Message);
         }
     }
 }


### PR DESCRIPTION
Fixed: numbers after a ',' are being ignored, instead of rejecting the whole expression (we use . for decimals and do not accept thousands separators).