### PR TITLE
improve communication time

### DIFF
--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -14,12 +14,14 @@ namespace CA_DataUploaderLib.IOconf
         public IOconfMap Map { get; set; }
 
 
-        protected void SetMap(string boxName)
+        protected void SetMap(string boxName, int? defaultBaudrate = null)
         {
             var maps = IOconfFile.GetMap();
             Map = maps.SingleOrDefault(x => x.BoxName == boxName);
             if (Map == null) 
                 throw new Exception($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
+            if (defaultBaudrate.HasValue)
+                Map.BaudRate = defaultBaudrate.Value;
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -39,10 +39,10 @@ namespace CA_DataUploaderLib.IOconf
             return false;
         }
 
-        private string USBPort { get; set; }
+        public string USBPort { get; private set; }
         private string SerialNumber { get; set; }
         public string BoxName { get; set; }
-        public int BaudRate;
+        public int BaudRate = 115200;
         public MCUBoard Board;
 
         public override string ToString() => $"{BoxName} - ${USBPort ?? SerialNumber}";

--- a/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
@@ -10,7 +10,7 @@ namespace CA_DataUploaderLib.IOconf
             var list = ToList();
             Name = list[1];
             BoxName = list[2];
-            SetMap(BoxName);
+            SetMap(BoxName, 9600);
         }
         
     }


### PR DESCRIPTION
- checks ports in parallel
- considers the oxygen sensor detected as soon as we see the luminox pattern
- configured luminox sensors default to 9600 baud rate
- IOConf - Map's baud rate is now used during initialization for devices configured by usb port
- board detection x baud rate aborts on first timeout