### PR TITLE
various stabilization fixes of the latest release

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -39,7 +39,7 @@ namespace CA_DataUploaderLib
 
             if (cmd != null)
             {
-                commandHelp = $"{commandName.ToLower() + " " + commandArgsHelp,-22}- {commandDescription}";
+                commandHelp = $"{commandName.ToLower() + " " + commandArgsHelp,-26}- {commandDescription}";
                 cmd.AddCommand(commandName.ToLower(), ShowQueue);
                 cmd.AddCommand("help", HelpMenu);
                 cmd.AddCommand("escape", Stop);

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -61,7 +61,7 @@ namespace CA_DataUploaderLib
             .Select(s => s.Clone())
             .Concat(_allBoardsState.Select(b => new SensorSample(b.sensorName, (int)b.State)));
 
-        public virtual List<VectorDescriptionItem> GetVectorDescriptionItems =>
+        public virtual List<VectorDescriptionItem> GetVectorDescriptionItems() =>
             _values
                 .Select(x => new VectorDescriptionItem("double", x.Input.Name, DataTypeEnum.Input))
                 .Concat(_allBoardsState.Select(b => new VectorDescriptionItem("double", b.sensorName, DataTypeEnum.State)))

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -236,7 +236,7 @@ namespace CA_DataUploaderLib
 
         public virtual void ProcessLine(IEnumerable<double> numbers, MCUBoard board)
         {
-            int i = 0;
+            int i = 1;
             var timestamp = DateTime.UtcNow;
             foreach (var value in numbers)
             {

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -48,7 +48,6 @@ namespace CA_DataUploaderLib
 
             _boards = _values.Where(x => !x.Input.Skip).Select(x => x.Input.Map.Board).Distinct().ToList();
             _allBoardsState = new AllBoardsState(_boards);
-            CALog.LogInfoAndConsoleLn(LogID.A, $"{commandName} boards: {_boards.Count()} values: {_values.Count()}");
 
             _running = true;
             new Thread(() => LoopForever()).Start();
@@ -62,15 +61,11 @@ namespace CA_DataUploaderLib
             .Select(s => s.Clone())
             .Concat(_allBoardsState.Select(b => new SensorSample(b.sensorName, (int)b.State)));
 
-        public virtual List<VectorDescriptionItem> GetVectorDescriptionItems()
-        {
-            var list = _values.Select(x => new VectorDescriptionItem("double", x.Input.Name, DataTypeEnum.Input)).ToList();
-            var dataPoints = list.Count;
-            list.AddRange(_allBoardsState.Select(b => new VectorDescriptionItem("double", b.sensorName, DataTypeEnum.State)));
-            CALog.LogInfoAndConsoleLn(LogID.A, $"{dataPoints,2} datapoints + {list.Count - dataPoints,2} boards from {Title}");
-
-            return list;
-        }
+        public virtual List<VectorDescriptionItem> GetVectorDescriptionItems =>
+            _values
+                .Select(x => new VectorDescriptionItem("double", x.Input.Name, DataTypeEnum.Input))
+                .Concat(_allBoardsState.Select(b => new VectorDescriptionItem("double", b.sensorName, DataTypeEnum.State)))
+                .ToList();
 
         protected bool ShowQueue(List<string> args)
         {

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -152,7 +152,7 @@ namespace CA_DataUploaderLib
                                 ProcessLine(numbers, board);
                                 receivedValues = true;
                             }
-                            else // mostly responses to commands or headers on reconnects.
+                            else if (!board.ConfigSettings.Parser.IsExpectedNonValuesLine(line))// mostly responses to commands or headers on reconnects.
                                 CALog.LogInfoAndConsoleLn(LogID.B, "Unhandled board response " + board.ToString() + " line: " + line);
                         }
                         catch (Exception ex)

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -60,12 +60,20 @@ namespace CA_DataUploaderLib
         public VectorDescription GetFullSystemVectorDescription() => _fullsystemFilterAndMath.Value.VectorDescription;
         public List<SensorSample> GetFullSystemVectorValues() => 
             _fullsystemFilterAndMath.Value.Apply(_subsystems.SelectMany(s => s.GetValues()).ToList());
-        private VectorFilterAndMath GetFullSystemFilterAndMath() => 
-            new VectorFilterAndMath(
-                new VectorDescription(
-                    _subsystems.SelectMany(s => s.GetVectorDescriptionItems()).ToList(),
-                    RpiVersion.GetHardware(),
-                    RpiVersion.GetSoftware()));
+        private VectorFilterAndMath GetFullSystemFilterAndMath()
+        { 
+            var items = new List<VectorDescriptionItem>(_subsystems.Count * 10);
+            foreach (var subsystem in _subsystems)
+            {
+                var subsystemItems = subsystem.GetVectorDescriptionItems();
+                CALog.LogInfoAndConsoleLn(LogID.A, $"{subsystemItems.Count,2} datapoints from {subsystem.Title}");
+                items.AddRange(subsystem.GetVectorDescriptionItems());                
+            }
+
+            return new VectorFilterAndMath(
+                new VectorDescription(items, RpiVersion.GetHardware(), RpiVersion.GetSoftware()));
+        }
+     
         public bool AssertArgs(List<string> args, int minimumLen)
         {
             if (args.Count() < minimumLen)

--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -67,6 +67,7 @@ namespace CA_DataUploaderLib
 
         private bool CanTurnOn(bool hasValidTemperature, double temperature)
         {
+            Console.WriteLine($"CanTurnOn: {IsOn} {ManualMode} {OvenTargetTemperature} {hasValidTemperature} {LastOff} {DateTime.UtcNow} {temperature}");
             if (IsOn) return false; // already on
             if (ManualMode) return false; // avoid auto on when manual mode is on.
             if (OvenTargetTemperature <= 0) return false; // oven's command is off, skip any extra checks

--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -67,11 +67,10 @@ namespace CA_DataUploaderLib
 
         private bool CanTurnOn(bool hasValidTemperature, double temperature)
         {
-            Console.WriteLine($"CanTurnOn: {IsOn} {ManualMode} {OvenTargetTemperature} {hasValidTemperature} {LastOff} {DateTime.UtcNow} {temperature}");
             if (IsOn) return false; // already on
             if (ManualMode) return false; // avoid auto on when manual mode is on.
             if (OvenTargetTemperature <= 0) return false; // oven's command is off, skip any extra checks
-            if (hasValidTemperature) return false; // no valid oven sensors
+            if (!hasValidTemperature) return false; // no valid oven sensors
 
             if (LastOff > DateTime.UtcNow.AddSeconds(-10))
                 return false;  // less than 10 seconds since we last turned it off

--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -29,12 +29,12 @@ namespace CA_DataUploaderLib
             _ioconf = heater;
             if (oven == null)
                 CALog.LogInfoAndConsoleLn(LogID.A, $"Warn: no oven configured for heater {heater.Name}");
-            else if (!oven.TypeK.IsInitialized())
+            else if (!oven.IsTemperatureSensorInitialized)
                 CALog.LogErrorAndConsoleLn(LogID.A, $"Warn: disabled oven for heater {heater.Name} - missing temperature board");
             else
             {
                 _area = oven.OvenArea;
-                _ovenSensor = oven.TypeK.Name;
+                _ovenSensor = oven.TemperatureSensorName;
             }
         }
 

--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -42,6 +42,8 @@ namespace CA_DataUploaderLib
             if (!TryGetSwitchboardInputsFromVector(vector, out var current, out var switchboardOnOffState)) 
                 return HeaterAction.None; // not connected, we skip this heater and act again when the connection is re-established
             var (hasValidTemperature, temp) = GetOvenTemperatureFromVector(vector);
+            if (!hasValidTemperature)
+                Console.WriteLine("heater does not have valid temperature");
             // Careful consideration must be taken if changing the order of the below statements.
             // Note that even though we received indication the board is connected above, 
             // if the connection is lost after we return the action, the control program can still fail to act on the heater. 

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -175,13 +175,7 @@ namespace CA_DataUploaderLib
                     throw new ArgumentException($"Arguments did not match the amount of configured areas: {areas.Count}");
                 }
                 
-                Console.WriteLine(string.Join(',', temperatures));
-                Console.WriteLine(string.Join(',', areas));
-                var targets = areas.Select((i, a) => 
-                {
-                    if (i >= temperatures.Count) throw new InvalidOperationException($"unexpected index {i} / {temperatures.Count}");
-                    return (a, temperatures[i]);
-                }).ToList();
+                var targets = areas.Select((a, i) => (a, temperatures[i])).ToList();
                 foreach (var heater in _heaters)
                     heater.SetTargetTemperature(targets);
             }

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -126,7 +126,7 @@ namespace CA_DataUploaderLib
                     .Select(g => BoardLoop(g.Key, g.ToList(), _boardLoopsStopTokenSource.Token))
                     .ToList();
                 await Task.WhenAll(boardLoops);                
-                CALog.LogInfoAndConsoleLn(LogID.A, "Exiting ValveController.LoopForever() " + DateTime.Now.Subtract(start).Humanize(5));
+                CALog.LogInfoAndConsoleLn(LogID.A, "Exiting HeatingController.LoopForever() " + DateTime.Now.Subtract(start).Humanize(5));
             }
             catch (Exception ex)
             {

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -49,7 +49,7 @@ namespace CA_DataUploaderLib
             cmd.AddSubsystem(this);
             _heaterCmd = new HeaterCommand(_heaters);
             _heaterCmd.Initialize(new PluginsCommandHandler(cmd), new PluginsLogger("heater"));
-            _ovenCmd = new OvenCommand(_heaters, ovens.Any());
+            _ovenCmd = new OvenCommand(_heaters, !ovens.Any());
             _ovenCmd.Initialize(new PluginsCommandHandler(cmd), new PluginsLogger("oven"));
             Task.Run(RunHeatersControlLoops);
         }
@@ -105,14 +105,6 @@ namespace CA_DataUploaderLib
                     var vector = await _cmd.When(_ => true, token);
                     foreach (var heater in _heaters)
                         DoHeaterActions(vector, heater, token);
-
-                    foreach (var heater in heaters)
-                    {
-                        var action = heater.MakeNextActionDecision(vector);
-                        if (action == HeaterAction.None) continue;
-                        else if (action != HeaterAction.TurnOn && action != HeaterAction.TurnOff) 
-                            throw new InvalidOperationException($"unexpected action received {action}");
-                    }
                 }
                 catch (Exception ex)
                 {

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -23,17 +23,17 @@ namespace CA_DataUploaderLib
         {
             _cmd = cmd;
 
-            var heaters = IOconfFile.GetHeater().ToList();
-            if (!_heaters.Any())
+            var heatersConfigs = IOconfFile.GetHeater().ToList();
+            if (heatersConfigs.Any())
                 return;
 
             var ovens = IOconfFile.GetOven().ToList();
-            foreach (var heater in heaters)
+            foreach (var heater in heatersConfigs)
                 _heaters.Add(new HeaterElement(
                     heater, 
                     ovens.SingleOrDefault(x => x.HeatingElement.Name == heater.Name)));
 
-            var unreachableBoards = heaters.Where(h => h.Map.Board == null).GroupBy(h => h.Map).ToList();
+            var unreachableBoards = heatersConfigs.Where(h => h.Map.Board == null).GroupBy(h => h.Map).ToList();
             foreach (var board in unreachableBoards)
                 CALog.LogErrorAndConsoleLn(LogID.A, $"Missing board {board.Key} for heaters {string.Join(",", board.Select(h => h.Name))}");
             if (unreachableBoards.Count > 0)

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -11,7 +11,7 @@ namespace CA_DataUploaderLib
 {
     public sealed class HeatingController : IDisposable, ISubsystemWithVectorData
     {
-        public string Title => "Heating";
+        public string Title => "Heaters";
         private static int HeaterOnTimeout = 60;
         private bool _disposed = false;
         private readonly List<HeaterElement> _heaters = new List<HeaterElement>();
@@ -79,7 +79,7 @@ namespace CA_DataUploaderLib
         public IEnumerable<SensorSample> GetValues() =>
             _heaters.Select(x => new SensorSample(x.Name() + "_On/Off", x.IsOn ? 1.0 : 0.0));
 
-        public List<VectorDescriptionItem> GetVectorDescriptionItems => 
+        public List<VectorDescriptionItem> GetVectorDescriptionItems() => 
             _heaters.Select(x => new VectorDescriptionItem("double", x.Name() + "_On/Off", DataTypeEnum.Output)).ToList();
 
         public void Dispose()

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -161,7 +161,6 @@ namespace CA_DataUploaderLib
             if (token.IsCancellationRequested)
                 return;
             var action = heater.MakeNextActionDecision(vector);
-            Console.WriteLine($"Vector: {vector["Heater_filter"]} Action: {action}");
             switch (action)
             {
                 case HeaterAction.TurnOn: HeaterOn(heater); break;

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -106,6 +106,11 @@ namespace CA_DataUploaderLib
                     foreach (var heater in heaters)
                         DoHeaterActions(vector, heater, token);
                 }
+                catch (TaskCanceledException ex)
+                {
+                    if (!token.IsCancellationRequested)
+                        CALog.LogErrorAndConsoleLn(LogID.A, ex.ToString());
+                }
                 catch (Exception ex)
                 {
                     CALog.LogErrorAndConsoleLn(LogID.A, ex.ToString());

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -175,7 +175,9 @@ namespace CA_DataUploaderLib
                     throw new ArgumentException($"Arguments did not match the amount of configured areas: {areas.Count}");
                 }
                 
-                var targets = areas.Select((i, a) => (a, temperatures[i]));
+                Console.WriteLine(string.Join(',', temperatures));
+                Console.WriteLine(string.Join(',', areas));
+                var targets = areas.Select((i, a) => (a, temperatures[i])).ToList();
                 foreach (var heater in _heaters)
                     heater.SetTargetTemperature(targets);
             }

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -103,7 +103,7 @@ namespace CA_DataUploaderLib
                 try
                 {
                     var vector = await _cmd.When(_ => true, token);
-                    foreach (var heater in _heaters)
+                    foreach (var heater in heaters)
                         DoHeaterActions(vector, heater, token);
                 }
                 catch (Exception ex)
@@ -156,6 +156,7 @@ namespace CA_DataUploaderLib
             if (token.IsCancellationRequested)
                 return;
             var action = heater.MakeNextActionDecision(vector);
+            Console.WriteLine($"Vector: {vector["Heater_filter"]} Action: {action}");
             switch (action)
             {
                 case HeaterAction.TurnOn: HeaterOn(heater); break;

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -24,7 +24,7 @@ namespace CA_DataUploaderLib
             _cmd = cmd;
 
             var heatersConfigs = IOconfFile.GetHeater().ToList();
-            if (heatersConfigs.Any())
+            if (!heatersConfigs.Any())
                 return;
 
             var ovens = IOconfFile.GetOven().ToList();

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -177,7 +177,11 @@ namespace CA_DataUploaderLib
                 
                 Console.WriteLine(string.Join(',', temperatures));
                 Console.WriteLine(string.Join(',', areas));
-                var targets = areas.Select((i, a) => (a, temperatures[i])).ToList();
+                var targets = areas.Select((i, a) => 
+                {
+                    if (i >= temperatures.Count) throw new InvalidOperationException($"unexpected index {i} / {temperatures.Count}");
+                    return (a, temperatures[i]);
+                }).ToList();
                 foreach (var heater in _heaters)
                     heater.SetTargetTemperature(targets);
             }

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -19,7 +19,7 @@ namespace CA_DataUploaderLib
         private readonly OvenCommand _ovenCmd;
         private readonly HeaterCommand _heaterCmd;
 
-        public HeatingController(BaseSensorBox caThermalBox, CommandHandler cmd)
+        public HeatingController(CommandHandler cmd)
         {
             _cmd = cmd;
 
@@ -44,11 +44,10 @@ namespace CA_DataUploaderLib
             cmd.AddCommand("escape", Stop);
             cmd.AddCommand("emergencyshutdown", EmergencyShutdown);    
             cmd.AddSubsystem(this);
-            var cmdPlugins = new PluginsCommandHandler(cmd);
             _heaterCmd = new HeaterCommand(_heaters);
-            _heaterCmd.Initialize(cmdPlugins, new PluginsLogger("heater"));
+            _heaterCmd.Initialize(new PluginsCommandHandler(cmd), new PluginsLogger("heater"));
             _ovenCmd = new OvenCommand(_heaters, ovens.Any());
-            _ovenCmd.Initialize(cmdPlugins, new PluginsLogger("oven"));
+            _ovenCmd.Initialize(new PluginsCommandHandler(cmd), new PluginsLogger("oven"));
             cmd.Execute("oven off", false); // by executing this, the oven command will ensure the heaters stay off
         }
 

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -79,12 +79,8 @@ namespace CA_DataUploaderLib
         public IEnumerable<SensorSample> GetValues() =>
             _heaters.Select(x => new SensorSample(x.Name() + "_On/Off", x.IsOn ? 1.0 : 0.0));
 
-        public List<VectorDescriptionItem> GetVectorDescriptionItems()
-        {
-            var list = _heaters.Select(x => new VectorDescriptionItem("double", x.Name() + "_On/Off", DataTypeEnum.Output)).ToList();
-            CALog.LogInfoAndConsoleLn(LogID.A, $"{list.Count,2} datapoints from HeatingController");
-            return list;
-        }
+        public List<VectorDescriptionItem> GetVectorDescriptionItems => 
+            _heaters.Select(x => new VectorDescriptionItem("double", x.Name() + "_On/Off", DataTypeEnum.Output)).ToList();
 
         public void Dispose()
         { // class is sealed without unmanaged resources, no need for the full disposable pattern.

--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -38,6 +39,8 @@ namespace CA_DataUploaderLib.IOconf
             }
 
             public virtual bool MatchesValuesFormat(string line) => _startsWithDigitRegex.IsMatch(line);
+
+            public virtual bool IsExpectedNonValuesLine(string line) => false;
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -17,6 +17,7 @@ namespace CA_DataUploaderLib.IOconf
         public bool StopWhenLosingSensor { get; set; } = true;
         public bool SkipBoardAutoDetection { get; set; } = false;
         public LineParser Parser { get; set; } = LineParser.Default;
+        public string ValuesEndOfLineChar { get; set; } = "\n";
 
         public class LineParser
         {

--- a/CA_DataUploaderLib/IOconf/IOconfFilter.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFilter.cs
@@ -11,6 +11,7 @@ namespace CA_DataUploaderLib.IOconf
         public FilterType filterType;
         public double filterLength;  // in seconds. 
         public string Name { get; set; }
+        public string NameInVector => Name + "_filter";
 
         public List<string> SourceNames;
         public bool HideSource { get; private set; }

--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -18,6 +18,7 @@ namespace CA_DataUploaderLib.IOconf
                 throw new Exception($"{type}: wrong port number: {row}");
             if (list.Count > 3 && "skip".Equals(list[3], StringComparison.InvariantCultureIgnoreCase)) 
                 Skip = true;
+            if (PortNumber < 1) throw new Exception($"{type}: port numbers must start at 1 {row}");
 
             if (parseBoxName) 
             {
@@ -29,7 +30,8 @@ namespace CA_DataUploaderLib.IOconf
 
         public string Name { get; set; }
         public string BoxName { get; set; }
-        public int PortNumber;
+        /// <summary>the 1-based port number</summary>
+        public int PortNumber = 1;
         public bool Skip { get; set; }
         public IOconfMap Map { get; set; }
         protected bool HasPort { get; }

--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -14,10 +14,15 @@ namespace CA_DataUploaderLib.IOconf
             
             if (parsePortRequired && list.Count < 4) 
                 throw new Exception($"{type}: wrong port number: {row}");
-            if (list.Count > 3 && !(HasPort = int.TryParse(list[3], out PortNumber)) && parsePortRequired) 
-                throw new Exception($"{type}: wrong port number: {row}");
-            if (list.Count > 3 && "skip".Equals(list[3], StringComparison.InvariantCultureIgnoreCase)) 
-                Skip = true;
+            if (list.Count > 3)
+            {
+                if (HasPort = int.TryParse(list[3], out var port))
+                    PortNumber = port; // we don't do out PortNumber above to avoid it being set to 0 when TryParse returns false.
+                else if (parsePortRequired)
+                    throw new Exception($"{type}: wrong port number: {row}");
+                if ("skip".Equals(list[3], StringComparison.InvariantCultureIgnoreCase)) 
+                    Skip = true;
+            }
             if (PortNumber < 1) throw new Exception($"{type}: port numbers must start at 1 {row}");
 
             if (parseBoxName) 

--- a/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
@@ -7,7 +7,7 @@ namespace CA_DataUploaderLib.IOconf
     public class IOconfOut230Vac : IOconfOutput
     {
         public IOconfOut230Vac(string row, int lineNum, string type) : base(row, lineNum, type, true, 
-            new BoardSettings() { Parser = SwitchBoardResponseParser.Default }) 
+            new BoardSettings() { Parser = SwitchBoardResponseParser.Default, ValuesEndOfLineChar = "\r" }) 
         {
             CurrentSensorName = Name + "_current";
             SwitchboardOnOffSensorName = Name + "_SwitchboardOn/Off";

--- a/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
@@ -35,7 +35,7 @@ namespace CA_DataUploaderLib.IOconf
             // the last 5 values are not there in older versions of the switchboard software.
             private const string _SwitchBoxPattern = "P1=(-?\\d\\.\\d\\d)A P2=(-?\\d\\.\\d\\d)A P3=(-?\\d\\.\\d\\d)A P4=(-?\\d\\.\\d\\d)A(?: ([01]), ([01]), ([01]), ([01])(?:, (-?\\d+.\\d\\d))?)?";
             private static readonly Regex _switchBoxCurrentsRegex = new Regex(_SwitchBoxPattern);
-            private const string _commandConfirmationPattern = "p[1-4] (?:auto off)|(?:off)|(?:on(?: \\d+))";
+            private const string _commandConfirmationPattern = "p[1-4] (?:auto off)|(?:off)|(?:on(?: \\d+)?)";
             private static readonly Regex _commandConfirmationRegex = new Regex(_commandConfirmationPattern);
             private readonly bool _expectCommandConfirmations;
 

--- a/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
@@ -7,7 +7,7 @@ namespace CA_DataUploaderLib.IOconf
     public class IOconfOut230Vac : IOconfOutput
     {
         public IOconfOut230Vac(string row, int lineNum, string type) : base(row, lineNum, type, true, 
-            new BoardSettings() { Parser = SwitchBoardResponseParser.Default, ValuesEndOfLineChar = "\r" }) 
+            new BoardSettings() { Parser = new SwitchBoardResponseParser(!row.Contains("showConfirmations")), ValuesEndOfLineChar = "\r" }) 
         {
             CurrentSensorName = Name + "_current";
             SwitchboardOnOffSensorName = Name + "_SwitchboardOn/Off";
@@ -35,7 +35,17 @@ namespace CA_DataUploaderLib.IOconf
             // the last 5 values are not there in older versions of the switchboard software.
             private const string _SwitchBoxPattern = "P1=(-?\\d\\.\\d\\d)A P2=(-?\\d\\.\\d\\d)A P3=(-?\\d\\.\\d\\d)A P4=(-?\\d\\.\\d\\d)A(?: ([01]), ([01]), ([01]), ([01])(?:, (-?\\d+.\\d\\d))?)?";
             private static readonly Regex _switchBoxCurrentsRegex = new Regex(_SwitchBoxPattern);
-            public new static SwitchBoardResponseParser Default { get; } = new SwitchBoardResponseParser();
+            private const string _commandConfirmationPattern = "p[1-4] (?:auto off)|(?:off)|(?:on(?: \\d+))";
+            private static readonly Regex _commandConfirmationRegex = new Regex(_commandConfirmationPattern);
+            private readonly bool _expectCommandConfirmations;
+
+            public new static SwitchBoardResponseParser Default { get; } = new SwitchBoardResponseParser(true);
+            // setting it to *not* expect command confirmations will normally cause them to be shown in the console + logs,
+            // which is mostly useful for debugging purposes.
+            public SwitchBoardResponseParser (bool expectCommandConfirmations)
+            {
+                _expectCommandConfirmations = expectCommandConfirmations;
+            }
 
             // returns currents 0-3, states 0-3, board temperature
             public override List<double> TryParseAsDoubleList(string line)
@@ -53,6 +63,13 @@ namespace CA_DataUploaderLib.IOconf
                 for (int i = 1; i < 10; i++)
                     data.Add(groups[i].Success ? groups[i].Value.ToDouble() : 10000d);
                 return data;
+            }
+            /// <summary>for now consider all command confirmations expected</summary>
+            public override bool IsExpectedNonValuesLine(string line)
+            {
+                if (line == "\n")
+                    return true; // the switchboard is currently sending \r\n\r at the end of a command confirmation (the last \r is being printed before the next current line)
+                return _expectCommandConfirmations && _commandConfirmationRegex.IsMatch(line); // note unlike for value lines where we only get \r, in these lines we get \n\r and this also ignores those
             }
         }
     }

--- a/CA_DataUploaderLib/IOconf/IOconfOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOutput.cs
@@ -14,11 +14,12 @@ namespace CA_DataUploaderLib.IOconf
             BoxName = list[2];
             SetMap(BoxName, settings); 
             if (parsePort && !int.TryParse(list[3], out PortNumber)) throw new Exception($"{type}: wrong port number: {row}");
+            if (PortNumber < 1) throw new Exception($"{type}: port numbers must start at 1 {row}");
         }
 
         public string Name { get; set; }
         public string BoxName { get; set; }
-        public int PortNumber;
+        public int PortNumber = 1;
         public IOconfMap Map { get; set; }
 
         protected void SetMap(string boxName, BoardSettings settings)

--- a/CA_DataUploaderLib/IOconf/IOconfOven.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOven.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using CA_DataUploaderLib.Extensions;
 
 namespace CA_DataUploaderLib.IOconf
 {
@@ -16,11 +18,26 @@ namespace CA_DataUploaderLib.IOconf
                 throw new Exception("Oven area must be a number bigger or equal to 1");
             
             HeatingElement = IOconfFile.GetHeater().Single(x => x.Name == list[2]);
-            TypeK = IOconfFile.GetTypeK().Single(x => x.Name == list[3]);
+            TemperatureSensorName = list[3];
+            var filter = IOconfFile.GetFilters().SingleOrDefault(x => x.Name == TemperatureSensorName);
+            if (filter != null)
+            {
+                TypeKs = IOconfFile.GetTypeK().Where(x => filter.SourceNames.Contains(x.Name)).ToList();
+                if (TypeKs.Count == 0)
+                    throw new Exception($"Failed to find source temperature sensors in filter {TemperatureSensorName} for oven");
+            }
+            else
+            {
+                TypeKs = IOconfFile.GetTypeK().Where(x => x.Name == TemperatureSensorName).ToList();
+                if (TypeKs.Count == 0)
+                    throw new Exception($"Failed to find temperature sensor {TemperatureSensorName} for oven");
+            }
         }
 
         public int OvenArea;
         public IOconfHeater HeatingElement;
-        public IOconfTypeK TypeK;
+        public bool IsTemperatureSensorInitialized => TypeKs.All(k => k.IsInitialized());
+        public string TemperatureSensorName { get; }
+        private readonly List<IOconfTypeK> TypeKs;
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfOven.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOven.cs
@@ -19,7 +19,7 @@ namespace CA_DataUploaderLib.IOconf
             
             HeatingElement = IOconfFile.GetHeater().Single(x => x.Name == list[2]);
             TemperatureSensorName = list[3];
-            var filter = IOconfFile.GetFilters().SingleOrDefault(x => x.Name == TemperatureSensorName);
+            var filter = IOconfFile.GetFilters().SingleOrDefault(x => x.NameInVector == TemperatureSensorName);
             if (filter != null)
             {
                 TypeKs = IOconfFile.GetTypeK().Where(x => filter.SourceNames.Contains(x.Name)).ToList();

--- a/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
@@ -26,9 +26,9 @@ namespace CA_DataUploaderLib.IOconf
         /// <summary>get expanded conf entries that include the oxygen %, oxygen partial pressure and error</summary>
         /// <remarks>the returned entries have port numbers that correspond to the ones returned by the LineParser</remarks>
         public IEnumerable<IOconfOxygen> GetExpandedConf() => new [] {
-            new IOconfOxygen($"Oxygen;{Name}_Oxygen%;{BoxName}", LineNumber) { PortNumber = 3},
-            new IOconfOxygen($"Oxygen;{Name}_OxygenPartialPressure;{BoxName}", LineNumber) { PortNumber = 0},
-            new IOconfOxygen($"Oxygen;{Name}_Error;{BoxName}", LineNumber) { PortNumber = 4}
+            new IOconfOxygen($"Oxygen;{Name}_Oxygen%;{BoxName}", LineNumber) { PortNumber = 4},
+            new IOconfOxygen($"Oxygen;{Name}_OxygenPartialPressure;{BoxName}", LineNumber) { PortNumber = 1},
+            new IOconfOxygen($"Oxygen;{Name}_Error;{BoxName}", LineNumber) { PortNumber = 5}
             };
 
         public class LineParser : BoardSettings.LineParser

--- a/CA_DataUploaderLib/IOconf/IOconfSaltLeakage.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfSaltLeakage.cs
@@ -6,7 +6,7 @@ namespace CA_DataUploaderLib.IOconf
     {
         public IOconfSaltLeakage(string row, int lineNum) : base(row, lineNum, "SaltLeakage")
         {
-            if (PortNumber < 1 || PortNumber > 16) throw new Exception("IOconfSaltLeakage: invalid port number: " + row);
+            if (PortNumber < 2 || PortNumber > 17) throw new Exception("IOconfSaltLeakage: invalid port number: " + row);
         }
 
     }

--- a/CA_DataUploaderLib/IOconf/IOconfTypeK.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfTypeK.cs
@@ -14,11 +14,11 @@ namespace CA_DataUploaderLib.IOconf
             if (list[3].ToLower() == "all")
             {
                 AllJunction = true;   // all => special command to show all junction temperatures including the first as average (used for calibration)
-                PortNumber = 0;
+                PortNumber = 1;
             }
             else if (!Skip && !HasPort)
                 throw new Exception("IOconfTypeK: wrong port number: " + row);
-            else if (!Skip && (PortNumber < 0 || PortNumber > 33)) 
+            else if (!Skip && (PortNumber < 1 || PortNumber > 34)) 
                 throw new Exception("IOconfTypeK: invalid port number: " + row);
         }
     }

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -91,6 +91,7 @@ namespace CA_DataUploaderLib
                         {
                             BoxName = ioconfMap.BoxName;
                             ConfigSettings = ioconfMap.BoardSettings;
+                            NewLine = ioconfMap.BoardSettings.ValuesEndOfLineChar;
                         }
                     }
                 }
@@ -215,7 +216,8 @@ namespace CA_DataUploaderLib
             // note this map is only found by usb, for map entries configured by serial we use auto detection with standard baud rates instead.
             var map = File.Exists("IO.conf") ? IOconfFile.GetMap().SingleOrDefault(m => m.USBPort == name) : null;
             var initialBaudrate = map != null && map.BaudRate != 0 ? map.BaudRate : 115200;
-            var mcu = new MCUBoard(name, initialBaudrate, (map?.BoardSettings ?? BoardSettings.Default).SkipBoardAutoDetection);
+            bool skipAutoDetection = (map?.BoardSettings ?? BoardSettings.Default).SkipBoardAutoDetection;
+            var mcu = new MCUBoard(name, initialBaudrate, skipAutoDetection);
             if (!mcu.InitialConnectionSucceeded)
                 mcu = OpenWithAutoDetection(name, initialBaudrate);
             if (mcu.serialNumber.IsNullOrEmpty())

--- a/CA_DataUploaderLib/PluginsLogger.cs
+++ b/CA_DataUploaderLib/PluginsLogger.cs
@@ -12,9 +12,10 @@ namespace CA_DataUploaderLib
             this.pluginName = pluginName;
         }
 
-        public void LogError(string message) => CALog.LogErrorAndConsoleLn(LogID.A, $"{pluginName} {message}");
+        public void LogError(string message) => CALog.LogErrorAndConsoleLn(LogID.A, FormatMessage(message));
         public void LogError(Exception ex) => CALog.LogException(LogID.A, ex);
-        public void LogInfo(string message) => CALog.LogInfoAndConsoleLn(LogID.A, $"{pluginName} {message}");
-        public void LogData(string message) => CALog.LogData(LogID.B, $"{pluginName} {message}");
+        public void LogInfo(string message) => CALog.LogInfoAndConsoleLn(LogID.A, FormatMessage(message));
+        public void LogData(string message) => CALog.LogData(LogID.B, FormatMessage(message));
+        private string FormatMessage(string message) => message.StartsWith(pluginName) ? message : $"{pluginName} {message}";
     }
 }


### PR DESCRIPTION
### Configuration Breaking Change
- Breaking Change: now all ports start at 1 instead of 0. 
  Reasons:
  - it was still not working properly due to switchboards taking p1-4 commands
  - the ports printed in all existing boxes start at 1

### Changes
- improved action independence in different switchboards
- fixed help formatting
- introduced showConfirmations setting on heater lines that allows to show/log all confirmations returned by the switchboard (mostly for debugging purpose)
- it is now possible to use the filtered value for the oven command. It is still possible to use the non filtered value as long as it is kept on the vector (the filter does not have hidesource).
- the system now warns for missing oven sensors instead of exiting the program. In this way, one can see on the graph what are the available sensors which makes double checking the configuration easier.
- various stabilization fixes, among these:
  - removed double listing of boards for each subsystem on startup
  - fixed heating controller having diff formatting of boards listed on starup
  - prevent recurring errors from being displayed on switchboard reads
  - fixed bug with the missing sensors check preventing to turn the oven on.