### PR TITLE
introduced/moved board related settings to the IOconf classes

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -86,7 +86,9 @@ namespace CA_DataUploaderLib
             DateTime start = DateTime.Now;
             int badRow = 0;
             // normally all boards have the same ms between reads, so for now just use the minimum value.
-            var msBetweenReads = _boards.Min(b => b.ConfigSettings.MillisecondsBetweenReads); 
+            // we reach here without boxes when the values are all Skip (a.k.a don't use usb boards),
+            // such like rpi temps in the ThermocoupleBox and pressure/temperature of the oxygen sensors.
+            var msBetweenReads = _boards.Count > 0 ? _boards.Min(b => b.ConfigSettings.MillisecondsBetweenReads) : 1000; 
 
             while (_running)
             {

--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using CA_DataUploaderLib.Extensions;
+
+namespace CA_DataUploaderLib.IOconf
+{
+    public class BoardSettings
+    {
+        public static BoardSettings Default { get; } = new BoardSettings();
+
+        public int DefaultBaudRate { get; set; } = 0;
+        public int MillisecondsBetweenReads { get; set; } = 100;
+        public int ExpectedHeaderLines { get; set; } = 8;
+        public int MaxMillisecondsWithoutNewValues { get; set; } = 2000;
+        public int SecondsBetweenReopens { get; set; } = 3;
+        public bool StopWhenLosingSensor { get; set; } = true;
+        public bool SkipBoardAutoDetection { get; set; } = false;
+        public LineParser Parser { get; set; } = LineParser.Default;
+
+        public class LineParser
+        {
+            public static LineParser Default { get; } = new LineParser();
+            private static readonly Regex _startsWithDigitRegex = new Regex(@"^\s*(-|\d+)\s*");
+
+            /// <returns>the list of doubles, or null when the line did not match the expected format</returns>
+            public virtual List<double> TryParseAsDoubleList(string line)
+            {
+                if (!_startsWithDigitRegex.IsMatch(line))
+                    return null;
+
+                return line.Split(",".ToCharArray())
+                    .Select(x => x.Trim())
+                    .Where(x => x.Length > 0)
+                    .Select(x => x.ToDouble())
+                    .ToList();
+            }
+
+            public virtual bool MatchesValuesFormat(string line) => _startsWithDigitRegex.IsMatch(line);
+        }
+    }
+}

--- a/CA_DataUploaderLib/IOconf/IOConfPressure.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfPressure.cs
@@ -8,9 +8,7 @@ namespace CA_DataUploaderLib.IOconf
         {
             format = "Pressure;Name;BoxName;[port number / skip]";
             var list = ToList();
-            if ("skip".Equals(list[3].ToLower(), StringComparison.InvariantCultureIgnoreCase))
-                Skip = true;
-            else if (!int.TryParse(list[3], out PortNumber)) 
+            if (!Skip && !HasPort)
                 throw new Exception("IOConfPressure: wrong port number: " + row);
         }
     }

--- a/CA_DataUploaderLib/IOconf/IOconfAirFlow.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAirFlow.cs
@@ -2,6 +2,7 @@
 {
     public class IOconfAirFlow : IOconfInput
     {
-        public IOconfAirFlow(string row, int lineNum) : base(row, lineNum, "AirFlow") { }
+        public IOconfAirFlow(string row, int lineNum) : 
+            base(row, lineNum, "AirFlow", true, true, new BoardSettings() { ExpectedHeaderLines = 12 }) { }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -6,19 +6,24 @@ namespace CA_DataUploaderLib.IOconf
     public class IOconfInput : IOconfRow
     {
         public IOconfInput(string row, int lineNum, string type) : this(row, lineNum, type, true, true, null)  { }
-        public IOconfInput(string row, int lineNum, string type, bool parsePort, bool parseBoxName, BoardSettings boardSettings) : base(row, lineNum, type) 
+        public IOconfInput(string row, int lineNum, string type, bool parsePortRequired, bool parseBoxName, BoardSettings boardSettings) : base(row, lineNum, type) 
         {
             format = $"{type};Name;BoxName;[port number]";
             var list = ToList();
             Name = list[1];
             
+            if (parsePortRequired && list.Count < 4) 
+                throw new Exception($"{type}: wrong port number: {row}");
+            if (list.Count > 3 && !(HasPort = int.TryParse(list[3], out PortNumber)) && parsePortRequired) 
+                throw new Exception($"{type}: wrong port number: {row}");
+            if (list.Count > 3 && list[3] == "Skip") 
+                Skip = true;
+
             if (parseBoxName) 
             {
                 BoxName = list[2];
-                SetMap(BoxName, boardSettings);
+                SetMap(BoxName, boardSettings, Skip) ;
             }
-
-            if (parsePort && !int.TryParse(list[3], out PortNumber)) throw new Exception($"{type}: wrong port number: {row}");
         }
 
 
@@ -27,15 +32,16 @@ namespace CA_DataUploaderLib.IOconf
         public int PortNumber;
         public bool Skip { get; set; }
         public IOconfMap Map { get; set; }
+        protected bool HasPort { get; }
 
-
-        private void SetMap(string boxName, BoardSettings settings)
+        private void SetMap(string boxName, BoardSettings settings, bool skipBoardSettings)
         {
             var maps = IOconfFile.GetMap();
             Map = maps.SingleOrDefault(x => x.BoxName == boxName);
             if (Map == null) 
                 throw new Exception($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
-            Map.BoardSettings = settings;
+            if (skipBoardSettings)
+                Map.BoardSettings = settings;
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -16,7 +16,7 @@ namespace CA_DataUploaderLib.IOconf
                 throw new Exception($"{type}: wrong port number: {row}");
             if (list.Count > 3 && !(HasPort = int.TryParse(list[3], out PortNumber)) && parsePortRequired) 
                 throw new Exception($"{type}: wrong port number: {row}");
-            if (list.Count > 3 && list[3] == "Skip") 
+            if (list.Count > 3 && "skip".Equals(list[3], StringComparison.InvariantCultureIgnoreCase)) 
                 Skip = true;
 
             if (parseBoxName) 

--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -40,7 +40,7 @@ namespace CA_DataUploaderLib.IOconf
             Map = maps.SingleOrDefault(x => x.BoxName == boxName);
             if (Map == null) 
                 throw new Exception($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
-            if (skipBoardSettings)
+            if (!skipBoardSettings)
                 Map.BoardSettings = settings;
         }
     }

--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -6,7 +6,7 @@ namespace CA_DataUploaderLib.IOconf
     public class IOconfInput : IOconfRow
     {
         public IOconfInput(string row, int lineNum, string type) : this(row, lineNum, type, true, true, null)  { }
-        public IOconfInput(string row, int lineNum, string type, bool parsePort, bool parseBoxName, int? baudRate) : base(row, lineNum, type) 
+        public IOconfInput(string row, int lineNum, string type, bool parsePort, bool parseBoxName, BoardSettings boardSettings) : base(row, lineNum, type) 
         {
             format = $"{type};Name;BoxName;[port number]";
             var list = ToList();
@@ -15,7 +15,7 @@ namespace CA_DataUploaderLib.IOconf
             if (parseBoxName) 
             {
                 BoxName = list[2];
-                SetMap(BoxName, baudRate);
+                SetMap(BoxName, boardSettings);
             }
 
             if (parsePort && !int.TryParse(list[3], out PortNumber)) throw new Exception($"{type}: wrong port number: {row}");
@@ -29,14 +29,13 @@ namespace CA_DataUploaderLib.IOconf
         public IOconfMap Map { get; set; }
 
 
-        protected void SetMap(string boxName, int? defaultBaudrate = null)
+        private void SetMap(string boxName, BoardSettings settings)
         {
             var maps = IOconfFile.GetMap();
             Map = maps.SingleOrDefault(x => x.BoxName == boxName);
             if (Map == null) 
                 throw new Exception($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
-            if (defaultBaudrate.HasValue)
-                Map.BaudRate = defaultBaudrate.Value;
+            Map.BoardSettings = settings;
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -56,6 +56,6 @@ namespace CA_DataUploaderLib.IOconf
         public MCUBoard Board;
         private BoardSettings _boardSettings = BoardSettings.Default;
 
-        public override string ToString() => $"{BoxName} - ${USBPort ?? SerialNumber}";
+        public override string ToString() => $"{BoxName} - {USBPort ?? SerialNumber}";
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -47,14 +47,13 @@ namespace CA_DataUploaderLib.IOconf
             set
             {
                 _boardSettings = value ?? BoardSettings.Default;
-                if (_baudRate == 0) _baudRate = _boardSettings.DefaultBaudRate;
+                if (BaudRate == 0) BaudRate = _boardSettings.DefaultBaudRate;
             }
         }
         /// <summary>the baud rate as specified in configuration and otherwise 0</summary>
         /// <remarks>check <see cref="BoardSettings" /> for additional baud rate set by configurations</remarks>
         public int BaudRate { get; private set; }
         public MCUBoard Board;
-        private int _baudRate;
         private BoardSettings _boardSettings = BoardSettings.Default;
 
         public override string ToString() => $"{BoxName} - ${USBPort ?? SerialNumber}";

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -19,8 +19,12 @@ namespace CA_DataUploaderLib.IOconf
                 SerialNumber = list[1];
 
             BoxName = list[2];
-            if (list.Count > 3 && !int.TryParse(list[3], out BaudRate))
-                BaudRate = 115200; // default baud rate. 
+            if (list.Count <= 3)
+                return;
+            if (!int.TryParse(list[3], out var baudrate))
+                CALog.LogErrorAndConsoleLn(LogID.A, $"Failed to parse the baud rate for the board: {BoxName}. Attempting with defaults.");
+            else
+                BaudRate = baudrate;
         }
 
         public bool SetMCUboard(MCUBoard board)
@@ -37,8 +41,21 @@ namespace CA_DataUploaderLib.IOconf
         public string USBPort { get; private set; }
         private string SerialNumber { get; set; }
         public string BoxName { get; set; }
-        public int BaudRate = 115200;
+        public BoardSettings BoardSettings
+        {
+            get => _boardSettings; 
+            set
+            {
+                _boardSettings = value ?? BoardSettings.Default;
+                if (_baudRate == 0) _baudRate = value.DefaultBaudRate;
+            }
+        }
+        /// <summary>the baud rate as specified in configuration and otherwise 0</summary>
+        /// <remarks>check <see cref="BoardSettings" /> for additional baud rate set by configurations</remarks>
+        public int BaudRate { get; private set; }
         public MCUBoard Board;
+        private int _baudRate;
+        private BoardSettings _boardSettings = BoardSettings.Default;
 
         public override string ToString() => $"{BoxName} - ${USBPort ?? SerialNumber}";
     }

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -47,7 +47,7 @@ namespace CA_DataUploaderLib.IOconf
             set
             {
                 _boardSettings = value ?? BoardSettings.Default;
-                if (_baudRate == 0) _baudRate = value.DefaultBaudRate;
+                if (_baudRate == 0) _baudRate = _boardSettings.DefaultBaudRate;
             }
         }
         /// <summary>the baud rate as specified in configuration and otherwise 0</summary>

--- a/CA_DataUploaderLib/IOconf/IOconfMotor.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMotor.cs
@@ -4,10 +4,12 @@
     {
         public string Direction;
 
-        public IOconfMotor(string row, int lineNum) : base(row, lineNum, "Motor", false)
+        public IOconfMotor(string row, int lineNum) : base(row, lineNum, "Motor", false, 
+            new BoardSettings() { DefaultBaudRate = 38400, SkipBoardAutoDetection = true })
         {
             format = "Motor;Name;BoxName;Forward/Backward";
             Direction = ToList()[3];
+            CALog.LogInfoAndConsoleLn(LogID.A, $"VFD config: disabled type detection for board {Map}");
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOutput.cs
@@ -6,13 +6,13 @@ namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfOutput : IOconfRow
     {
-        public IOconfOutput(string row, int lineNum, string type, bool parsePort = true) : base(row, lineNum, type) 
+        public IOconfOutput(string row, int lineNum, string type, bool parsePort = true, BoardSettings settings = null) : base(row, lineNum, type) 
         { 
             format = $"{type};Name;BoxName;[port number]";
             var list = ToList();
             Name = list[1];
             BoxName = list[2];
-            SetMap(BoxName); 
+            SetMap(BoxName, settings); 
             if (parsePort && !int.TryParse(list[3], out PortNumber)) throw new Exception($"{type}: wrong port number: {row}");
         }
 
@@ -21,13 +21,13 @@ namespace CA_DataUploaderLib.IOconf
         public int PortNumber;
         public IOconfMap Map { get; set; }
 
-        protected void SetMap(string boxName)
+        protected void SetMap(string boxName, BoardSettings settings)
         {
             var maps = IOconfFile.GetMap();
             Map = maps.SingleOrDefault(x => x.BoxName == boxName);
             if (Map == null)
                 throw new Exception($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
+            Map.BoardSettings = settings;
         }
-
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
@@ -26,9 +26,9 @@ namespace CA_DataUploaderLib.IOconf
         /// <summary>get expanded conf entries that include the oxygen %, oxygen partial pressure and error</summary>
         /// <remarks>the returned entries have port numbers that correspond to the ones returned by the LineParser</remarks>
         public IEnumerable<IOconfOxygen> GetExpandedConf() => new [] {
-            new IOconfOxygen($"Oxygen_Oxygen%;{Name};{BoxName}", LineNumber) { PortNumber = 3},
-            new IOconfOxygen($"Oxygen_OxygenPartialPressure;{Name};{BoxName}", LineNumber) { PortNumber = 0},
-            new IOconfOxygen($"Oxygen_Error;{Name};{BoxName}", LineNumber) { PortNumber = 4}
+            new IOconfOxygen($"Oxygen;Oxygen_Oxygen%;{Name};{BoxName}", LineNumber) { PortNumber = 3},
+            new IOconfOxygen($"Oxygen;Oxygen_OxygenPartialPressure;{Name};{BoxName}", LineNumber) { PortNumber = 0},
+            new IOconfOxygen($"Oxygen;Oxygen_Error;{Name};{BoxName}", LineNumber) { PortNumber = 4}
             };
 
         public class LineParser : BoardSettings.LineParser

--- a/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
@@ -26,9 +26,9 @@ namespace CA_DataUploaderLib.IOconf
         /// <summary>get expanded conf entries that include the oxygen %, oxygen partial pressure and error</summary>
         /// <remarks>the returned entries have port numbers that correspond to the ones returned by the LineParser</remarks>
         public IEnumerable<IOconfOxygen> GetExpandedConf() => new [] {
-            new IOconfOxygen($"Oxygen;Oxygen_Oxygen%;{Name};{BoxName}", LineNumber) { PortNumber = 3},
-            new IOconfOxygen($"Oxygen;Oxygen_OxygenPartialPressure;{Name};{BoxName}", LineNumber) { PortNumber = 0},
-            new IOconfOxygen($"Oxygen;Oxygen_Error;{Name};{BoxName}", LineNumber) { PortNumber = 4}
+            new IOconfOxygen($"Oxygen;{Name}_Oxygen%;{BoxName}", LineNumber) { PortNumber = 3},
+            new IOconfOxygen($"Oxygen;{Name}_OxygenPartialPressure;{BoxName}", LineNumber) { PortNumber = 0},
+            new IOconfOxygen($"Oxygen;{Name}_Error;{BoxName}", LineNumber) { PortNumber = 4}
             };
 
         public class LineParser : BoardSettings.LineParser

--- a/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
@@ -1,10 +1,57 @@
-﻿namespace CA_DataUploaderLib.IOconf
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using CA_DataUploaderLib.Extensions;
+
+namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfOxygen : IOconfInput
     {
-        public IOconfOxygen(string row, int lineNum) : base(row, lineNum, "Oxygen", false, true, 9600)
+        public IOconfOxygen(string row, int lineNum) : base(
+            row, lineNum, "Oxygen", false, true, 
+            new BoardSettings() 
+            {
+                DefaultBaudRate = 9600,
+                ExpectedHeaderLines = 1,
+                MaxMillisecondsWithoutNewValues = 10000,
+                MillisecondsBetweenReads = 1200,
+                SecondsBetweenReopens = 10,
+                StopWhenLosingSensor = false,
+                Parser = LineParser.Default
+            })
         {
             format = "Oxygen;Name;BoxName";
+        }
+
+        /// <summary>get expanded conf entries that include the oxygen %, oxygen partial pressure and error</summary>
+        /// <remarks>the returned entries have port numbers that correspond to the ones returned by the LineParser</remarks>
+        public IEnumerable<IOconfOxygen> GetExpandedConf() => new [] {
+            new IOconfOxygen($"Oxygen_Oxygen%;{Name};{BoxName}", LineNumber) { PortNumber = 3},
+            new IOconfOxygen($"Oxygen_OxygenPartialPressure;{Name};{BoxName}", LineNumber) { PortNumber = 0},
+            new IOconfOxygen($"Oxygen_Error;{Name};{BoxName}", LineNumber) { PortNumber = 4}
+            };
+
+        private class LineParser : BoardSettings.LineParser
+        {
+            // "O 0213.1 T +21.0 P 1019 % 020.92 e 0000"
+            private const string _luminoxPattern = "O ((?:[0-9]*[.])?[0-9]+) T ([+-]?(?:[0-9]*[.])?[0-9]+) P ((?:[0-9]*[.])?[0-9]+) % ((?:[0-9]*[.])?[0-9]+) e ([0-9]*)";
+            private readonly Regex _luminoxRegex = new Regex(_luminoxPattern);
+            public new static LineParser Default { get; } = new LineParser();
+
+            // returns partial pressure, temperature, pressure, oxygen %, error code
+            public override List<double> TryParseAsDoubleList(string line)
+            {
+                var match = _luminoxRegex.Match(_luminoxPattern);
+                if (!match.Success) 
+                    return null; 
+
+                var list = match.Groups.Cast<Group>().Skip(1)
+                    .Where(x => x.Value.TryToDouble(out _))
+                    .Select(x => x.Value.ToDouble()).ToList();
+                return new List<double> { list[0], list[1], (list[2] - 1000) / 1000.0, list[3], list[4] };
+            }
+
+            public override bool MatchesValuesFormat(string line) => _luminoxRegex.IsMatch(line);
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
@@ -31,7 +31,7 @@ namespace CA_DataUploaderLib.IOconf
             new IOconfOxygen($"Oxygen_Error;{Name};{BoxName}", LineNumber) { PortNumber = 4}
             };
 
-        private class LineParser : BoardSettings.LineParser
+        public class LineParser : BoardSettings.LineParser
         {
             // "O 0213.1 T +21.0 P 1019 % 020.92 e 0000"
             private const string _luminoxPattern = "O ((?:[0-9]*[.])?[0-9]+) T ([+-]?(?:[0-9]*[.])?[0-9]+) P ((?:[0-9]*[.])?[0-9]+) % ((?:[0-9]*[.])?[0-9]+) e ([0-9]*)";
@@ -41,7 +41,7 @@ namespace CA_DataUploaderLib.IOconf
             // returns partial pressure, temperature, pressure, oxygen %, error code
             public override List<double> TryParseAsDoubleList(string line)
             {
-                var match = _luminoxRegex.Match(_luminoxPattern);
+                var match = _luminoxRegex.Match(line);
                 if (!match.Success) 
                     return null; 
 

--- a/CA_DataUploaderLib/IOconf/IOconfScale.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfScale.cs
@@ -1,7 +1,31 @@
-﻿namespace CA_DataUploaderLib.IOconf
+﻿using System.Collections.Generic;
+using CA_DataUploaderLib.Extensions;
+
+namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfScale : IOconfInput
     { 
-        public IOconfScale(string row, int lineNum) : base(row, lineNum, "Scale", false, true, 9600) { }
+        public IOconfScale(string row, int lineNum) : base(row, lineNum, "Scale", false, true, 
+            new BoardSettings()
+            {
+                DefaultBaudRate = 9600,
+                ExpectedHeaderLines = 1, 
+                Parser = LineParser.Default
+            }) 
+        { 
+        }
+
+        private class LineParser : BoardSettings.LineParser
+        {
+            public new static LineParser Default { get; } = new LineParser();
+            
+            public override List<double> TryParseAsDoubleList(string line)
+            { // expected line format: "+0000.00 kg"
+                line = line.TrimEnd('k', 'g');
+                return base.TryParseAsDoubleList(line);
+            }
+
+            public override bool MatchesValuesFormat(string line) => line.TrimEnd('k', 'g').TryToDouble(out _);
+        }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfTypeK.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfTypeK.cs
@@ -11,20 +11,15 @@ namespace CA_DataUploaderLib.IOconf
 
             var list = ToList();
             AllJunction = false;
-            if (list[3].ToLower() == "skip")
-            {
-                Skip = true;   // BaseSensorBox will skip reading from this box. Data is comming from other sensors through ProcessLine() instead. You must skip all lines from this box in IO.conf, else it will not work.
-            }
-            else if (list[3].ToLower() == "all")
+            if (list[3].ToLower() == "all")
             {
                 AllJunction = true;   // all => special command to show all junction temperatures including the first as average (used for calibration)
                 PortNumber = 0;
             }
-            else
-            {
-                if (!int.TryParse(list[3], out PortNumber)) throw new Exception("IOconfTypeK: wrong port number: " + row);
-                if (PortNumber < 0 || PortNumber > 33) throw new Exception("IOconfTypeK: invalid port number: " + row);
-            }
+            else if (!Skip && HasPort)
+                throw new Exception("IOconfTypeK: wrong port number: " + row);
+            else if (!Skip && (PortNumber < 0 || PortNumber > 33)) 
+                throw new Exception("IOconfTypeK: invalid port number: " + row);
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfTypeK.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfTypeK.cs
@@ -16,7 +16,7 @@ namespace CA_DataUploaderLib.IOconf
                 AllJunction = true;   // all => special command to show all junction temperatures including the first as average (used for calibration)
                 PortNumber = 0;
             }
-            else if (!Skip && HasPort)
+            else if (!Skip && !HasPort)
                 throw new Exception("IOconfTypeK: wrong port number: " + row);
             else if (!Skip && (PortNumber < 0 || PortNumber > 33)) 
                 throw new Exception("IOconfTypeK: invalid port number: " + row);

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -7,6 +7,7 @@ using CA_DataUploaderLib.IOconf;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace CA_DataUploaderLib
 {
@@ -39,7 +40,7 @@ namespace CA_DataUploaderLib
         public string mcuFamily = null;
         public const string mcuFamilyHeader = "MCU Family: ";
         private readonly Regex _startsWithNumberRegex = new Regex(@"^(-|\d+)");
-        public bool UnableToRead = true;
+        public bool InitialConnectionSucceeded {get;} = false;
 
         public DateTime PortOpenTimeStamp;
 
@@ -51,10 +52,12 @@ namespace CA_DataUploaderLib
         private static int _luminoxSensorsDetected;
         private static readonly Regex _scaleRegex = new Regex("[+-](([0-9]*[.])?[0-9]+) kg"); // "+0000.00 kg"
         private static int _detectedScaleBoards;
+        private static int _detectedUnknownBoards;
 
-        public MCUBoard(string name, int baudrate) // : base(name, baudrate, 0, 8, 1, 0)
+        public BoardSettings ConfigSettings { get; set; } = BoardSettings.Default;
+
+        private MCUBoard(string name, int baudrate, bool skipBoardAutoDetection) 
         {
-
             try
             {
                 if(IsOpen)
@@ -75,14 +78,20 @@ namespace CA_DataUploaderLib
 
                 Open();
 
-                ReadSerialNumber();
+                if (skipBoardAutoDetection)
+                    InitialConnectionSucceeded = true;
+                else
+                    InitialConnectionSucceeded = ReadSerialNumber();
 
                 if (File.Exists("IO.conf"))
-                {
+                { // note that unlike the discovery at MCUBoard.OpenDeviceConnection that only considers the usb port, in here we can find the boards by the serial number too.
                     foreach (var ioconfMap in IOconfFile.GetMap())
                     {
                         if (ioconfMap.SetMCUboard(this))
+                        {
                             BoxName = ioconfMap.BoxName;
+                            ConfigSettings = ioconfMap.BoardSettings;
+                        }
                     }
                 }
             }
@@ -91,7 +100,7 @@ namespace CA_DataUploaderLib
                 CALog.LogException(LogID.A, ex);
             }
 
-            if (UnableToRead)
+            if (!InitialConnectionSucceeded)
             {
                 Close();
                 Thread.Sleep(100);
@@ -153,7 +162,7 @@ namespace CA_DataUploaderLib
         /// 
         /// No exceptions are produced if there is a failure to reopen, although information about is added to log B.
         /// </remarks>
-        public bool SafeReopen(int expectedHeaderLines = 8, int secondsBetweenReopens = 3)
+        public bool SafeReopen()
         {
             var lines = new List<string>();
             var bytesToRead500ms = 0;
@@ -162,7 +171,7 @@ namespace CA_DataUploaderLib
                 lock (this)
                 {
                     TimeSpan timeSinceLastReopen = DateTime.Now.Subtract(_lastReopenTime);
-                    if (timeSinceLastReopen.TotalSeconds < secondsBetweenReopens)
+                    if (timeSinceLastReopen.TotalSeconds < ConfigSettings.SecondsBetweenReopens)
                     {
                         CALog.LogData(LogID.B, $"(Reopen) skipped {PortName} {productType} {serialNumber} - time since last reopen {timeSinceLastReopen}");
                         return true;
@@ -182,16 +191,9 @@ namespace CA_DataUploaderLib
                     Open();
                     Thread.Sleep(500);
 
-                    CALog.LogData(LogID.B, $"(Reopen) skipping {expectedHeaderLines} header lines for port {PortName} {productType} {serialNumber} ");
                     bytesToRead500ms = BytesToRead;
-                    for (int i = 0; i < expectedHeaderLines; i++)
-                    {
-                        var line = ReadLine().Trim();
-                        lines.Add(line);
-                        if (_startsWithNumberRegex.IsMatch(line) && i > 0) // making sure we skip the first one, as it is something a partial line (perhaps from the last read before the restart, although pi buffer is cleared).
-                            break; // we are past the header.
-                    }
-
+                    CALog.LogData(LogID.B, $"(Reopen) skipping {ConfigSettings.ExpectedHeaderLines} header lines for port {PortName} {productType} {serialNumber} ");
+                    lines = SkipExtraHeaders(ConfigSettings.ExpectedHeaderLines);
                     _lastReopenTime = DateTime.Now;
                 }
             }
@@ -208,11 +210,55 @@ namespace CA_DataUploaderLib
             return true;
         }
 
-        private void ReadSerialNumber()
+        public static MCUBoard OpenDeviceConnection(string name)
+        {
+            // note this map is only found by usb, for map entries configured by serial we use auto detection with standard baud rates instead.
+            var map = File.Exists("IO.conf") ? IOconfFile.GetMap().SingleOrDefault(m => m.USBPort == name) : null;
+            var initialBaudrate = map != null && map.BaudRate != 0 ? map.BaudRate : 115200;
+            var mcu = new MCUBoard(name, initialBaudrate, (map?.BoardSettings ?? BoardSettings.Default).SkipBoardAutoDetection);
+            if (!mcu.InitialConnectionSucceeded)
+                mcu = OpenWithAutoDetection(name, initialBaudrate);
+            if (mcu.serialNumber.IsNullOrEmpty())
+                mcu.serialNumber = "unknown" + Interlocked.Increment(ref _detectedUnknownBoards);
+            if (mcu.InitialConnectionSucceeded && map != null && map.BaudRate != 0 && mcu.BaudRate != map.BaudRate)
+                CALog.LogErrorAndConsoleLn(LogID.A, $"Unexpected baud rate for {map}. Board info {mcu}");
+            if (mcu.ConfigSettings.ExpectedHeaderLines > 8)
+                mcu.SkipExtraHeaders(mcu.ConfigSettings.ExpectedHeaderLines - 8);
+            return mcu;
+        }
+
+        private List<string> SkipExtraHeaders(int extraHeaderLinesToSkip)
+        {
+            var lines = new List<string>(extraHeaderLinesToSkip);
+            for (int i = 0; i < ConfigSettings.ExpectedHeaderLines; i++)
+            {
+                var line = ReadLine().Trim();
+                lines.Add(line);
+                if (ConfigSettings.Parser.MatchesValuesFormat(line))
+                    break; // we are past the header.
+            }
+
+            return lines;
+        }
+
+        private static MCUBoard OpenWithAutoDetection(string name, int previouslyAttemptedBaudRate)
+        { 
+            var skipAutoDetection = false;
+            if (previouslyAttemptedBaudRate == 115200)
+                return new MCUBoard(name, 9600, skipAutoDetection);
+            if (previouslyAttemptedBaudRate == 9600)
+                return new MCUBoard(name, 115200, skipAutoDetection);
+            var mcu = new MCUBoard(name, 115200, skipAutoDetection);
+            return mcu.InitialConnectionSucceeded ? mcu : new MCUBoard(name, 9600, skipAutoDetection);
+        }
+
+        /// <returns><c>true</c> if we were able to read</returns>
+        private bool ReadSerialNumber()
         {
             WriteLine("Serial");
             var stop = DateTime.Now.AddSeconds(5);
             bool sentSerialCommandTwice = false;
+            bool ableToRead = false;
             while (IsEmpty() && DateTime.Now < stop)
             {
 
@@ -228,7 +274,7 @@ namespace CA_DataUploaderLib
                             CALog.LogColor(LogID.A, ConsoleColor.Green, input);
                         }
 
-                        UnableToRead = input.Length < 2;
+                        ableToRead = input.Length >= 2;
                         if (input.Contains(MCUBoard.serialNumberHeader))
                             serialNumber = input.Substring(input.IndexOf(MCUBoard.serialNumberHeader) + MCUBoard.serialNumberHeader.Length).Trim();
                         else if (input.Contains(MCUBoard.boardFamilyHeader))
@@ -250,9 +296,9 @@ namespace CA_DataUploaderLib
                         else if (input.Contains(MCUBoard.mcuFamilyHeader))
                             mcuFamily = input.Substring(input.IndexOf(MCUBoard.mcuFamilyHeader) + MCUBoard.mcuFamilyHeader.Length).Trim();
                         else if (DetectLuminoxSensor(input)) // avoid waiting for a never present serial for luminox sensors 
-                            return;
+                            return true;
                         else if (DetectAscale(input))
-                            return;
+                            return true;
                         else if (input.Contains("MISREAD") && !sentSerialCommandTwice && serialNumber == null)
                         {
                             WriteLine("Serial");
@@ -271,6 +317,8 @@ namespace CA_DataUploaderLib
                     }
                 }
             }
+
+            return ableToRead;
         }
 
         private bool DetectLuminoxSensor(string line)

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -308,12 +308,12 @@ namespace CA_DataUploaderLib
                     }
                     catch (TimeoutException ex)
                     {
-                        CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {PortName}: " + ex.Message);
+                        CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {PortName} ({BaudRate}): " + ex.Message);
                         break;
                     }
                     catch (Exception ex)
                     {
-                        CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {PortName}: " + ex.Message);
+                        CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {PortName} ({BaudRate}): " + ex.Message);
                     }
                 }
             }

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -67,7 +67,7 @@ namespace CA_DataUploaderLib
         {
             if (vector.Count() != _vectorDescription.Length)
                 throw new ArgumentException($"wrong vector length (input, expected): {vector.Count} <> {_vectorDescription.Length}");
-            if (_lastTimestamp < timestamp)
+            if (timestamp <= _lastTimestamp)
             {
                 CALog.LogData(LogID.B, $"non changing or out of order timestamp received - vector ignored: last recorded {_lastTimestamp} vs received {timestamp}");
                 return;

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -114,8 +114,11 @@ namespace CA_DataUploaderLib
                         PostVectorAsync(GetSignedVectors(list), list.First().timestamp);
 
                     var alerts = DequeueAllEntries(_alertQueue);
-                    foreach (var alert in alerts)
-                        PostAlertAsync(alert);
+                    if (alerts != null)
+                    {
+                        foreach (var alert in alerts)
+                            PostAlertAsync(alert);
+                    }
 
                     PrintBadPackagesMessage(false);
                 }

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -103,8 +103,10 @@ namespace CA_DataUploaderLib
         private void LoopForever()
         {
             _running = true;
+            var vectorUploadDelay = IOconfFile.GetVectorUploadDelay();
             while (_running)
             {
+                Wait(vectorUploadDelay, ref _waitLoopForeverTimestamp);
                 try
                 {
                     var list = DequeueAllEntries(_queue);
@@ -116,7 +118,6 @@ namespace CA_DataUploaderLib
                         PostAlertAsync(alert);
 
                     PrintBadPackagesMessage(false);
-                    Wait(IOconfFile.GetVectorUploadDelay(), ref _waitLoopForeverTimestamp);
                 }
                 catch (Exception ex)
                 {

--- a/CA_DataUploaderLib/SwitchBoardBase.cs
+++ b/CA_DataUploaderLib/SwitchBoardBase.cs
@@ -50,7 +50,7 @@ namespace CA_DataUploaderLib
                         return _lastRead = _lastValidRead = values;
                     }
                     
-                    CALog.LogData(LogID.B, $"board {box.ToString()} without valid reads since {_timeSinceLastValidRead} ms - latest invalid response: {lines}");
+                    CALog.LogData(LogID.B, $"board {box.ToString()} without valid reads since {_timeSinceLastValidRead.ElapsedMilliseconds} ms - latest invalid response: {lines}");
                     if (_timeSinceLastValidRead.IsRunning && _timeSinceLastValidRead.ElapsedMilliseconds < 300)
                         return _lastRead = _lastValidRead;
                 }

--- a/CA_DataUploaderLib/ThermocoupleBox.cs
+++ b/CA_DataUploaderLib/ThermocoupleBox.cs
@@ -12,7 +12,7 @@ namespace CA_DataUploaderLib
         private readonly SensorSample _rpiGpuSample;
         private readonly SensorSample _rpiCpuSample;
         public ThermocoupleBox(CommandHandler cmd) : base(cmd, "Temperatures", string.Empty, "show all temperatures in input queue", GetSensors()) 
-        { // these are null when its not windows, see GetSensors
+        { // these are disabled / null when we are not running on windows, see GetSensors
             _rpiGpuSample = _values.FirstOrDefault(x => x.Name.EndsWith("Gpu"));
             _rpiCpuSample = _values.FirstOrDefault(x => x.Name.EndsWith("Cpu"));
         }

--- a/UnitTests/BoardSettingsTests.cs
+++ b/UnitTests/BoardSettingsTests.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CA_DataUploaderLib;
+using CA_DataUploaderLib.IOconf;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class BoardSettingsTests
+    {
+        [TestMethod]
+        public void DefaultSettingsParsesExpectedValuesFormat()
+        {
+            var parser = BoardSettings.Default.Parser;
+            CollectionAssert.AreEqual(new[] {0.01,0.05,0.06}, parser.TryParseAsDoubleList("0.01,0.05,0.06"));
+        }
+    }
+}

--- a/UnitTests/IOconfOxygenTests.cs
+++ b/UnitTests/IOconfOxygenTests.cs
@@ -1,0 +1,18 @@
+using CA_DataUploaderLib.IOconf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class IOconfOxyenTests
+    {
+        [TestMethod]
+        public void AlertTriggers() 
+        {
+            string input = "O 0213.1 T +21.1 P 1019 % 020.92 e 0001";
+            var parser = IOconfOxygen.LineParser.Default;
+            var output = parser.TryParseAsDoubleList(input);
+            CollectionAssert.AreEqual(new []{213.1, 21.1, 0.019, 20.92, 1}, output);
+        }
+    }
+}


### PR DESCRIPTION
Reasons:
- hardcoding these in BaseSensorBox required too much code to be unnecesarily overwritten in derived classes
- benefits cases where BaseSensorBox is not used i.e. VFD now uses "SkipBoardAutoDetection" that should speed up startup
- its now much easier to support boards that use different lines formats (see IOconfScale for an example)
- the IOconf classes now owns the decision to stop the system when losing communications to a that type of sensor
- MCUBoard now skips extra header lines during initialization, instead of only on SafeReopen / useful for the flow box

note: only the MCUBoard and BaseSensorBox (and derived classes) are using the new configurations at the moment.

Other improvements:
- VFD board comm initialization now skips trying to read serial while still checking a connection is made at the target baud rate.
- If an usb port is expected to have a given baud rate, we still attempt auto discovery with other baud rates and we print/log a message with the board info with the unexpected baud rate.
- We now show the attempted baud rate on failure messages connecting to a board
- Slowed down Server.Uploader on recurrent failures
- BaseSensorBox.CheckFails avoids unnecesary lists allocations on every loop cycle / now it does it only when we lost the connection to a board
- the connection to ignored sensors due to lost communication now is disposed, which could allow connecting to those for diagnostics while the system still runs