### PR TITLE
.net 5 regression: child parallel processes crash

### DIFF
--- a/CA_DataUploader/CA_DataUploader.csproj
+++ b/CA_DataUploader/CA_DataUploader.csproj
@@ -13,4 +13,11 @@
     <Content Include="USBmapper.sh;IO.conf" CopyToOutputDirectory="Always" ExcludeFromSingleFile="true" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="2.4.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/CA_DataUploaderLib/CALog.cs
+++ b/CA_DataUploaderLib/CALog.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 
 namespace CA_DataUploaderLib
 {

--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://github.com/copenhagenatomics/CA_DataUploader</PackageProjectUrl>
     <PackageTags>Raspberry Pi, IOT, Data Logger</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.0</Version>
+    <Version>2.1</Version>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) Copenhagen Atomics ($([System.DateTime]::UtcNow.ToString("dd-MMM-yyyy HH:mm")))</Copyright>
     <RepositoryUrl>https://github.com/copenhagenatomics/CA_DataUploader</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -10,7 +10,6 @@
     <PackageProjectUrl>https://github.com/copenhagenatomics/CA_DataUploader</PackageProjectUrl>
     <PackageTags>Raspberry Pi, IOT, Data Logger</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.1</Version>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) Copenhagen Atomics ($([System.DateTime]::UtcNow.ToString("dd-MMM-yyyy HH:mm")))</Copyright>
     <RepositoryUrl>https://github.com/copenhagenatomics/CA_DataUploader</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -40,6 +39,10 @@
     <PackageReference Include="CoreCLR-NCalc" Version="2.2.92" />
     <PackageReference Include="Humanizer.Core" Version="2.8.26" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+    <PackageReference Include="MinVer" Version="2.4.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.IO.Ports" Version="5.0.0" />
     <PackageReference Include="System.Management" Version="5.0.0" />
   </ItemGroup>

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -292,40 +292,26 @@ namespace CA_DataUploaderLib
             }
         }
 
-        public List<SensorSample> GetStates()
-        {
-            var list = new List<SensorSample>();
-            if (_logLevel == CALogLevel.Debug)
-            {
-                list.Add(new SensorSample("off_temperature", _offTemperature));
-                list.Add(new SensorSample("last_temperature", _lastTemperature));
-            }
-
-            return list;
-        }
-
-        public IEnumerable<SensorSample> GetPower()
-        {
-            var powerValues = _heaters.Select(x => x.Current.Clone());
-            var states =_heaters.Select(x => new SensorSample(x.Name() + "_On/Off", x.IsOn ? 1.0 : 0.0));
-            var switchboardStates =_heaters.Select(x => new SensorSample(
-                x.Name() + "_SwitchboardOn/Off", x.IsSwitchboardOn == null ? 10000 : x.IsSwitchboardOn.Value ? 1.0 : 0.0));
-            var values = powerValues.Concat(states).Concat(switchboardStates);
-            if (_logLevel == CALogLevel.Debug)
-            {
-                var loopTimes = _heaters.Select(x => new SensorSample(x.Name() + "_LoopTime", x.Current.ReadSensor_LoopTime));
-                return values.Concat(loopTimes);
-            }
-
-            return values;
-        }
-
         /// <summary>
         /// Gets all the values in the order specified by <see cref="GetVectorDescriptionItems"/>.
         /// </summary>
         public IEnumerable<SensorSample> GetValues()
         {
-            return GetPower().Concat(GetStates());
+            var currentValues = _heaters.Select(x => x.Current.Clone());
+            var states =_heaters.Select(x => new SensorSample(x.Name() + "_On/Off", x.IsOn ? 1.0 : 0.0));
+            var switchboardStates =_heaters.Select(x => new SensorSample(
+                x.Name() + "_SwitchboardOn/Off", x.IsSwitchboardOn == null ? 10000 : x.IsSwitchboardOn.Value ? 1.0 : 0.0));
+            var values = currentValues.Concat(states).Concat(switchboardStates);
+            if (_logLevel == CALogLevel.Debug)
+            {
+                var loopTimes = _heaters.Select(x => new SensorSample(x.Name() + "_LoopTime", x.Current.ReadSensor_LoopTime));
+                return values
+                    .Concat(loopTimes)
+                    .Append(new SensorSample("off_temperature", _offTemperature))
+                    .Append(new SensorSample("last_temperature", _lastTemperature));
+            }
+
+            return values;
         }
 
         public List<VectorDescriptionItem> GetVectorDescriptionItems()

--- a/CA_DataUploaderLib/Helpers/DULutil.cs
+++ b/CA_DataUploaderLib/Helpers/DULutil.cs
@@ -54,7 +54,7 @@ namespace CA_DataUploaderLib.Helpers
             lock (SingleProcessLock)
             {
                 if (timeSinceLastProcessExit.IsRunning && timeSinceLastProcessExit.ElapsedMilliseconds < 10)
-                    Thread.Sleep(10);
+                    Thread.Sleep(20);
 
                 using (var p = Process.Start(info))
                 {

--- a/CA_DataUploaderLib/Helpers/DULutil.cs
+++ b/CA_DataUploaderLib/Helpers/DULutil.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace CA_DataUploaderLib.Helpers
 {
     public class DULutil
     {
-        private static readonly object SingleProcessLock = new object();
-        private static readonly Stopwatch timeSinceLastProcessExit = new Stopwatch();
         public static void OpenUrl(string url)
         {
             try
@@ -51,27 +47,20 @@ namespace CA_DataUploaderLib.Helpers
                 RedirectStandardError = true
             };
 
-            lock (SingleProcessLock)
+            using (var p = Process.Start(info))
             {
-                if (timeSinceLastProcessExit.IsRunning && timeSinceLastProcessExit.ElapsedMilliseconds < 10)
-                    Thread.Sleep(20);
+                string err = null;
+                p.ErrorDataReceived += (sender, e) => err += e.Data;
+                string output = p.StandardOutput.ReadToEnd();
+                if (!p.WaitForExit(waitForExit))
+                    CALog.LogData(LogID.A, $"timed out waiting for command to exit: {command}");
+                else
+                    p.WaitForExit(); // make sure all async events are finished handling https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=net-5.0#System_Diagnostics_Process_WaitForExit_System_Int32_
+                if (!string.IsNullOrEmpty(err))
+                    CALog.LogData(LogID.A, $"error while running command {command} - {err}");
 
-                using (var p = Process.Start(info))
-                {
-                    string err = null;
-                    p.ErrorDataReceived += (sender, e) => err += e.Data;
-                    string output = p.StandardOutput.ReadToEnd();
-                    if (!p.WaitForExit(waitForExit))
-                        CALog.LogData(LogID.A, $"timed out waiting for command to exit: {command}");
-                    else
-                        p.WaitForExit(); // make sure all async events are finished handling https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=net-5.0#System_Diagnostics_Process_WaitForExit_System_Int32_
-                    if (!string.IsNullOrEmpty(err))
-                        CALog.LogData(LogID.A, $"error while running command {command} - {err}");
-
-                    p.ErrorDataReceived -= (sender, e) => err += e.Data;
-                    timeSinceLastProcessExit.Restart();
-                    return output;
-                }
+                p.ErrorDataReceived -= (sender, e) => err += e.Data;
+                return output;
             }
         }
     }

--- a/CA_DataUploaderLib/IOconf/IOconfFilter.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFilter.cs
@@ -34,7 +34,7 @@ namespace CA_DataUploaderLib.IOconf
                 sources.Remove("hidesource");
             }
 
-            // source validation happens later, as there is not a 1-1 relation of IOConfFile entries and values getting into the Vector i.e. oxygen has 3 values, heaters have power and state. 
+            // source validation happens later, as there is not a 1-1 relation of IOConfFile entries and values getting into the Vector i.e. oxygen has 3 values, heaters have current and state. 
             SourceNames = sources;
         }
     }

--- a/CA_DataUploaderLib/IOconf/IOconfHeater.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfHeater.cs
@@ -23,7 +23,7 @@ namespace CA_DataUploaderLib.IOconf
         {
             return new IOconfInput(Row, LineNumber, "Heater")
             {
-                Name = Name + "_Power"
+                Name = Name + "_current"
             };
         }
     }

--- a/CA_DataUploaderLib/RpiVersion.cs
+++ b/CA_DataUploaderLib/RpiVersion.cs
@@ -53,11 +53,19 @@ namespace CA_DataUploaderLib
 
         public static string GetSoftware()
         {
+            var hostAssembly = Assembly.GetEntryAssembly();
+            var hostVersion = hostAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
             Assembly asm = typeof(RpiVersion).Assembly;
             var copyright = asm.GetCustomAttribute<AssemblyCopyrightAttribute>().Copyright;
-            return asm.GetName()
-                + Environment.NewLine + copyright + Environment.NewLine
-                + "Kernel version : " + GetKernalVersion();
+            string version = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            string newLine = Environment.NewLine;
+            return 
+$@"{hostAssembly.GetName()}
+    FileVersion {hostVersion}
+{asm.GetName()}
+    FileVersion {version}
+    copyright {copyright}
+    Kernel version {GetKernelVersion()}";
         }
 
         public static string GetHardwareInfo()
@@ -180,7 +188,7 @@ namespace CA_DataUploaderLib
             return System.Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
         }
 
-        private static string GetKernalVersion()
+        private static string GetKernelVersion()
         {
             if(_OS.Platform == PlatformID.Unix)
                 return DULutil.ExecuteShellCommand("uname -r").Trim();


### PR DESCRIPTION
The upgrade to net5.0 broke the workaround used in #59. However, the reason the original issue still triggered in some systems without the delay between processes was because the conflict also involved a process started by a third party API being used on the affected systems. So the delay is what in reality was avoiding the conflict with that process and the lock was not doing anything for that.

Due to this, a better workaround that is in practice a permament fix for our case is for the program that runs in the other systems to be adjusted so that the offending third party code runs at a time where we can be certain no other child processes are being ran by us.

This PR removes the earlier attempted workarounds, so that child processes can now again run in parallel without any kind of locks or delays. It also includes the unrelated change of _power to _current we have on the graphs.