### PR TITLE
separated decision making vs. actuations + safe valves in IO.conf + minor improvements

### DIFF
--- a/CA_DataUploader/Program.cs
+++ b/CA_DataUploader/Program.cs
@@ -32,9 +32,8 @@ namespace CA_DataUploader
                     int i = 0;
                     while (cmd.IsRunning)
                     {
-                        var sensorsSamples = cmd.GetFullSystemVectorValues();
-                        cmd.OnNewVectorReceived(sensorsSamples);
-                        cloud.SendVector(sensorsSamples.Select(v => v.Value).ToList(), sensorsSamples.First().TimeStamp);
+                        var (sensorsSamples, vectorTime) = cmd.GetFullSystemVectorValues();
+                        cloud.SendVector(sensorsSamples.Select(v => v.Value).ToList(), vectorTime);
                         Console.Write($"\r data points uploaded: {i++}"); // we don't want this in the log file. 
                         cloud.Wait(100);
                         if (i == 20) DULutil.OpenUrl(cloud.GetPlotUrl());

--- a/CA_DataUploaderLib/Alerts.cs
+++ b/CA_DataUploaderLib/Alerts.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CA.LoopControlPluginBase;
+using CA_DataUploaderLib.Extensions;
 using CA_DataUploaderLib.IOconf;
 
 namespace CA_DataUploaderLib
@@ -71,7 +72,7 @@ namespace CA_DataUploaderLib
 
         public override void OnNewVectorReceived(object sender, NewVectorReceivedArgs e)
         {
-            var timestamp = DateTime.UtcNow.ToString("yyyy.MM.dd HH:mm:ss");
+            var timestamp = e.GetVectorTime().ToString("yyyy.MM.dd HH:mm:ss");
             var (alertsToTrigger, noSensorAlerts) = GetAlertsToTrigger(e); // we gather alerts separately from triggering, to reduce time locking the _alerts list
             
             foreach (var a in alertsToTrigger ?? Enumerable.Empty<IOconfAlert>())
@@ -94,7 +95,7 @@ namespace CA_DataUploaderLib
                 {
                     if (!e.TryGetValue(a.Sensor, out var val))
                         EnsureInitialized(ref noSensorAlerts).Add(a);
-                    else if (a.CheckValue(val))
+                    else if (a.CheckValue(val, e.GetVectorTime()))
                         EnsureInitialized(ref alertsToTrigger).Add(a);
                 }
             

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -289,15 +289,16 @@ namespace CA_DataUploaderLib
             private readonly string[] _sensorNames;
             private readonly Dictionary<MCUBoard, int> _boardsIndexes;
 
-            public AllBoardsState(List<MCUBoard> boards)
+            public AllBoardsState(IEnumerable<MCUBoard> boards)
             {
-                _boards = boards;
-                _states = new ConnectionState[boards.Count];
-                _sensorNames = new string[boards.Count];
-                _boardsIndexes = new Dictionary<MCUBoard, int>(boards.Count);
-                for (int i = 0; i < boards.Count; i++)
+                // taking a copy of the list ensures we can keep reporting the state of the board, as otherwise the calling code can remove it, for example, when it decides to ignore the board
+                _boards = boards.ToList(); 
+                _states = new ConnectionState[_boards.Count];
+                _sensorNames = new string[_boards.Count];
+                _boardsIndexes = new Dictionary<MCUBoard, int>(_boards.Count);
+                for (int i = 0; i < _boards.Count; i++)
                 {
-                    _sensorNames[i] = boards[i].BoxName + "_state";
+                    _sensorNames[i] = _boards[i].BoxName + "_state";
                     _boardsIndexes[_boards[i]] = i;
                 }
             }

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -9,6 +9,7 @@ using Humanizer;
 using System.Diagnostics;
 using CA_DataUploaderLib.Extensions;
 using System.Collections;
+using CA.LoopControlPluginBase;
 
 namespace CA_DataUploaderLib
 {
@@ -57,10 +58,11 @@ namespace CA_DataUploaderLib
                 _values.SingleOrDefault(x => x.Input.Name == title) ??
                 throw new Exception(title + " not found in _config. Known names: " + string.Join(", ", _values.Select(x => x.Input.Name)));
 
-        public IEnumerable<SensorSample> GetValues() => _values
+        public IEnumerable<SensorSample> GetInputValues() => _values
             .Select(s => s.Clone())
             .Concat(_allBoardsState.Select(b => new SensorSample(b.sensorName, (int)b.State)));
 
+        public IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs) => Enumerable.Empty<SensorSample>();
         public virtual List<VectorDescriptionItem> GetVectorDescriptionItems() =>
             _values
                 .Select(x => new VectorDescriptionItem("double", x.Input.Name, DataTypeEnum.Input))

--- a/CA_DataUploaderLib/Extensions/VectorArgsExtensions.cs
+++ b/CA_DataUploaderLib/Extensions/VectorArgsExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CA.LoopControlPluginBase;
+
+namespace CA_DataUploaderLib.Extensions
+{
+    public static class VectorArgsExtensions
+    {
+        public static IEnumerable<SensorSample> WithVectorTime(this IEnumerable<SensorSample> samples, DateTime vectorTime) => 
+            samples.Append(new SensorSample("vectortime", vectorTime.ToVectorDouble()));
+        public static DateTime GetVectorTime(this NewVectorReceivedArgs args) => args["vectortime"].ToVectorDate();
+        // repetition below removes ms rounding differences later (documented behavior of FromOADate).
+        // unrelated: the only reason we use FromODate and ToODate is because its an out of the box conversion between DateTime and double.
+        public static double ToVectorDouble(this DateTime date) => DateTime.FromOADate(date.ToOADate()).ToOADate(); 
+        public static DateTime ToVectorDate(this double date) => DateTime.FromOADate(date); 
+    }
+}

--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -183,7 +183,7 @@ namespace CA_DataUploaderLib
             return true;
         }
         private bool CurrentIsOn(double current) => current > _ioconf.CurrentSensingNoiseTreshold;
-        public string Name() => _ioconf.Name.ToLower();
+        public string Name() => _ioconf.Name;
         public MCUBoard Board() => _ioconf.Map.Board;
         private void LogRepeatCommand(string command, double  temp, double current, double switchboardOnOffState) => 
             CALog.LogData(LogID.A, $"{command}.={Name()}-{temp:N0}, v#={current}, switch-on/off={switchboardOnOffState}, WB={Board().BytesToWrite}{Environment.NewLine}");

--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -17,12 +17,14 @@ namespace CA_DataUploaderLib
         private DateTime LastOn = DateTime.UtcNow.AddSeconds(-20); // assume nothing happened in the last 20 seconds
         private DateTime LastOff = DateTime.UtcNow.AddSeconds(-20); // assume nothing happened in the last 20 seconds
         private readonly Stopwatch invalidValuesTime = new Stopwatch();
+        private DateTime invalidValuesStartedVectorTime = default;
         private double onTemperature = 10000;
         public bool IsOn;
         private bool ManualMode;
         public bool IsActive { get { return OvenTargetTemperature > 0;  } }
         private Stopwatch timeSinceLastNegativeValuesWarning = new Stopwatch();
         private Stopwatch timeSinceLastMissingTemperatureWarning = new Stopwatch();
+        private SwitchboardAction _lastAction = new SwitchboardAction(false, DateTime.UtcNow);
 
         public HeaterElement(IOconfHeater heater, IOconfOven oven)
         {
@@ -38,21 +40,23 @@ namespace CA_DataUploaderLib
             }
         }
 
-        public HeaterAction MakeNextActionDecision(NewVectorReceivedArgs vector)
+        public SwitchboardAction MakeNextActionDecision(NewVectorReceivedArgs vector)
         {
             if (!TryGetSwitchboardInputsFromVector(vector, out var current, out var switchboardOnOffState)) 
-                return HeaterAction.None; // not connected, we skip this heater and act again when the connection is re-established
+                return _lastAction; // not connected, we skip this heater and act again when the connection is re-established
             var (hasValidTemperature, temp) = GetOvenTemperatureFromVector(vector);
             // Careful consideration must be taken if changing the order of the below statements.
             // Note that even though we received indication the board is connected above, 
             // if the connection is lost after we return the action, the control program can still fail to act on the heater. 
             // When it happens, the MustResend* methods will resend the expected action after 5 seconds.
-            return 
-                MustTurnOff(hasValidTemperature, temp) ? HeaterAction.TurnOff :
-                CanTurnOn(hasValidTemperature, temp) ? HeaterAction.TurnOn :
-                MustResendOnCommand(temp, current, switchboardOnOffState) ? HeaterAction.TurnOn : 
-                MustResendOffCommand(temp, current, switchboardOnOffState) ? HeaterAction.TurnOff :
-                HeaterAction.None;
+            var vectorTime = vector.GetVectorTime();
+            var action =
+                MustTurnOff(hasValidTemperature, temp, vectorTime) ? new SwitchboardAction(false, vectorTime):
+                CanTurnOn(hasValidTemperature, temp, vectorTime) ? new SwitchboardAction(true, vectorTime.AddSeconds(60)) : //TODO: short time outs?
+                MustResendOnCommand(temp, current, switchboardOnOffState, vectorTime) ? new SwitchboardAction(true, vectorTime.AddSeconds(60)): //TODO: short time outs? also we should not extend time to turn off here ...
+                MustResendOffCommand(temp, current, switchboardOnOffState, vectorTime) ? new SwitchboardAction(false, vectorTime) :
+                _lastAction;
+            return _lastAction = action;
         }
 
         public void SetTargetTemperature(int value) => OvenTargetTemperature = Math.Min(value, _ioconf.MaxTemperature);
@@ -65,31 +69,31 @@ namespace CA_DataUploaderLib
                     SetTargetTemperature(temperature);
         }
 
-        private bool CanTurnOn(bool hasValidTemperature, double temperature)
+        private bool CanTurnOn(bool hasValidTemperature, double temperature, DateTime vectorTime)
         {
             if (IsOn) return false; // already on
             if (ManualMode) return false; // avoid auto on when manual mode is on.
             if (OvenTargetTemperature <= 0) return false; // oven's command is off, skip any extra checks
             if (!hasValidTemperature) return false; // no valid oven sensors
 
-            if (LastOff > DateTime.UtcNow.AddSeconds(-10))
+            if (LastOff > vectorTime.AddSeconds(-10))
                 return false;  // less than 10 seconds since we last turned it off
 
             if (temperature >= OvenTargetTemperature)
                 return false; // already at target temperature. 
 
             onTemperature = temperature;
-            return SetOnProperties();
+            return SetOnProperties(vectorTime);
         }
 
-        private bool MustTurnOff(bool hasValidTemperature, double temperature)
+        private bool MustTurnOff(bool hasValidTemperature, double temperature, DateTime vectorTime)
         {
             if (!IsOn) return false; // already off
             if (OvenTargetTemperature <= 0 && !ManualMode)
-                return SetOffProperties(); // turn off: oven's command is off, skip any extra checks
-            var timeoutResult = CheckInvalidValuesTimeout(hasValidTemperature, 2000);
+                return SetOffProperties(vectorTime); // turn off: oven's command is off, skip any extra checks
+            var timeoutResult = CheckInvalidValuesTimeout(hasValidTemperature, 2000, vectorTime);
             if (timeoutResult.HasValue && timeoutResult.Value)
-                return SetOffProperties(); // turn off: 2 seconds without valid temperatures (even if running with manual mode)
+                return SetOffProperties(vectorTime); // turn off: 2 seconds without valid temperatures (even if running with manual mode)
             else if (timeoutResult.HasValue)
                 return false; // no valid temperatures, waiting up to 2 seconds before turn off
 
@@ -97,36 +101,37 @@ namespace CA_DataUploaderLib
                 return false; // avoid auto on/off when running in manual mode (except the 2 seconds without valid reads earlier)
 
             if (onTemperature < 10000 && temperature > onTemperature + 20)
-                return SetOffProperties(); // turn off: already 20C higher than the last time we turned on
+                return SetOffProperties(vectorTime); // turn off: already 20C higher than the last time we turned on
 
             if (temperature > OvenTargetTemperature)
-                return SetOffProperties(); //turn off: already at target temperature
+                return SetOffProperties(vectorTime); //turn off: already at target temperature
 
             return false;
         }
 
         // returns true to simplify MustTurnOff
-        private bool SetOffProperties()
+        private bool SetOffProperties(DateTime vectorTime)
         {
             IsOn = false;
-            LastOff = DateTime.UtcNow;
+            LastOff = vectorTime;
             return true;
         }
 
-        private bool SetOnProperties()
+        private bool SetOnProperties(DateTime vectorTime)
         {
             IsOn = true;
-            LastOn = DateTime.UtcNow;
+            LastOn = vectorTime;
             return true;
         }
 
         public void SetManualMode(bool turnOn)
         { 
+            var vectorTime = DateTime.UtcNow; // note: when running distributed decisions this needs to be the logical time like we have in the vector.
             ManualMode = turnOn;
             if (turnOn)
-                SetOnProperties();
+                SetOnProperties(vectorTime);
             else
-                SetOffProperties();
+                SetOffProperties(vectorTime);
         }
 
         private (bool hasValidTemperature, double temp) GetOvenTemperatureFromVector(NewVectorReceivedArgs vector) 
@@ -161,28 +166,28 @@ namespace CA_DataUploaderLib
         }
 
         /// <returns><c>true</c> if timed out with invalid values, <c>false</c> if we are waiting for the timeout and <c>null</c> if <paramref name="hasValidSensors"/> was <c>true</c></returns>
-        private bool? CheckInvalidValuesTimeout(bool hasValidSensors, int milliseconds)
+        private bool? CheckInvalidValuesTimeout(bool hasValidSensors, int milliseconds, DateTime vectorTime)
         {
             if (hasValidSensors)
-                invalidValuesTime.Reset();
-            else if(!invalidValuesTime.IsRunning)
-                invalidValuesTime.Restart();
+                invalidValuesStartedVectorTime = default;
+            else if(invalidValuesStartedVectorTime == default)
+                invalidValuesStartedVectorTime = vectorTime;
 
-            return hasValidSensors ? default(bool?) : invalidValuesTime.ElapsedMilliseconds >= milliseconds;
+            return hasValidSensors ? default(bool?) : (vectorTime - invalidValuesStartedVectorTime).TotalMilliseconds >= milliseconds;
         }
 
         // resends the on command every 5 seconds as long as there is no current.
-        private bool MustResendOnCommand(double temp, double current, double switchboardOnOffState)
+        private bool MustResendOnCommand(double temp, double current, double switchboardOnOffState, DateTime vectorTime)
         { 
-            if (!IsOn || DateTime.UtcNow < LastOn.AddSeconds(5) || CurrentIsOn(current)) return false;
+            if (!IsOn || vectorTime < LastOn.AddSeconds(5) || CurrentIsOn(current)) return false;
             LogRepeatCommand("on", temp, current, switchboardOnOffState);
             return true;
         }
 
         // resends the off command every 5 seconds as long as there is current.
-        private bool MustResendOffCommand(double temp, double current, double switchboardOnOffState) 
+        private bool MustResendOffCommand(double temp, double current, double switchboardOnOffState, DateTime vectorTime) 
         { 
-            if (IsOn || DateTime.UtcNow < LastOff.AddSeconds(5) || !CurrentIsOn(current)) return false;
+            if (IsOn || vectorTime < LastOff.AddSeconds(5) || !CurrentIsOn(current)) return false;
             LogRepeatCommand("off", temp, current, switchboardOnOffState);
             return true;
         }
@@ -209,12 +214,5 @@ namespace CA_DataUploaderLib
                 throw new InvalidOperationException($"missing switchboard on/off state: {_ioconf.SwitchboardOnOffSensorName}");
             return true;
         }
-    }
-
-    public enum HeaterAction
-    {
-        None,
-        TurnOff,
-        TurnOn
     }
 }

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -129,7 +129,6 @@ namespace CA_DataUploaderLib
             public override string ArgsHelp => " [name] on/off";
             public override string Description => "turn the heater with the given name in IO.conf on and off";
             private readonly List<HeaterElement> _heaters = new List<HeaterElement>();
-            private static int ManualHeaterOnTimeout = 60;
 
             public HeaterCommand(List<HeaterElement> heaters)
             {

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -153,11 +153,6 @@ namespace CA_DataUploaderLib
                 }
 
                 heater.SetManualMode(args[2].ToLower() == "on");
-                if (heater.IsOn) //TODO: do this via the heaterElement.MakeDecision?
-                    heater.Board().SafeWriteLine($"p{heater.PortNumber} on {ManualHeaterOnTimeout}");
-                else
-                    heater.Board().SafeWriteLine($"p{heater.PortNumber} off");
-
                 return Task.CompletedTask;
             }
         }

--- a/CA_DataUploaderLib/Helpers/VectorFilterAndMath.cs
+++ b/CA_DataUploaderLib/Helpers/VectorFilterAndMath.cs
@@ -6,18 +6,33 @@ using System.Linq;
 
 namespace CA_DataUploaderLib.Helpers
 {
+    /// <summary>adds filters and maths, while moving all outputs to the end of the vector</summary>
     public class VectorFilterAndMath
     {
         private readonly CALogLevel _logLevel;
-        protected List<FilterSample> _values;
-        protected MathVectorExpansion _mathVectorExpansion;
+        private List<FilterSample> _values;
+        private MathVectorExpansion _mathVectorExpansion;
+        private int _outputCount;
+        public VectorDescription VectorDescription { get; }
+
         public VectorFilterAndMath(VectorDescription vectorDescription)
         {
             _logLevel = IOconfFile.GetOutputLevel();
+            VectorDescription = vectorDescription;
             _values = GetFilters(vectorDescription);
             vectorDescription._items.AddRange(_values.Select(m => new VectorDescriptionItem("double", m.Output.Name, DataTypeEnum.Input)));
             RemoveHiddenSources(vectorDescription._items, i => i.Descriptor);
-            _mathVectorExpansion = new MathVectorExpansion(vectorDescription);
+            _mathVectorExpansion = new MathVectorExpansion();
+            VectorDescription._items.AddRange(_mathVectorExpansion.GetVectorDescriptionEntries());
+            _outputCount = MoveOutputsToTheEnd(vectorDescription._items);
+        }
+
+        private int MoveOutputsToTheEnd(List<VectorDescriptionItem> items)
+        {
+            var outputs = items.Where(i => i.DirectionType == DataTypeEnum.Output).ToList();
+            items.RemoveAll(i => i.DirectionType == DataTypeEnum.Output);
+            items.AddRange(outputs);
+            return outputs.Count;
         }
 
         private static List<FilterSample> GetFilters(VectorDescription vectorDesc)
@@ -43,19 +58,24 @@ namespace CA_DataUploaderLib.Helpers
             }
         }
 
-        public VectorDescription VectorDescription { get { return _mathVectorExpansion.VectorDescription; } }
-
-        public List<SensorSample> Apply(List<SensorSample> vector)
+        /// <remarks>the input vector is expected to contains all input + state initially sent in the vector description passed to the constructor.</remarks>
+        public List<SensorSample> Apply(List<SensorSample> inputVector)
         {
             foreach (var filter in _values)
             {
-                filter.Input(vector);
-                vector.Add(filter.Output);
+                filter.Input(inputVector);
+                inputVector.Add(filter.Output);
             }
 
-            RemoveHiddenSources(vector, i => i.Name);
-            _mathVectorExpansion.Expand(vector);
-            return vector;
+            RemoveHiddenSources(inputVector, i => i.Name);
+            _mathVectorExpansion.Expand(inputVector);
+            if (inputVector.Count + _outputCount != VectorDescription.Length)
+                throw new ArgumentException($"wrong input vector length (input, expected): {inputVector.Count} <> {VectorDescription.Length - _outputCount}");
+            return inputVector;
         }
+
+        /// <summary>appends the specified outputs to the end of the input vector</summary>
+        /// <remarks>the input vector is expected to be the expanded version returned by the <see cref="Apply" /> method</remarks>
+        public void AddOutputsToInputVector(List<SensorSample> expandedInputVector, IEnumerable<SensorSample> outputs) => expandedInputVector.AddRange(outputs);
     }
 }

--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/CA_DataUploaderLib/IOconf/IOconfAccount.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAccount.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace CA_DataUploaderLib.IOconf
+﻿namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfAccount : IOconfState
     {

--- a/CA_DataUploaderLib/IOconf/IOconfAlert.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAlert.cs
@@ -61,21 +61,21 @@ namespace CA_DataUploaderLib.IOconf
         private const int DefaultRateLimitMinutes = 30; // by default fire the same alert max once every 30 mins.
         private DateTime LastTriggered;
 
-        public bool CheckValue(double newValue)
+        public bool CheckValue(double newValue, DateTime vectorTime)
         {
             Message = MessageTemplate + newValue.ToString(CultureInfo.InvariantCulture) + ")";
             bool newMatches = RawCheckValue(newValue);
             bool lastMatches = !_isFirstCheck && RawCheckValue(LastValue); // there is no lastValue to check on the first call
             _isFirstCheck = false;
             LastValue = newValue;
-            return newMatches && !lastMatches && !RateLimit();
+            return newMatches && !lastMatches && !RateLimit(vectorTime);
         }
 
-        private bool RateLimit()
+        private bool RateLimit(DateTime vectorTime)
         {
-            if (DateTime.UtcNow.Subtract(LastTriggered).TotalMinutes < RateLimitMinutes)
+            if (vectorTime.Subtract(LastTriggered).TotalMinutes < RateLimitMinutes)
                 return true;
-            LastTriggered = DateTime.UtcNow;
+            LastTriggered = vectorTime;
             return false;
         }
 

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -53,6 +53,7 @@ namespace CA_DataUploaderLib.IOconf
                 if (row.StartsWith("Geiger")) return new IOconfGeiger(row, lineNum);
                 if (row.StartsWith("Scale")) return new IOconfScale(row, lineNum);
                 if (row.StartsWith("Valve")) return new IOconfValve(row, lineNum);
+                if (row.StartsWith("SafeValve")) return new IOconfSafeValve(row, lineNum);
                 if (row.StartsWith("Filter")) return new IOconfFilter(row, lineNum);
                 if (row.StartsWith("RPiTemp")) return new IOconfRPiTemp(row, lineNum);
                 if (row.StartsWith("VacuumPump")) return new IOconfVacuumPump(row, lineNum);
@@ -122,6 +123,7 @@ namespace CA_DataUploaderLib.IOconf
         public static IEnumerable<IOconfMotor> GetMotor()=> GetEntries<IOconfMotor>();
         public static IEnumerable<IOconfScale> GetScale() => GetEntries<IOconfScale>();
         public static IEnumerable<IOconfValve> GetValve()=> GetEntries<IOconfValve>();
+        public static IEnumerable<IOconfSafeValve> GetSafeValves()=> GetEntries<IOconfSafeValve>();
         public static IEnumerable<IOconfHeater> GetHeater() => GetEntries<IOconfHeater>();
         public static IEnumerable<IOconfLight> GetLight() => GetEntries<IOconfLight>();
         public static IEnumerable<IOconfOxygen> GetOxygen() => GetEntries<IOconfOxygen>();

--- a/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
@@ -17,6 +17,7 @@ namespace CA_DataUploaderLib.IOconf
         public string CurrentSensorName { get; }
         public string SwitchboardOnOffSensorName { get; }
         public string BoardStateSensorName { get; } 
+        public bool HasOnSafeState { get; protected set; } = false;
         public IEnumerable<IOconfInput> GetExpandedInputConf()
         { // note "_On/Off" is not included as its not an input but the current expected on/off state as seen by the control loop.
             yield return NewPortInput(CurrentSensorName, 0 + PortNumber);

--- a/CA_DataUploaderLib/IOconf/IOconfSafeValve.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfSafeValve.cs
@@ -1,0 +1,41 @@
+﻿using CA_DataUploaderLib.Extensions;
+using System;
+using System.Linq;
+
+namespace CA_DataUploaderLib.IOconf
+{
+    public class IOconfSafeValve : IOconfRow
+    {
+        public string Name { get; }
+        public string ValveName { get; }
+        /// <summary>sensor name as appears in the vector</summary>
+        /// <remarks>only pressures, filters and math are allowed</remarks>
+        public string SensorName { get; }
+        /// <summary>max sensor value. Above this value the safe valve triggers, setting the valve to the default/safe position</summary>
+        public double Max { get; }
+
+        public IOconfSafeValve(string row, int lineNum) : base(row, lineNum, "Filter")
+        {
+            format = "SafeValve;Name;ValveName;SensorName;Max";
+
+            var list = ToList();
+            if (list.Count < 5)
+                throw new Exception($"Wrong SafeValve type: {row} {Environment.NewLine}{format}");
+            Name = list[1];
+            ValveName = list[2];
+            SensorName = list[3];
+            if (!list[4].TryToDouble(out var max))
+                throw new Exception($"Wrong filter length: {row} {Environment.NewLine}{format}");
+            Max = max;
+
+            if  (!IOconfFile.GetValve().Any(v => v.Name == ValveName))
+                throw new Exception($"Failed to find valve: {ValveName} for safevalve: {row}");
+            var foundSensor = 
+                IOconfFile.GetPressure().Any(p => p.Name == SensorName) ||
+                IOconfFile.GetMath().Any(m => m.Name == SensorName) ||
+                IOconfFile.GetFilters().Any(m => m.NameInVector == SensorName);
+            if (!foundSensor)
+                throw new Exception($"Failed to find sensor: {SensorName} for safevalve: {row}");
+        }
+    }
+}

--- a/CA_DataUploaderLib/IOconf/IOconfValve.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfValve.cs
@@ -2,6 +2,11 @@
 {
     public class IOconfValve : IOconfOut230Vac
     {
-        public IOconfValve(string row, int lineNum) : base(row, lineNum, "Valve") { }
+        public IOconfValve(string row, int lineNum) : base(row, lineNum, "Valve") 
+        { 
+            HasOpenSafeState = HasOnSafeState = Name.ToLower().Contains("out");
+        }
+
+        public bool HasOpenSafeState { get; }
     }
 }

--- a/CA_DataUploaderLib/IVectorDataProvider.cs
+++ b/CA_DataUploaderLib/IVectorDataProvider.cs
@@ -1,11 +1,14 @@
+using System;
 using System.Collections.Generic;
+using CA.LoopControlPluginBase;
 
 namespace CA_DataUploaderLib
 {
     public interface ISubsystemWithVectorData
     {
-        IEnumerable<SensorSample> GetValues();
-        List<VectorDescriptionItem> GetVectorDescriptionItems();
         string Title { get; }
+        List<VectorDescriptionItem> GetVectorDescriptionItems();
+        IEnumerable<SensorSample> GetInputValues();
+        IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs);
     }
 }

--- a/CA_DataUploaderLib/MathVectorExpansion.cs
+++ b/CA_DataUploaderLib/MathVectorExpansion.cs
@@ -7,43 +7,31 @@ namespace CA_DataUploaderLib
 {
     public class MathVectorExpansion
     {
-        public VectorDescription VectorDescription { get; private set; }
         private readonly List<IOconfMath> _mathStatements;
 
-        public MathVectorExpansion(VectorDescription vectorDescription) : this(vectorDescription, IOconfFile.GetMath) { }
-        public MathVectorExpansion(VectorDescription vectorDescription, Func<IEnumerable<IOconfMath>> getMath)
+        public MathVectorExpansion() : this(IOconfFile.GetMath) { }
+        public MathVectorExpansion(Func<IEnumerable<IOconfMath>> getMath)
         {
-            VectorDescription = vectorDescription;
             _mathStatements = getMath().ToList();
-            VectorDescription._items.AddRange(_mathStatements.Select(m => new VectorDescriptionItem("double", m.Name, DataTypeEnum.State)));
         }
 
-        /// <param name="vector">The vector to expand.</param>
+        public IEnumerable<VectorDescriptionItem> GetVectorDescriptionEntries() => 
+            _mathStatements.Select(m => new VectorDescriptionItem("double", m.Name, DataTypeEnum.State));
+
+        /// <param name="inputVector">the vector to expand.</param>
         /// <remarks>
-        /// The vector must match the order and amount of entries specified in <see cref="MathVectorExpansion(VectorDescription)"/>.
+        /// The math statements are appended at the end of the vector in the order returned by <see cref="GetVectorDescriptionEntries()" />.
         /// This method and class does not track changes to the <see cref="IOconfFile"/>, use a new instance if needed.
         /// </remarks>
-        public void Expand(List<SensorSample> vector)
+        public void Expand(List<SensorSample> inputVector)
         {
-            if (vector.Count() + _mathStatements.Count() != VectorDescription.Length)
-                throw new ArgumentException($"wrong vector length (input, expected): {vector.Count} <> {VectorDescription.Length - _mathStatements.Count()}");
-
-            var dic = GetVectorDictionary(vector);
+            var dic = GetVectorDictionary(inputVector);
             foreach (var math in _mathStatements)
             {
-                vector.Add(math.Calculate(dic));
+                inputVector.Add(math.Calculate(dic));
             }
         }
 
-        private Dictionary<string, object> GetVectorDictionary(List<SensorSample> vector)
-        {
-            var dic = new Dictionary<string, object>(VectorDescription.Length);
-            for(int i = 0;i<vector.Count;i++)            
-            {
-                dic.Add(VectorDescription._items[i].Descriptor, vector[i].Value);
-            }
-
-            return dic;
-        }
+        private Dictionary<string, object> GetVectorDictionary(List<SensorSample> vector) => vector.ToDictionary(s => s.Name, s => (object)s.Value);
     }
 }

--- a/CA_DataUploaderLib/SwitchBoardAction.cs
+++ b/CA_DataUploaderLib/SwitchBoardAction.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using CA_DataUploaderLib.Extensions;
+using CA.LoopControlPluginBase;
+
+namespace CA_DataUploaderLib
+{
+    public class SwitchboardAction
+    {
+        public bool IsOn { get; }
+        public DateTime TimeToTurnOff { get; }
+
+        public SwitchboardAction(bool isOn, DateTime timeToTurnOff)
+        {
+            IsOn = isOn;
+            TimeToTurnOff = timeToTurnOff;
+        }
+
+        public int GetRemainingOnSeconds(DateTime currentVectorTime)
+        {
+            if (!IsOn) return 0;
+            var remainingTime = TimeToTurnOff - currentVectorTime;
+            return (int) Math.Ceiling(remainingTime.TotalSeconds); // switchboard ports can't be turn on less than 1 second.
+        }
+
+        public IEnumerable<SensorSample> ToVectorSamples(string portName) 
+        {
+            yield return new SensorSample(GetOnName(portName), IsOn ? 1.0 : 0.0);
+            yield return new SensorSample(GetTimeOffName(portName), TimeToTurnOff.ToVectorDouble());
+        }
+
+        public static SwitchboardAction FromVectorSamples(NewVectorReceivedArgs args, string portName)
+        {
+            var isOnName = GetOnName(portName);
+            var timeOffName = GetTimeOffName(portName);
+            if (!args.TryGetValue(isOnName, out var isOn)) throw new ArgumentOutOfRangeException($"failed to find {isOnName}");
+            if (!args.TryGetValue(timeOffName, out var timeOff)) throw new ArgumentOutOfRangeException($"failed to find {timeOffName}");
+            return new SwitchboardAction(isOn == 1.0, timeOff.ToVectorDate());
+        }
+
+        public override bool Equals(object obj) => 
+            obj is SwitchboardAction typedObj ?
+                IsOn == typedObj.IsOn && TimeToTurnOff == typedObj.TimeToTurnOff :
+                false;
+        public override int GetHashCode() => HashCode.Combine(IsOn, TimeToTurnOff);
+        private static string GetOnName(string portName) => portName + "_On/Off";
+        private static string GetTimeOffName(string portName) => portName + "_timeOff";
+    }
+}

--- a/CA_DataUploaderLib/SwitchBoardAction.cs
+++ b/CA_DataUploaderLib/SwitchBoardAction.cs
@@ -29,6 +29,12 @@ namespace CA_DataUploaderLib
             yield return new SensorSample(GetTimeOffName(portName), TimeToTurnOff.ToVectorDouble());
         }
 
+        public static IEnumerable<VectorDescriptionItem> GetVectorDescriptionItems(string portName) 
+        {
+            yield return new VectorDescriptionItem("double", GetOnName(portName), DataTypeEnum.Output);
+            yield return new VectorDescriptionItem("double", GetTimeOffName(portName), DataTypeEnum.Output);
+        }
+
         public static SwitchboardAction FromVectorSamples(NewVectorReceivedArgs args, string portName)
         {
             var isOnName = GetOnName(portName);
@@ -39,7 +45,7 @@ namespace CA_DataUploaderLib
         }
 
         public override bool Equals(object obj) => 
-            obj is SwitchboardAction typedObj ?
+            obj != null && obj is SwitchboardAction typedObj ?
                 IsOn == typedObj.IsOn && TimeToTurnOff == typedObj.TimeToTurnOff :
                 false;
         public override int GetHashCode() => HashCode.Combine(IsOn, TimeToTurnOff);

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -1,7 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CA.LoopControlPluginBase;
+using CA_DataUploaderLib.Extensions;
 using CA_DataUploaderLib.IOconf;
+using Humanizer;
 
 namespace CA_DataUploaderLib
 {
@@ -9,22 +14,31 @@ namespace CA_DataUploaderLib
     {
         /// <summary>runs when the subsystem is about to stop running, but before all boards are closed</summary>
         /// <remarks>some boards might be closed, specially if the system is stopping due to losing connection to one of the boards</remarks>
-        public event EventHandler Stopping;
         private readonly BaseSensorBox _reader;
         private static readonly object ControllerInitializationLock = new object();
+        private PluginsCommandHandler _cmd;
         private static SwitchBoardController _instance;
+        private readonly TaskCompletionSource _boardControlLoopsStopped = new TaskCompletionSource();
+        private readonly CancellationTokenSource _boardLoopsStopTokenSource = new CancellationTokenSource();
 
         private SwitchBoardController(CommandHandler cmd) 
         {
+            _cmd = new PluginsCommandHandler(cmd);
             var heaters = IOconfFile.GetHeater().Cast<IOconfOut230Vac>();
-            var ports = heaters.Concat(IOconfFile.GetValve()).Where(p => p.Map.Board != null);
+            var ports = heaters.Concat(IOconfFile.GetValve()).Where(p => p.Map.Board != null).ToList();
             var boardsTemperatures = ports.GroupBy(p => p.BoxName).Select(b => b.Select(p => p.GetBoardTemperatureInputConf()).FirstOrDefault());
             var inputs = ports.SelectMany(p => p.GetExpandedInputConf()).Concat(boardsTemperatures);
             _reader = new BaseSensorBox(cmd, "switchboards", string.Empty, "show switchboards inputs", inputs);
-            _reader.Stopping += OnStopping;
+            _reader.Stopping += WaitForLoopStopped;
+            cmd.AddCommand("escape", Stop);
+            Task.Run(() => RunBoardControlLoops(ports));
         }
 
-        public void Dispose() => _reader.Dispose();
+        public void Dispose() 
+        { 
+            _boardLoopsStopTokenSource.Cancel();
+            _reader.Dispose();
+        }
 
         public static SwitchBoardController GetOrCreate(CommandHandler cmd)
         {
@@ -36,6 +50,103 @@ namespace CA_DataUploaderLib
             }
         }
 
-        private void OnStopping(object sender, EventArgs args) => Stopping?.Invoke(this, EventArgs.Empty);
+        private bool Stop(List<string> args)
+        {
+            _boardLoopsStopTokenSource.Cancel();
+            return true;
+        }
+
+        private async Task BoardLoop(MCUBoard board, List<IOconfOut230Vac> ports, CancellationToken token)
+        {
+            var lastActions = new SwitchboardAction[ports.Count];
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    var vector = await _cmd.When(_ => true, token);
+                    foreach (var port in ports)
+                        DoPortActions(vector, board, port, lastActions, token);
+                }
+                catch (TaskCanceledException ex)
+                {
+                    if (!token.IsCancellationRequested)
+                        CALog.LogErrorAndConsoleLn(LogID.A, ex.ToString());
+                }
+                catch (Exception ex)
+                {
+                    CALog.LogErrorAndConsoleLn(LogID.A, ex.ToString());
+                }
+            }
+            
+            AllOff(board, ports);
+        }
+
+        private async Task RunBoardControlLoops(List<IOconfOut230Vac> ports)
+        {
+            DateTime start = DateTime.Now;
+            try
+            {
+                var boardLoops = ports
+                    .GroupBy(v => v.Map.Board)
+                    .Select(g => BoardLoop(g.Key, g.ToList(), _boardLoopsStopTokenSource.Token))
+                    .ToList();
+                await Task.WhenAll(boardLoops);                
+                CALog.LogInfoAndConsoleLn(LogID.A, "Exiting SwitchBoardController.RunBoardControlLoops() " + DateTime.Now.Subtract(start).Humanize(5));
+            }
+            catch (Exception ex)
+            {
+                CALog.LogErrorAndConsoleLn(LogID.A, ex.ToString());
+            }
+            finally
+            {
+                _boardControlLoopsStopped.TrySetResult();
+            }
+        }
+        
+        private void DoPortActions(NewVectorReceivedArgs vector, MCUBoard board, IOconfOut230Vac port, SwitchboardAction[] lastActions, CancellationToken token)
+        {
+            if (token.IsCancellationRequested)
+                return;
+            try
+            {
+                var action = SwitchboardAction.FromVectorSamples(vector, port.Name);
+                if (action.Equals(lastActions[port.PortNumber - 1]))
+                    return; // no action changes has been requested since the last action taken on the heater.
+                
+                var onSeconds = action.GetRemainingOnSeconds(vector.GetVectorTime());
+                if (onSeconds == 0)
+                    board.SafeWriteLine($"p{port.PortNumber} off");
+                else
+                    board.SafeWriteLine($"p{port.PortNumber} on {onSeconds}");
+                lastActions[port.PortNumber - 1] = action;
+            }
+            catch (Exception)
+            {
+                CALog.LogErrorAndConsoleLn(LogID.A, $"Failed executing port action for board {board.BoxName} port {port.Name} - {port.Name}");
+                throw; // this will log extra info and avoid extra board actions on this cycle
+            }
+        }
+
+        private void AllOff(MCUBoard board, List<IOconfOut230Vac> ports)
+        {
+            try
+            {
+                board.SafeWriteLine("off"); 
+                foreach (var port in ports)
+                    if (port.HasOnSafeState)
+                        board.SafeWriteLine($"p{port.PortNumber} on");
+            }
+            catch (Exception ex)
+            {
+                CALog.LogErrorAndConsoleLn(LogID.A, $"Error detected while attempting to set ports to default positions for board {board.BoxName}", ex);
+            }
+        }
+
+        private void WaitForLoopStopped(object sender, EventArgs args)
+        {
+            CALog.LogData(LogID.A, "waiting for switchboards control loops to finish actions and set ports to their default value");
+            _boardControlLoopsStopped.Task.Wait();
+            CALog.LogData(LogID.A, "finished waiting for switchboards loops");
+        }
     }
 }

--- a/UnitTests/IOconfAlertTests.cs
+++ b/UnitTests/IOconfAlertTests.cs
@@ -21,7 +21,7 @@ namespace UnitTests
         public void AlertTriggers(string row, double value) 
         {
             var alert = new IOconfAlert(row, 0);
-            Assert.IsTrue(alert.CheckValue(value));
+            Assert.IsTrue(alert.CheckValue(value, DateTime.UtcNow));
         }
 
         [DataRow("Alert;MyName;Sensorx = 123", 122d, 123d)]
@@ -41,8 +41,8 @@ namespace UnitTests
         public void AlertTriggersWhenOldValueDidNotMatch(string row, double oldValue, double value)
         {
             var alert = new IOconfAlert(row, 0);
-            alert.CheckValue(oldValue);
-            Assert.IsTrue(alert.CheckValue(value));
+            alert.CheckValue(oldValue, DateTime.UtcNow);
+            Assert.IsTrue(alert.CheckValue(value, DateTime.UtcNow));
         }
 
         [DataRow("Alert;MyName;Sensorx = 123", 122d, 123d, " MyName (Sensorx) = 123 (123)")]
@@ -51,8 +51,8 @@ namespace UnitTests
         public void AlertReturnsExpectedMessageAfterCheckingValueTwice(string row, double oldValue, double value, string expectedMessage)
         {
             var alert = new IOconfAlert(row, 0);
-            alert.CheckValue(oldValue);
-            alert.CheckValue(value);
+            alert.CheckValue(oldValue, DateTime.UtcNow);
+            alert.CheckValue(value, DateTime.UtcNow);
             Assert.AreEqual(expectedMessage, alert.Message);
         }
 
@@ -68,8 +68,8 @@ namespace UnitTests
         public void AlertDoesNotTriggersWhenOldValueMatched(string row, double oldValue, double value)
         {
             var alert = new IOconfAlert(row, 0);
-            alert.CheckValue(oldValue);
-            Assert.IsFalse(alert.CheckValue(value));
+            alert.CheckValue(oldValue, DateTime.UtcNow);
+            Assert.IsFalse(alert.CheckValue(value, DateTime.UtcNow));
         }
 
         [DataRow("Alert;MyName;Sensorx;=;123", DisplayName = "old format - no longer supported")]


### PR DESCRIPTION
- fixed crash when ignoring boards + safe valves in IO.conf
    Reason: when reconnect attempts to a board has been exceeded the code ignores the board when 
    BoardSettings.StopWhenLosingSensor is set to false. The problem was that the code ignoring the board was removing it from a list shared by the code reporting the connection states sent in the vector. Which ended in an error like the following: `System.ArgumentException: wrong vector length (input, expected): 34 <> 35`
- added SafeValve to the IO.conf so they don't need to be explicitely added after each restart.
- separated decision making vs. actuations. 
    - Heaters actuations are now executed by the SwitchBoardController so they can be used for other devices.
    - Related to this, the execution of manual commands now goes through the vector
- some time checks now use the vector time, including ones used for heating control
- using shorter timeouts for heater control (10 instead of 60)
    reason: if we lose connection to the switchbox it doesn't keep the heater on for so long.
- removed the current sensing repeat on, as the control system will keep sending the on commands approx. every 9 seconds anyway.
- oven off and oven 0 now also turns off heaters that were running in manual mode
- manual mode is no longer disabled when there are no sensors for the heaters. It prevented manual heater control in systems without configured ovens