### PR TITLE
minor improvements

### DIFF
--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -1,4 +1,5 @@
 ﻿using CA.LoopControlPluginBase;
+using CA_DataUploaderLib.Extensions;
 using CA_DataUploaderLib.IOconf;
 using System;
 using System.Collections.Generic;
@@ -58,7 +59,7 @@ namespace CA_DataUploaderLib
         public IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs)
         { 
             foreach (var heater in _heaters)
-            foreach (var sample in heater.MakeNextActionDecision(inputVectorReceivedArgs).ToVectorSamples(heater.Name()))
+            foreach (var sample in heater.MakeNextActionDecision(inputVectorReceivedArgs).ToVectorSamples(heater.Name(), inputVectorReceivedArgs.GetVectorTime()))
                 yield return sample;
         }
 

--- a/CA_DataUploaderLib/SwitchBoardAction.cs
+++ b/CA_DataUploaderLib/SwitchBoardAction.cs
@@ -7,29 +7,55 @@ namespace CA_DataUploaderLib
 {
     public class SwitchboardAction
     {
-        public bool IsOn { get; }
-        public DateTime TimeToTurnOff { get; }
+        private static readonly DateTime ModifiedMaxDateTime = DateTime.FromOADate(DateTime.MaxValue.AddMilliseconds(-1).ToOADate()); 
+        private readonly DateTime _timeToTurnOff;
 
+        public bool IsOn { get; }
+        public DateTime TimeToTurnOff => _timeToTurnOff >= ModifiedMaxDateTime ? DateTime.MaxValue : _timeToTurnOff; //we don't check max time exactly to avoid differences with the vector + allow the modified max date time.
         public SwitchboardAction(bool isOn, DateTime timeToTurnOff)
         {
             IsOn = isOn;
-            TimeToTurnOff = timeToTurnOff;
+            _timeToTurnOff = timeToTurnOff;
         }
 
+        ///<summary>gets a positive value of how many seconds are remaining (rounded up) or 0 or less for how many full seconds have passed since the time to turn off</summary>
+        ///<remarks>if the action is to turn off and the time to turn off is in the future, this method will keep returning 0 until reaching the time to turn off</remarks>
         public int GetRemainingOnSeconds(DateTime currentVectorTime)
         {
-            if (!IsOn) return 0;
+            if (!IsOn && TimeToTurnOff > currentVectorTime) return 0;
+            if (TimeToTurnOff == DateTime.MaxValue) return int.MaxValue;
             var remainingTime = TimeToTurnOff - currentVectorTime;
-            return (int) Math.Ceiling(remainingTime.TotalSeconds); // switchboard ports can't be turn on less than 1 second.
+            return (int)Math.Ceiling(remainingTime.TotalSeconds); // switchboard ports can't be turn on less than 1 second.
         }
 
-        public IEnumerable<SensorSample> ToVectorSamples(string portName) 
+        /// <summary>returns a slightly changed version of the same command that can be used to request repeating the action</summary>
+        /// <remarks>
+        /// <see cref="TimeToTurnOff" /> will still return the max date even when it is changes (+1/-1 millisecond)
+        /// <see cref="TimeToTurnOff" /> will return the vector time when the repeat off was requested or +1 millisecond for other on commands.
+        /// The repeat actions use milliseconds instead of ticks modifications as the date stored in the vector only has millisecond precision.
+        /// </remarks>
+        public SwitchboardAction Repeat(DateTime currentVectorTime)
         {
-            yield return new SensorSample(GetOnName(portName), IsOn ? 1.0 : 0.0);
-            yield return new SensorSample(GetTimeOffName(portName), TimeToTurnOff.ToVectorDouble());
+            if (!IsOn)
+                return new SwitchboardAction(false, currentVectorTime);
+            if (_timeToTurnOff == ModifiedMaxDateTime)
+                return new SwitchboardAction(true, DateTime.MaxValue); 
+            if (_timeToTurnOff > ModifiedMaxDateTime) //we don't check max time exactly to avoid differences with the vector.
+                return new SwitchboardAction(true, ModifiedMaxDateTime);
+            return new SwitchboardAction(true, _timeToTurnOff.AddMilliseconds(1));
+        }
+        public IEnumerable<SensorSample> ToVectorSamples(string portName, DateTime currentVectorTime)
+        {
+            // we use GetRemainingOnSeconds instead of IsOn so that:
+            // 1. the reported vector correctly states the expected on/off state
+            // 2. the port still turns off even if the switchbox did not on its own
+            // 3. the port can be turned off in sub second durations (up to vector decision frequency),
+            //    which could happen when an actuation vector is missed or when resuming from a safe valve.
+            yield return new SensorSample(GetOnName(portName), GetRemainingOnSeconds(currentVectorTime) > 0 ? 1.0 : 0.0);
+            yield return new SensorSample(GetTimeOffName(portName), _timeToTurnOff.ToVectorDouble());
         }
 
-        public static IEnumerable<VectorDescriptionItem> GetVectorDescriptionItems(string portName) 
+        public static IEnumerable<VectorDescriptionItem> GetVectorDescriptionItems(string portName)
         {
             yield return new VectorDescriptionItem("double", GetOnName(portName), DataTypeEnum.Output);
             yield return new VectorDescriptionItem("double", GetTimeOffName(portName), DataTypeEnum.Output);
@@ -44,11 +70,11 @@ namespace CA_DataUploaderLib
             return new SwitchboardAction(isOn == 1.0, timeOff.ToVectorDate());
         }
 
-        public override bool Equals(object obj) => 
+        public override bool Equals(object obj) =>
             obj != null && obj is SwitchboardAction typedObj ?
-                IsOn == typedObj.IsOn && TimeToTurnOff == typedObj.TimeToTurnOff :
+                IsOn == typedObj.IsOn && _timeToTurnOff == typedObj._timeToTurnOff :
                 false;
-        public override int GetHashCode() => HashCode.Combine(IsOn, TimeToTurnOff);
+        public override int GetHashCode() => HashCode.Combine(IsOn, _timeToTurnOff);
         private static string GetOnName(string portName) => portName + "_On/Off";
         private static string GetTimeOffName(string portName) => portName + "_timeOff";
     }

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -114,8 +114,10 @@ namespace CA_DataUploaderLib
                     return; // no action changes has been requested since the last action taken on the heater.
                 
                 var onSeconds = action.GetRemainingOnSeconds(vector.GetVectorTime());
-                if (onSeconds == 0)
+                if (onSeconds <= 0)
                     board.SafeWriteLine($"p{port.PortNumber} off");
+                else if (onSeconds == int.MaxValue)
+                    board.SafeWriteLine($"p{port.PortNumber} on");
                 else
                     board.SafeWriteLine($"p{port.PortNumber} on {onSeconds}");
                 lastActions[port.PortNumber - 1] = action;

--- a/UnitTests/BoardSettingsTests.cs
+++ b/UnitTests/BoardSettingsTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using CA_DataUploaderLib;
 using CA_DataUploaderLib.IOconf;
 
 namespace UnitTests

--- a/UnitTests/SwitchboardActionTests.cs
+++ b/UnitTests/SwitchboardActionTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Linq;
+using CA.LoopControlPluginBase;
+using CA_DataUploaderLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class SwitchboardActionTests
+    {
+        [TestMethod]
+        public void RepeatMaxReturnsModifiedAction()
+        {
+            var action = new SwitchboardAction(true, DateTime.MaxValue);
+            var repeatAction = action.Repeat(DateTime.UtcNow);
+            Assert.AreNotEqual(action, repeatAction);
+        }
+
+        [TestMethod]
+        public void RemainingSecondsOnRepeatActionReturnsIntMax()
+        {
+            var remaining = new SwitchboardAction(true, DateTime.MaxValue)
+                .Repeat(DateTime.UtcNow)
+                .GetRemainingOnSeconds(DateTime.UtcNow);
+            Assert.AreEqual(int.MaxValue, remaining);
+        }
+
+        [TestMethod]
+        public void RemainingSecondsOnRepeatActionViaVectorReturnsIntMax()
+        {
+            var samples = new SwitchboardAction(true, DateTime.MaxValue)
+                .Repeat(DateTime.UtcNow)
+                .ToVectorSamples("port", DateTime.UtcNow);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(
+                new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(DateTime.UtcNow);
+            Assert.AreEqual(int.MaxValue, remaining);
+        }
+                
+        [TestMethod]
+        public void RemainingSecondsOnMaxViaVectorReturnsIntMax()
+        {
+            var samples = new SwitchboardAction(true, DateTime.MaxValue).ToVectorSamples("port", DateTime.UtcNow);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(
+                new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(DateTime.UtcNow);
+            Assert.AreEqual(int.MaxValue, remaining);
+        }
+
+        [TestMethod]
+        public void TimeToTurnOffOnRepeatActionViaVectorReturnsDateTimeMax()
+        {
+            var samples = new SwitchboardAction(true, DateTime.MaxValue)
+                .Repeat(DateTime.UtcNow)
+                .ToVectorSamples("port", DateTime.UtcNow);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(
+                new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            Assert.AreEqual(DateTime.MaxValue, actionFromVector.TimeToTurnOff);
+        }
+                
+        [TestMethod]
+        public void TimeToTurnOffOnMaxViaVectorReturnsDateTimeMax()
+        {
+            var samples = new SwitchboardAction(true, DateTime.MaxValue).ToVectorSamples("port", DateTime.UtcNow);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(
+                new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            Assert.AreEqual(DateTime.MaxValue, actionFromVector.TimeToTurnOff);
+        }
+                
+        [TestMethod]
+        public void RemainingSecondsViaVectorReturnsIntMax()
+        {
+            var samples = new SwitchboardAction(true, DateTime.MaxValue)
+                .Repeat(DateTime.UtcNow)
+                .ToVectorSamples("port", DateTime.UtcNow);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(
+                new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(DateTime.UtcNow);
+            Assert.AreEqual(int.MaxValue, remaining);
+        }
+                
+        [TestMethod]
+        public void RemainingSecondsOnTimeWithTicksViaVectorReturnsFullSeconds()
+        {
+            var vectorTime =  new DateTime(2021, 6, 22, 12, 5, 2, 333).AddTicks(42);
+            var samples = new SwitchboardAction(true, vectorTime.AddSeconds(10)).ToVectorSamples("port", vectorTime);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(vectorTime);
+            Assert.AreEqual(10, remaining);
+        }
+               
+        [TestMethod]
+        public void RemainingSecondsOnTimeWithHighTicksViaVectorReturnsFullSeconds()
+        {
+            var vectorTime =  new DateTime(2021, 6, 22, 12, 5, 2, 333).AddTicks(-1);
+            var samples = new SwitchboardAction(true, vectorTime.AddSeconds(10)).ToVectorSamples("port", vectorTime);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(vectorTime);
+            Assert.AreEqual(10, remaining);
+        }
+               
+        [TestMethod]
+        public void RemainingSecondsOnTimeWithLowTicksViaVectorReturnsFullSeconds()
+        {
+            var vectorTime =  new DateTime(2021, 6, 22, 12, 5, 2, 333).AddTicks(1);
+            var samples = new SwitchboardAction(true, vectorTime.AddSeconds(10)).ToVectorSamples("port", vectorTime);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(vectorTime);
+            Assert.AreEqual(10, remaining);
+        }
+               
+        [TestMethod]
+        public void RemainingSecondsAfter5SecondsReturns5Seconds()
+        {
+            var vectorTime =  new DateTime(2021, 6, 22, 12, 5, 2, 333).AddTicks(1);
+            var samples = new SwitchboardAction(true, vectorTime.AddSeconds(10)).ToVectorSamples("port", vectorTime);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(vectorTime.AddSeconds(5));
+            Assert.AreEqual(5, remaining);
+        }
+               
+        [TestMethod]
+        public void RemainingSecondsAfter10SecondsReturns0Seconds()
+        {
+            var vectorTime =  new DateTime(2021, 6, 22, 12, 5, 2, 333).AddTicks(1);
+            var samples = new SwitchboardAction(true, vectorTime.AddSeconds(10)).ToVectorSamples("port", vectorTime);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(vectorTime.AddSeconds(10));
+            Assert.AreEqual(0, remaining);
+        }
+               
+        [TestMethod]
+        public void RemainingSecondsAfter9SecondsAnd800MillisecondsReturns1Second()
+        {
+            var vectorTime =  new DateTime(2021, 6, 22, 12, 5, 2, 333).AddTicks(1);
+            var samples = new SwitchboardAction(true, vectorTime.AddSeconds(10)).ToVectorSamples("port", vectorTime);
+            var actionFromVector = SwitchboardAction.FromVectorSamples(new NewVectorReceivedArgs(samples.ToDictionary(s => s.Name, s => s.Value)), "port");
+            var remaining = actionFromVector.GetRemainingOnSeconds(vectorTime.AddSeconds(9).AddMilliseconds(800));
+            Assert.AreEqual(1, remaining);
+        }
+    }
+}


### PR DESCRIPTION
- added always on switchboard actions (pass DateTime.MaxValue to the constructor). Usage of this should be limited to devices where the safe state is on (which is discouraged, as the safe state of devices should be off).
- SwitchboardAction.ToVectorSamples now reports the port is off if the time off has passed
- SwitchboardAction.GetRemainingOnSeconds now returns how many seconds since the time to turn off has passed as a negative number (it used to return 0 all the time)
- added SwitchBoardAction.Repeat that can be used to request the vector based action to be repeated