### PR TITLE
fix for #58 issues running commands

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -73,12 +73,11 @@ namespace CA_DataUploaderLib
 
             while (_running)
             {
-                Thread.Sleep(100); //boards typically write a line every 100 ms (note we also way on exception cases)
-
                 try
                 {
                     ReadSensors();
                     CheckFails(); // check if any of the boards stopped responding. 
+                    Thread.Sleep(100); //boards typically write a line every 100 ms
                 }
                 catch (Exception ex)
                 {
@@ -89,6 +88,8 @@ namespace CA_DataUploaderLib
                         _cmd?.Execute("escape");
                         _running = false;
                     }
+                    else
+                        Thread.Sleep(100); //boards typically write a line every 100 ms
                 }
             }
 

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -73,11 +73,12 @@ namespace CA_DataUploaderLib
 
             while (_running)
             {
+                Thread.Sleep(100); //boards typically write a line every 100 ms (note we also way on exception cases)
+
                 try
                 {
                     ReadSensors();
                     CheckFails(); // check if any of the boards stopped responding. 
-                    Thread.Sleep(100);//boards typically write a line every 100 ms
                 }
                 catch (Exception ex)
                 {

--- a/CA_DataUploaderLib/Helpers/DULutil.cs
+++ b/CA_DataUploaderLib/Helpers/DULutil.cs
@@ -52,7 +52,8 @@ namespace CA_DataUploaderLib.Helpers
             string err = null;
             p.ErrorDataReceived += (sender, e) => err += e.Data;
             string output = p.StandardOutput.ReadToEnd();
-            p.WaitForExit(waitForExit);
+            if (!p.WaitForExit(waitForExit))
+                CALog.LogData(LogID.B, $"timed out waiting for command to exit: {command}");
             if (!string.IsNullOrEmpty(err))
                 Console.WriteLine(err);
 

--- a/CA_DataUploaderLib/Helpers/DULutil.cs
+++ b/CA_DataUploaderLib/Helpers/DULutil.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace CA_DataUploaderLib.Helpers
 {
     public class DULutil
     {
+        private static readonly object SingleProcessLock = new object();
+        private static readonly Stopwatch timeSinceLastProcessExit = new Stopwatch();
         public static void OpenUrl(string url)
         {
             try
@@ -48,16 +51,28 @@ namespace CA_DataUploaderLib.Helpers
                 RedirectStandardError = true
             };
 
-            var p = Process.Start(info);
-            string err = null;
-            p.ErrorDataReceived += (sender, e) => err += e.Data;
-            string output = p.StandardOutput.ReadToEnd();
-            if (!p.WaitForExit(waitForExit))
-                CALog.LogData(LogID.B, $"timed out waiting for command to exit: {command}");
-            if (!string.IsNullOrEmpty(err))
-                Console.WriteLine(err);
+            lock (SingleProcessLock)
+            {
+                if (timeSinceLastProcessExit.IsRunning && timeSinceLastProcessExit.ElapsedMilliseconds < 10)
+                    Thread.Sleep(10);
 
-            return output;
+                using (var p = Process.Start(info))
+                {
+                    string err = null;
+                    p.ErrorDataReceived += (sender, e) => err += e.Data;
+                    string output = p.StandardOutput.ReadToEnd();
+                    if (!p.WaitForExit(waitForExit))
+                        CALog.LogData(LogID.A, $"timed out waiting for command to exit: {command}");
+                    else
+                        p.WaitForExit(); // make sure all async events are finished handling https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=net-5.0#System_Diagnostics_Process_WaitForExit_System_Int32_
+                    if (!string.IsNullOrEmpty(err))
+                        CALog.LogData(LogID.A, $"error while running command {command} - {err}");
+
+                    p.ErrorDataReceived -= (sender, e) => err += e.Data;
+                    timeSinceLastProcessExit.Restart();
+                    return output;
+                }
+            }
         }
     }
 }

--- a/CA_DataUploaderLib/Helpers/DULutil.cs
+++ b/CA_DataUploaderLib/Helpers/DULutil.cs
@@ -49,11 +49,13 @@ namespace CA_DataUploaderLib.Helpers
             };
 
             var p = Process.Start(info);
+            string err = null;
+            p.ErrorDataReceived += (sender, e) => err += e.Data;
             string output = p.StandardOutput.ReadToEnd();
-            string err = p.StandardError.ReadToEnd();
+            p.WaitForExit(waitForExit);
             if (!string.IsNullOrEmpty(err))
                 Console.WriteLine(err);
-            p.WaitForExit(waitForExit);
+
             return output;
         }
     }

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -81,16 +81,18 @@ namespace CA_DataUploaderLib.IOconf
                 CALog.LogErrorAndConsoleLn(LogID.A, $"ERROR in {Directory.GetCurrentDirectory()}\\IO.conf:{Environment.NewLine} Heater: {heater.Key.Name} occure in several oven areas : {string.Join(", ", heater.Select(y => y.OvenArea).Distinct())}");
         }
 
+        private static IOconfLoopName GetLoopConfig() => Table.OfType<IOconfLoopName>().SingleOrDefault() ?? IOconfLoopName.Default;
+
         public static ConnectionInfo GetConnectionInfo()
         {
             try
             {
-                var loopName = ((IOconfLoopName)Table.Single(x => x.GetType() == typeof(IOconfLoopName)));
+                var loopConfig = GetLoopConfig();
                 var account = ((IOconfAccount)Table.Single(x => x.GetType() == typeof(IOconfAccount)));
                 return new ConnectionInfo
                 {
-                    LoopName = loopName.Name,
-                    Server = loopName.Server,
+                    LoopName = loopConfig.Name,
+                    Server = loopConfig.Server,
                     Fullname = account.Name,
                     email = account.Email,
                     password = account.Password,
@@ -102,10 +104,7 @@ namespace CA_DataUploaderLib.IOconf
             }
         }
 
-        public static string GetLoopName()
-        {
-            return ((IOconfLoopName)Table.Single(x => x.GetType() == typeof(IOconfLoopName))).Name;
-        }
+        public static string GetLoopName() => GetLoopConfig().Name;
 
         public static int GetVectorUploadDelay()
         {
@@ -116,11 +115,7 @@ namespace CA_DataUploaderLib.IOconf
             return ((IOconfSamplingRates)Table.SingleOrDefault(x => x.GetType() == typeof(IOconfSamplingRates)))?.MainLoopDelay ?? 200;
         }
 
-        public static CALogLevel GetOutputLevel()
-        {
-            if (!Table.Any()) return CALogLevel.None;
-            return ((IOconfLoopName)Table.Single(x => x.GetType() == typeof(IOconfLoopName))).LogLevel;
-        }
+        public static CALogLevel GetOutputLevel() => GetLoopConfig().LogLevel;
 
         public static IEnumerable<IOconfMap> GetMap()
         {

--- a/CA_DataUploaderLib/IOconf/IOconfLoopName.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfLoopName.cs
@@ -16,6 +16,8 @@ namespace CA_DataUploaderLib.IOconf
                 Server = list[3];
         }
 
+        public static IOconfLoopName Default { get; } = 
+            new IOconfLoopName($"LoopName;{ Environment.MachineName };Normal;https://www.theng.dk", 0);
         public string Name;
         public CALogLevel LogLevel;
         public string Server;

--- a/CA_DataUploaderLib/RpiVersion.cs
+++ b/CA_DataUploaderLib/RpiVersion.cs
@@ -122,7 +122,7 @@ namespace CA_DataUploaderLib
 
             // https://elinux.org/RPi_HardwareHistory
             if (_OS.Platform == PlatformID.Unix)
-                return DULutil.ExecuteShellCommand("sudo cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'").Trim();
+                return DULutil.ExecuteShellCommand("cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'").Trim();
 
             return "unknown";
         }
@@ -133,7 +133,7 @@ namespace CA_DataUploaderLib
             //    return "BCM2835";
 
             if (_OS.Platform == PlatformID.Unix)
-                return DULutil.ExecuteShellCommand("sudo cat /proc/cpuinfo | grep 'Hardware' | awk '{print $3}' | sed 's/^1000//'").Trim();
+                return DULutil.ExecuteShellCommand("cat /proc/cpuinfo | grep 'Hardware' | awk '{print $3}' | sed 's/^1000//'").Trim();
 
             return Environment.Is64BitProcess ? "64 bit" : "32 bit";
         }
@@ -141,7 +141,7 @@ namespace CA_DataUploaderLib
         private static string GetSerialNumber()
         {
             if (_OS.Platform == PlatformID.Unix)
-                return DULutil.ExecuteShellCommand("sudo cat /proc/cpuinfo | grep 'Serial' | awk '{print $3}' | sed 's/^1000//'").Trim();
+                return DULutil.ExecuteShellCommand("cat /proc/cpuinfo | grep 'Serial' | awk '{print $3}' | sed 's/^1000//'").Trim();
 
             return "unknown";
         }
@@ -149,7 +149,7 @@ namespace CA_DataUploaderLib
         private static string GetWiFi_SSID()
         {
             if (_OS.Platform == PlatformID.Unix)
-                return DULutil.ExecuteShellCommand("sudo iwgetid").Trim();
+                return DULutil.ExecuteShellCommand("iwgetid").Trim();
 
             return "unknown";
         }
@@ -183,7 +183,7 @@ namespace CA_DataUploaderLib
         private static string GetCPU()
         {
             if (_OS.Platform == PlatformID.Unix)
-                return DULutil.ExecuteShellCommand("sudo cat /proc/cpuinfo | grep 'model name'").Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).First().Substring(18).Trim();
+                return DULutil.ExecuteShellCommand("cat /proc/cpuinfo | grep 'model name'").Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).First().Substring(18).Trim();
 
             return System.Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
         }
@@ -199,7 +199,7 @@ namespace CA_DataUploaderLib
         private static int GetNumberOfCores()
         {
             if(_OS.Platform == PlatformID.Unix)
-                return DULutil.ExecuteShellCommand("sudo cat /proc/cpuinfo | grep 'model name'").Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Count();
+                return DULutil.ExecuteShellCommand("cat /proc/cpuinfo | grep 'model name'").Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Count();
 
             return Environment.ProcessorCount;
         }

--- a/CA_DataUploaderLib/SerialNumberMapper.cs
+++ b/CA_DataUploaderLib/SerialNumberMapper.cs
@@ -1,4 +1,5 @@
 ﻿using CA_DataUploaderLib.Extensions;
+using CA_DataUploaderLib.Helpers;
 using CA_DataUploaderLib.IOconf;
 using System;
 using System.Collections.Generic;
@@ -85,25 +86,8 @@ namespace CA_DataUploaderLib
                 return null;
 
             portName = portName.Substring(portName.LastIndexOf('/') + 1);
-            var info = new ProcessStartInfo();
-            info.FileName = "sudo";
-            info.Arguments = "dmesg";
-
-            info.UseShellExecute = false;
-            info.CreateNoWindow = true;
-
-            info.RedirectStandardOutput = true;
-            info.RedirectStandardError = true;
-
-            var p = Process.Start(info);
-            var result = p.StandardOutput.ReadToEnd().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-            if (!p.WaitForExit(1000))
-                CALog.LogData(LogID.B, $"timed out waiting for command to exit: sudo dmesg");
-            var line = result.FirstOrDefault(x => x.EndsWith(portName));
-            if (line == null)
-                return null;
-
-            return line.StringBetween(": ", " to ttyUSB");
+            var result = DULutil.ExecuteShellCommand($"dmesg | grep {portName}").Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            return result.FirstOrDefault(x => x.EndsWith(portName))?.StringBetween(": ", " to ttyUSB");
         }
 
         /// <summary>

--- a/CA_DataUploaderLib/SerialNumberMapper.cs
+++ b/CA_DataUploaderLib/SerialNumberMapper.cs
@@ -97,7 +97,8 @@ namespace CA_DataUploaderLib
 
             var p = Process.Start(info);
             var result = p.StandardOutput.ReadToEnd().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-            p.WaitForExit(1000);
+            if (!p.WaitForExit(1000))
+                CALog.LogData(LogID.B, $"timed out waiting for command to exit: sudo dmesg");
             var line = result.FirstOrDefault(x => x.EndsWith(portName));
             if (line == null)
                 return null;

--- a/CA_DataUploaderLib/SerialNumberMapper.cs
+++ b/CA_DataUploaderLib/SerialNumberMapper.cs
@@ -96,8 +96,8 @@ namespace CA_DataUploaderLib
             info.RedirectStandardError = true;
 
             var p = Process.Start(info);
-            p.WaitForExit(1000);
             var result = p.StandardOutput.ReadToEnd().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            p.WaitForExit(1000);
             var line = result.FirstOrDefault(x => x.EndsWith(portName));
             if (line == null)
                 return null;

--- a/CA_DataUploaderLib/ThermocoupleBox.cs
+++ b/CA_DataUploaderLib/ThermocoupleBox.cs
@@ -56,8 +56,6 @@ namespace CA_DataUploaderLib
         {
             base.ReadSensors();
 
-            if (initDelayWatch.ElapsedMilliseconds < 2000) 
-                return; // wait 10 seconds before running temp commands / attempt to avoid conflicts with systemd's main process detection due to the commands
 
             if (_rpiGpuSample != null)
                 _rpiGpuSample.Value = DULutil.ExecuteShellCommand("vcgencmd measure_temp").Replace("temp=", "").Replace("'C", "").ToDouble();

--- a/CA_DataUploaderLib/ThermocoupleBox.cs
+++ b/CA_DataUploaderLib/ThermocoupleBox.cs
@@ -1,11 +1,9 @@
 ﻿using CA_DataUploaderLib.IOconf;
 using CA_DataUploaderLib.Extensions;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using CA_DataUploaderLib.Helpers;
-using System.Diagnostics;
 
 namespace CA_DataUploaderLib
 {
@@ -13,7 +11,6 @@ namespace CA_DataUploaderLib
     {
         private readonly SensorSample _rpiGpuSample;
         private readonly SensorSample _rpiCpuSample;
-        private readonly Stopwatch initDelayWatch;
         public ThermocoupleBox(CommandHandler cmd)
         {
             Title = "Thermocouples";
@@ -48,7 +45,6 @@ namespace CA_DataUploaderLib
                     board.WriteLine("Junction");
             }
 
-            initDelayWatch = Stopwatch.StartNew();
             new Thread(() => this.LoopForever()).Start();
         }
 


### PR DESCRIPTION
The main fix that was confirmed to address the issue is we avoid running processes in parallel + ensure there are 10+ ms from the exit of one to the start of the next one.

Also did the following, which was confirmed to still reproduce the issue without the main fix:
- fixed missing Dispose of the Process, in an attempt to address a crash after 3 days running 2 child processes every 100 ms.
- removed previous timing based workaround, that could still hit the issue depending on the configuration of the system i.e. depends on the start time which in turns depends on the overall system complexity
- aligned process start with msdn docs removing possibility of deadlock. In one case if the standard error buffer got full and the child process would wait while the parent was waiting for the output to finish. In the other case in SerialNumberMapper if standard output buffer got full and the child process would wait while the parent waited for the child to exit.
- removed sudo usages that should not have been there