### PR TITLE
fixed: multiple reconnects for skipped sensor boards

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -160,8 +160,6 @@ namespace CA_DataUploaderLib
                         reconnectLimitExceeded |= !item.Input.Map.Board.SafeReopen(expectedHeaderLines);
                     failPorts.Add(item.Input.Name);
                 }
-                else if (msSinceLastRead > maxDelay)
-                    CALog.LogInfoAndConsoleLn(LogID.A, $"{Title} stale value detected for port: {item.Input.Name}{Environment.NewLine}{msSinceLastRead} milliseconds since last read - no action (sensor with Skip)");
             }
 
             if (reconnectLimitExceeded)

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -151,15 +151,17 @@ namespace CA_DataUploaderLib
             bool reconnectLimitExceeded = false;
             foreach (var item in _values)
             {
-                maxDelay = (item.Input.Name.ToLower().Contains("luminox")) ? 10000 : 2000;
+                maxDelay = item.Input.Name.ToLower().Contains("luminox") ? 10000 : 2000;
                 var msSinceLastRead = DateTime.UtcNow.Subtract(item.TimeStamp).TotalMilliseconds;
-                if (msSinceLastRead > maxDelay)
+                if (msSinceLastRead > maxDelay && !item.Input.Skip)
                 {
                     CALog.LogErrorAndConsoleLn(LogID.A, $"{Title} stale value detected for port: {item.Input.Name}{Environment.NewLine}{msSinceLastRead} milliseconds since last read - closing serial port to restablish connection");
-                    if(item.Input.Map != null)
+                    if (item.Input.Map != null)
                         reconnectLimitExceeded |= !item.Input.Map.Board.SafeReopen(expectedHeaderLines);
                     failPorts.Add(item.Input.Name);
                 }
+                else if (msSinceLastRead > maxDelay)
+                    CALog.LogInfoAndConsoleLn(LogID.A, $"{Title} stale value detected for port: {item.Input.Name}{Environment.NewLine}{msSinceLastRead} milliseconds since last read - no action (sensor with Skip)");
             }
 
             if (reconnectLimitExceeded)

--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -106,6 +106,10 @@ namespace CA_DataUploaderLib
             return _area == ovenArea;
         }
 
+        public bool MustResendOnCommand() => !CurrentIsOn() && IsOn && LastOn.AddSeconds(2) < DateTime.UtcNow;
+        public bool MustResendOffCommand() => CurrentIsOn() && !IsOn && LastOff.AddSeconds(2) < DateTime.UtcNow;
+        private bool CurrentIsOn() => Current.Value > _ioconf.CurrentSensingNoiseTreshold;
+
         public override string ToString()
         {
             string msg = string.Empty;

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -235,7 +235,7 @@ namespace CA_DataUploaderLib
                     heater.Current.Value = values[heater._ioconf.PortNumber - 1];
 
                     // this is a hot fix to make sure heaters are on/off. 
-                    const double CurrentZeroNoiseLevel = 0.15d; // this can be reduced as we confirm noise is consistently lower.
+                    const double CurrentZeroNoiseLevel = 0.1d; // this can be reduced as we confirm noise is consistently lower.
                     if (heater.Current.Value <= CurrentZeroNoiseLevel && heater.IsOn && heater.LastOn.AddSeconds(2) < DateTime.UtcNow)
                     {
                         HeaterOn(heater);

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -234,15 +234,14 @@ namespace CA_DataUploaderLib
                 {
                     heater.Current.Value = values[heater._ioconf.PortNumber - 1];
 
-                    // this is a hot fix to make sure heaters are on/off. 
-                    const double CurrentZeroNoiseLevel = 0.1d; // this can be reduced as we confirm noise is consistently lower.
-                    if (heater.Current.Value <= CurrentZeroNoiseLevel && heater.IsOn && heater.LastOn.AddSeconds(2) < DateTime.UtcNow)
+                    // this is for extra safety to make sure heaters are on/off when expected to be. 
+                    if (heater.MustResendOnCommand())
                     {
                         HeaterOn(heater);
                         CALog.LogData(LogID.A, $"on.={heater.Name()}-{heater.MaxSensorTemperature():N0}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");
                     }
 
-                    if (heater.Current.Value > CurrentZeroNoiseLevel && !heater.IsOn && heater.LastOff.AddSeconds(2) < DateTime.UtcNow)
+                    if (heater.MustResendOffCommand())
                     {
                         HeaterOff(heater);
                         CALog.LogData(LogID.A, $"off.={heater.Name()}-{heater.MaxSensorTemperature():N0}, v#={string.Join(", ", values)}, WB={board.BytesToWrite}{Environment.NewLine}");

--- a/CA_DataUploaderLib/IOconf/IOconfHeater.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfHeater.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CA_DataUploaderLib.Extensions;
+using System;
 
 namespace CA_DataUploaderLib.IOconf
 {
@@ -6,13 +7,17 @@ namespace CA_DataUploaderLib.IOconf
     {
         public IOconfHeater(string row, int lineNum) : base(row, lineNum, "Heater")
         {
-            format = "Heater;Name;BoxName;port number;MaxTemperature";
+            format = "Heater;Name;BoxName;port number;MaxTemperature;CurrentSensingNoiseTreshold";
 
             var list = ToList();
             if (list.Count < 5 || !int.TryParse(list[4], out MaxTemperature)) throw new Exception("IOconfHeater: missing max temperature: " + row);
+            if (list.Count == 6 && !list[5].TryToDouble(out CurrentSensingNoiseTreshold)) throw new Exception("IOconfHeater: failed to parse CurrentSensingNoiseTreshold: " + row);
         }
 
         public int MaxTemperature;
+        /// <summary>the heater is considered off below this current level (in amps)</summary>
+        /// <remarks>at the time of writting, this can not be lowered for the current version of the AC switchboard</remarks>
+        public readonly double CurrentSensingNoiseTreshold = 0.4;
 
         public IOconfInput AsConfInput()
         {


### PR DESCRIPTION
- BaseSensor attempted reconnects against skipped sensors. For the oxygen sensor, the temperature and pressure sensors triggered reconnects for the same board that disregard the lack of header in the sensor.
- Moved the tracking of last reopen time in MCUBoard.SafeReopen so it is *after* the reconnect attempt finishes, which improves the chance of a successful reconnect if the same board is reconnected to from different controllers.
- Refactored some of the MCUBoard.Read/Write methods for code reuse.
- added current sensing noise treshold to config (defaults to 0.4A)