### PR TITLE
enabled rpi temp by default

### DIFF
--- a/CA_DataUploaderLib/Helpers/DULutil.cs
+++ b/CA_DataUploaderLib/Helpers/DULutil.cs
@@ -51,7 +51,8 @@ namespace CA_DataUploaderLib.Helpers
             var p = Process.Start(info);
             string output = p.StandardOutput.ReadToEnd();
             string err = p.StandardError.ReadToEnd();
-            Console.WriteLine(err);
+            if (!string.IsNullOrEmpty(err))
+                Console.WriteLine(err);
             p.WaitForExit(waitForExit);
             return output;
         }

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -29,22 +29,7 @@ namespace CA_DataUploaderLib.IOconf
             // remove empty lines and commented out lines
             var lines2 = lines.Where(x => !x.Trim().StartsWith("//") && x.Trim().Length > 2).Select(x => x.Trim()).ToList();
             lines2.ForEach(x => Table.Add(CreateType(x, lines.IndexOf(x))));
-            EnsureRpiTempTableConfiguration();
             CheckRules();
-        }
-
-        /// <summary>removes disabled rpi temps & applies the default if no rpi temps lines were configured</summary>
-        private static void EnsureRpiTempTableConfiguration()
-        {
-            var temps = Table.OfType<IOconfRPiTemp>().ToList();
-            if (temps.Count == 0 && !RpiVersion.IsWindows())
-            {
-                Table.Add(IOconfRPiTemp.Default);
-                return;
-            }
-
-            foreach (var temp in temps.Where(t => t.Disabled))
-                Table.Remove(temp);
         }
 
         private static IOconfRow CreateType(string row, int lineNum)
@@ -152,10 +137,10 @@ namespace CA_DataUploaderLib.IOconf
             return Table.Where(x => x.GetType() == typeof(IOconfSaltLeakage)).Cast<IOconfSaltLeakage>();
         }
 
-        public static IEnumerable<IOconfInput> GetTypeKAndLeakageAndRPiTemp()
-        {
-            return Table.Where(x => x.GetType() == typeof(IOconfTypeK) || x.GetType() == typeof(IOconfSaltLeakage) || x.GetType() == typeof(IOconfRPiTemp)).Cast<IOconfInput>();
-        }
+        public static IEnumerable<IOconfInput> GetTypeKAndLeakage() =>
+            Table.Where(x => x.GetType() == typeof(IOconfTypeK) || x.GetType() == typeof(IOconfSaltLeakage)).Cast<IOconfInput>();
+
+        public static IOconfRPiTemp GetRPiTemp() => Table.OfType<IOconfRPiTemp>().SingleOrDefault() ?? IOconfRPiTemp.Default;
 
         public static IEnumerable<IOconfOut230Vac> GetOut230Vac()
         {

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -29,7 +29,22 @@ namespace CA_DataUploaderLib.IOconf
             // remove empty lines and commented out lines
             var lines2 = lines.Where(x => !x.Trim().StartsWith("//") && x.Trim().Length > 2).Select(x => x.Trim()).ToList();
             lines2.ForEach(x => Table.Add(CreateType(x, lines.IndexOf(x))));
+            EnsureRpiTempTableConfiguration();
             CheckRules();
+        }
+
+        /// <summary>removes disabled rpi temps & applies the default if no rpi temps lines were configured</summary>
+        private static void EnsureRpiTempTableConfiguration()
+        {
+            var temps = Table.OfType<IOconfRPiTemp>().ToList();
+            if (temps.Count == 0 && !RpiVersion.IsWindows())
+            {
+                Table.Add(IOconfRPiTemp.Default);
+                return;
+            }
+
+            foreach (var temp in temps.Where(t => t.Disabled))
+                Table.Remove(temp);
         }
 
         private static IOconfRow CreateType(string row, int lineNum)

--- a/CA_DataUploaderLib/IOconf/IOconfRPiTemp.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRPiTemp.cs
@@ -15,5 +15,7 @@ namespace CA_DataUploaderLib.IOconf
             Disabled = list.Count > 2 && list[2] == "Disabled";
             Skip = true;
         }
+
+        public IOconfRPiTemp WithName(string name) => new IOconfRPiTemp(Row, LineNumber) {Name = name };
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfRPiTemp.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRPiTemp.cs
@@ -4,14 +4,16 @@ namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfRPiTemp : IOconfInput
     {
+        public static IOconfRPiTemp Default { get; } = new IOconfRPiTemp("RPiTemp;RPiTemp", 0);
+        public bool Disabled;
         public IOconfRPiTemp(string row, int lineNum) : base(row, lineNum, "RPiTemp")
         {
-            format = "RPiTemp;Name";
+            format = "RPiTemp;Name;[Disabled]";
 
             var list = ToList();
             Name = list[1];
+            Disabled = list.Count > 2 && list[2] == "Disabled";
             Skip = true;
         }
-
     }
 }

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -272,7 +272,7 @@ namespace CA_DataUploaderLib
         {
             if (!_luminoxRegex.IsMatch(line)) return false;
             // later on we should get the actual serial number. 
-            serialNumber = "Oxygen" + (Interlocked.Increment(ref luminoxSensorsDetected) + 1);
+            serialNumber = "Oxygen" + Interlocked.Increment(ref luminoxSensorsDetected);
             productType = "Luminox O2";
             return true;
         }


### PR DESCRIPTION
- fixed recurrent empty lines printed by the RpiTemp code
- as its now on by default, its now possible to explicitely disable Rpi Temp: RpiTemp;RpiTemp;Disabled
- only add rpi temp to the vector when its enabled
- rpi temp now records both cpu and gpu