### PR TITLE
improved board state + less shutdowns + better sensor independence + better reconnects

### DIFF
--- a/CA_DataUploader/Program.cs
+++ b/CA_DataUploader/Program.cs
@@ -30,12 +30,13 @@ namespace CA_DataUploader
                     CALog.LogInfoAndConsoleLn(LogID.A, "Now connected to server...");
 
                     int i = 0;
+                    var uploadThrottle = new TimeThrottle(100);
                     while (cmd.IsRunning)
                     {
                         var (sensorsSamples, vectorTime) = cmd.GetFullSystemVectorValues();
                         cloud.SendVector(sensorsSamples.Select(v => v.Value).ToList(), vectorTime);
                         Console.Write($"\r data points uploaded: {i++}"); // we don't want this in the log file. 
-                        cloud.Wait(100);
+                        uploadThrottle.Wait();
                         if (i == 20) DULutil.OpenUrl(cloud.GetPlotUrl());
                     }
                 }

--- a/CA_DataUploaderLib/AlertFiredArgs.cs
+++ b/CA_DataUploaderLib/AlertFiredArgs.cs
@@ -1,0 +1,12 @@
+namespace CA_DataUploaderLib
+{
+    public class AlertFiredArgs
+    {
+        public AlertFiredArgs(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+    }
+}

--- a/CA_DataUploaderLib/Alerts.cs
+++ b/CA_DataUploaderLib/Alerts.cs
@@ -15,14 +15,14 @@ namespace CA_DataUploaderLib
         public override string Description => string.Empty;
         public override bool IsHiddenCommand => true;
         private readonly List<IOconfAlert> _alerts;
-        private readonly ServerUploader _uploader;
+        private readonly CommandHandler _cmd;
 
-        public Alerts(VectorDescription vectorDescription, CommandHandler cmd, ServerUploader uploader) : base()
+        public Alerts(VectorDescription vectorDescription, CommandHandler cmd) : base()
         {
+            _cmd = cmd;
             var cmdPlugins = new PluginsCommandHandler(cmd);
             Initialize(cmdPlugins, new PluginsLogger("Alerts"));
             cmdPlugins.AddCommand("removealert", RemoveAlert);
-            _uploader = uploader;
             _alerts = GetAlerts(vectorDescription, cmd);
         }
 
@@ -111,7 +111,7 @@ namespace CA_DataUploaderLib
             if (a.TriggersEmergencyShutdown)
                 ExecuteCommand("emergencyshutdown");
 
-            _uploader.SendAlert(message);
+            _cmd.FireAlert(message);            
         }
 
         private List<T> EnsureInitialized<T>(ref List<T> list) => list = list ?? new List<T>();

--- a/CA_DataUploaderLib/AsyncReaderWriterLock.cs
+++ b/CA_DataUploaderLib/AsyncReaderWriterLock.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CA_DataUploaderLib
+{
+    // async compatible reader / writer lock based on https://stackoverflow.com/a/64757462/66372
+    // it doesn't have a lot of protection, so keep its usage simple i.e. blocks where try/finally can be used and no recursion can happen
+    // How it works:
+    //  - in general, a reader/writer lock allows any amount of readers to enter the lock while only a single writer can do so. While the writer holds the lock, no reader can hold the lock
+    //  - 2 semaphores + a count of readers in the lock are used to provide the above guarantees
+    //  - to guarantee no new readers or writers can enter the lock while a writer is active, a write semaphore is used
+    //    - both readers and writers acquire this semaphore first when trying to take the lock
+    //    - readers release the semaphore just after acquiring the read lock, so more readers can enter the lock (so technically acquiring of readers locks do not happens in parallel)
+    //  - to guarantee the writer does not enter the lock while there are still readers in the lock, a read semaphore is used
+    //    - both the writer and the first reader acquire this semaphore when trying to take the lock. They do it *after* they hold the write semaphore
+    //    - the last active reader holding the lock, releases the read semaphore. Note it does not need to be the reader that acquired it first.
+    //    - to track a reader acquiring/releasing a lock is the first/last one, a reader count is tracked when acquiring/releasing the read lock.
+    //  - cancellation tokens are supported so that readers/writers can abort while waiting for an active writer to finish its job.
+    public sealed class AsyncReaderWriterLock : IDisposable
+    {
+        readonly SemaphoreSlim _readSemaphore  = new SemaphoreSlim(1, 1);
+        readonly SemaphoreSlim _writeSemaphore = new SemaphoreSlim(1, 1);
+        int _readerCount;
+
+        public async Task AcquireWriterLock(CancellationToken token = default)
+        {
+            await _writeSemaphore.WaitAsync(token).ConfigureAwait(false);
+            try
+            {
+                await _readSemaphore.WaitAsync(token).ConfigureAwait(false);
+            }
+            catch
+            {
+                _writeSemaphore.Release();
+                throw;
+            }
+        }
+
+        public void ReleaseWriterLock()
+        {
+            _readSemaphore.Release();
+            _writeSemaphore.Release();
+        }
+
+        public async Task AcquireReaderLock(CancellationToken token = default)
+        {
+            await _writeSemaphore.WaitAsync(token).ConfigureAwait(false);
+
+            if (Interlocked.Increment(ref _readerCount) == 1)
+            {
+                try
+                {
+                    await _readSemaphore.WaitAsync(token).ConfigureAwait(false);
+                }
+                catch
+                {
+                    Interlocked.Decrement(ref _readerCount); 
+                    _writeSemaphore.Release();
+                    throw;
+                }
+            }
+
+            _writeSemaphore.Release();
+        }
+
+        public void ReleaseReaderLock()
+        {
+            if (Interlocked.Decrement(ref _readerCount) == 0)
+            {
+                _readSemaphore.Release();
+            }
+        }
+
+        public void Dispose()
+        {
+            _writeSemaphore.Dispose();
+            _readSemaphore.Dispose();
+        }
+    }
+}

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -120,8 +120,8 @@ namespace CA_DataUploaderLib
                 try
                 {
                     await readThrottle.WaitAsync();
-                    var disconnectDetected = await SafeReadSensors(board, targetSamples, msBetweenReads, token);
-                    if (disconnectDetected || CheckFails(board, targetSamples))
+                    var stillConnected = await SafeReadSensors(board, targetSamples, msBetweenReads, token);
+                    if (!stillConnected || CheckFails(board, targetSamples))
                         await ReconnectBoard(board, targetSamples, token);
                 }
                 catch (TaskCanceledException ex)

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -407,15 +407,6 @@ namespace CA_DataUploaderLib
             public void SetAttemptingReconnectState(MCUBoard board) => SetState(board, ConnectionState.Connecting);
             public void SetDisconnectedState(MCUBoard board) => SetState(board, ConnectionState.Disconnected);
             public void SetConnectedState(MCUBoard board) => SetState(board, ConnectionState.Connected);
-            public void SetReadSensorsState(MCUBoard board, bool hadDataAvailable, bool receivedValues)
-            {
-                var newState = 
-                    receivedValues ? ConnectionState.ReceivingValues :
-                    hadDataAvailable ? ConnectionState.ReturningNonValues : 
-                    ConnectionState.NoDataAvailable;
-                SetState(board, newState);
-            }
-
             public void SetState(MCUBoard board, ConnectionState state) => _states[_boardsIndexes[board]] = state;
             private ConnectionState GetLastState(MCUBoard board) => _states[_boardsIndexes[board]];
 

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -181,11 +181,11 @@ namespace CA_DataUploaderLib
                         _allBoardsState.SetState(board, ConnectionState.ReceivingValues);
                     }
                     else if (!board.ConfigSettings.Parser.IsExpectedNonValuesLine(line))// mostly responses to commands or headers on reconnects.
-                        LogInfo(board, $"unexpected board response {line}");
+                        LogInfo(board, $"unexpected board response {line.Replace("\r", "\\r")}"); // we avoid \r as it makes the output hard to read
                 }
                 catch (Exception ex)
                 { //usually a parsing errors on non value data, we log it and consider it as such i.e. we finish reading available data and set ReturningNonValues if we did not get valid values
-                    LogError(board, $"failed handling board response {line}", ex);
+                    LogError(board, $"failed handling board response {line.Replace("\r", "\\r")}", ex); // we avoid \r as it makes the output hard to read
                 }
             }
             while (await board.SafeHasDataInReadBuffer(token) && timeInLoop.ElapsedMilliseconds < msBetweenReads);

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -25,6 +25,7 @@ namespace CA_DataUploaderLib
         protected readonly AllBoardsState _allBoardsState;
         private readonly string commandHelp;
         private readonly CancellationTokenSource _boardLoopsStopTokenSource = new CancellationTokenSource();
+        private readonly Dictionary<MCUBoard, SensorSample[]> _boardSamples;
 
         public BaseSensorBox(
             CommandHandler cmd, string commandName, string commandArgsHelp, string commandDescription, IEnumerable<IOconfInput> values)
@@ -263,6 +264,14 @@ namespace CA_DataUploaderLib
 
                 i++;
             }
+        }
+        public void ProcessLine(IEnumerable<double> numbers, MCUBoard board) => ProcessLine(numbers, board, GetSamples(board));
+        private SensorSample[] GetSamples(MCUBoard board)
+        {
+            if (_boardSamples.TryGetValue(board, out var samples))
+                return samples;
+            _boardSamples[board] = samples = _values.Where(s => s.Input.BoxName == board.BoxName).ToArray();
+            return samples;
         }
 
         private void HandleSaltLeakage(SensorSample sensor)

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -10,30 +10,27 @@ using System.Diagnostics;
 using CA_DataUploaderLib.Extensions;
 using System.Collections;
 using CA.LoopControlPluginBase;
+using System.Threading.Tasks;
 
 namespace CA_DataUploaderLib
 {
     public class BaseSensorBox : IDisposable, ISubsystemWithVectorData
     {
-        protected bool _running = true;
         public string Title { get; protected set; }
         /// <summary>runs when the subsystem is about to stop running, but before all boards are closed</summary>
         /// <remarks>some boards might be closed, specially if the system is stopping due to losing connection to one of the boards</remarks>
         public event EventHandler Stopping;
-        private readonly CALogLevel _logLevel;
         private readonly CommandHandler _cmd;
         protected readonly List<SensorSample> _values = new List<SensorSample>();
-        protected readonly List<MCUBoard> _boards = new List<MCUBoard>();
         protected readonly AllBoardsState _allBoardsState;
         private readonly string commandHelp;
-        private readonly HashSet<MCUBoard> _lostBoards = new HashSet<MCUBoard>();
+        private readonly CancellationTokenSource _boardLoopsStopTokenSource = new CancellationTokenSource();
 
         public BaseSensorBox(
             CommandHandler cmd, string commandName, string commandArgsHelp, string commandDescription, IEnumerable<IOconfInput> values)
         { 
             Title = commandName;
             _cmd = cmd;
-            _logLevel = IOconfFile.GetOutputLevel();
             _values = values.IsInitialized().Select(x => new SensorSample(x)).ToList();
             if (!_values.Any())
                 return;  // no data
@@ -47,16 +44,10 @@ namespace CA_DataUploaderLib
                 cmd.AddSubsystem(this);
             }
 
-            _boards = _values.Where(x => !x.Input.Skip).Select(x => x.Input.Map.Board).Distinct().ToList();
-            _allBoardsState = new AllBoardsState(_boards);
-
-            _running = true;
-            new Thread(() => LoopForever()).Start();
+            var boards = _values.Where(x => !x.Input.Skip).GroupBy(x => x.Input.Map.Board).Select(g => (board: g.Key, values: g.ToArray())).ToArray();
+            _allBoardsState = new AllBoardsState(boards.Select(b => b.board));
+            Task.Run(() => RunBoardReadLoops(boards));
         }
-
-        public SensorSample GetValueByTitle(string title) =>
-                _values.SingleOrDefault(x => x.Input.Name == title) ??
-                throw new Exception(title + " not found in _config. Known names: " + string.Join(", ", _values.Select(x => x.Input.Name)));
 
         public IEnumerable<SensorSample> GetInputValues() => _values
             .Select(s => s.Clone())
@@ -84,160 +75,185 @@ namespace CA_DataUploaderLib
 
         private double GetAvgLoopTime() => _values.Average(x => x.ReadSensor_LoopTime);
 
-        private static readonly Regex _startsWithDigitRegex = new Regex(@"^\s*(-|\d+)\s*");
-
-        protected void LoopForever()
+        private async Task RunBoardReadLoops((MCUBoard board, SensorSample[] values)[] boards)
         {
             DateTime start = DateTime.Now;
-            int badRow = 0;
-            // normally all boards have the same ms between reads, so for now just use the minimum value.
-            // we reach here without boxes when the values are all Skip (a.k.a don't use usb boards),
-            // such like rpi temps in the ThermocoupleBox and pressure/temperature of the oxygen sensors.
-            var msBetweenReads = _boards.Count > 0 ? _boards.Min(b => b.ConfigSettings.MillisecondsBetweenReads) : 1000; 
-
-            while (_running)
+            try
             {
-                Thread.Sleep(msBetweenReads);
-                try
-                {
-                    ReadSensors();
-                    CheckFails(); // check if any of the boards stopped responding. 
-                }
-                catch (Exception ex)
-                {
-                    CALog.LogInfoAndConsoleLn(LogID.A, ".", ex);
-                    if (badRow++ > 10)
-                    {
-                        CALog.LogErrorAndConsoleLn(LogID.A, "Too many bad rows from thermocouple ports.. shutting down:");
-                        _cmd?.Execute("escape");
-                        _running = false;
-                    }
-                }
+                var readLoops = StartReadLoops(boards, _boardLoopsStopTokenSource.Token);
+                await Task.WhenAll(readLoops);
+                CALog.LogInfoAndConsoleLn(LogID.A, $"Exiting {Title}.RunBoardReadLoops() " + DateTime.Now.Subtract(start).Humanize(5));
+            }
+            catch (Exception ex)
+            {
+                CALog.LogErrorAndConsoleLn(LogID.A, ex.ToString());
             }
 
             Stopping?.Invoke(this, EventArgs.Empty);
-            foreach (var board in _boards)
-            {
-                board?.SafeClose();
-                _allBoardsState.SetDisconnectedState(board);
-            }
-
-            CALog.LogInfoAndConsoleLn(LogID.A, $"Exiting {Title}.LoopForever() " + DateTime.Now.Subtract(start).Humanize(5));
-        }
-
-        protected virtual void ReadSensors()
-        {
-            foreach (var board in _boards)
+            foreach (var board in boards)
             {
                 try
                 {
-                    bool hadDataAvailable = false, receivedValues = false;
-                    var timeInLoop = Stopwatch.StartNew();
-                    // We read all lines available. We make sure to exit within 100ms, to allow reads to other boards
-                    // and to avoid being stuck when data with errors is continuously returned by the board.
-                    // We use time instead of attempts as SafeHasDataInReadBuffer can continuously report there is data when a partial line is returned by a board that stalls,
-                    // which then consistently times out in SafeReadLine, making each loop iteration 2 seconds.
-                    while (board.SafeHasDataInReadBuffer() && timeInLoop.ElapsedMilliseconds < 100)
-                    {
-                        hadDataAvailable = true;
-                        var line = board.SafeReadLine(); // tries to read a full line for up to MCUBoard.ReadTimeout
-                        try
-                        {
-                            var numbers = TryParseAsDoubleList(board, line);
-                            if (numbers != null)
-                            {
-                                ProcessLine(numbers, board);
-                                receivedValues = true;
-                            }
-                            else if (!board.ConfigSettings.Parser.IsExpectedNonValuesLine(line))// mostly responses to commands or headers on reconnects.
-                                CALog.LogInfoAndConsoleLn(LogID.B, "Unhandled board response " + board.ToString() + " line: " + line);
-                        }
-                        catch (Exception ex)
-                        {
-                            CALog.LogErrorAndConsoleLn(LogID.B, "Failed handling board response " + board.ToString() + " line: " + line, ex);
-                        }
-                    }
-
-                    _allBoardsState.SetReadSensorsState(board, hadDataAvailable, receivedValues);
-                    if (!hadDataAvailable) 
-                        // we expect data on every cycle (each 100 ms), as the boards normally write a line every 100 ms.
-                        CALog.LogData(LogID.B, "No data available for " + board.ToString());
+                    board.board?.SafeClose(CancellationToken.None);
+                    _allBoardsState.SetDisconnectedState(board.board);
                 }
-                catch
+                catch(Exception ex)
                 {
-                    _allBoardsState.SetReadSensorsExceptionState(board);
-                    throw;
+                    CALog.LogErrorAndConsoleLn(LogID.A, $"error closing the connection to board {board}", ex);
                 }
             }
+        }
+
+        protected virtual List<Task> StartReadLoops((MCUBoard board, SensorSample[] values)[] boards, CancellationToken token)
+        {
+            return boards
+                .Select(b => BoardLoop(b.board, b.values, token))
+                .ToList();
+        }
+
+        private async Task BoardLoop(MCUBoard board, SensorSample[] targetSamples, CancellationToken token)
+        {
+            var msBetweenReads = board.ConfigSettings.MillisecondsBetweenReads;
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(msBetweenReads, token);
+                    await SafeReadSensors(board, targetSamples, token); 
+                    if (CheckFails(board, targetSamples))
+                        await ReconnectBoard(board, targetSamples, token);
+                }
+                catch (TaskCanceledException ex)
+                {
+                    if (!token.IsCancellationRequested)
+                        CALog.LogErrorAndConsoleLn(LogID.A, ex.ToString());
+                }
+                catch (Exception ex)
+                { // we expect most errors to be handled within SafeReadSensors and in the SafeReopen of the ReconnectBoard,
+                  // so seeing this in the log is most likely a bug handling some error case.
+                    _allBoardsState.SetReadSensorsExceptionState(board);
+                    CALog.LogErrorAndConsoleLn(LogID.A, $"unhandled error for {Title}-{board}", ex);
+                }
+            }
+        }
+
+        private async Task SafeReadSensors(MCUBoard board, SensorSample[] targetSamples, CancellationToken token)
+        {
+            try
+            {
+                await ReadSensors(board, targetSamples, token);
+            }
+            catch (Exception ex)
+            { // seeing this is the log is not unexpected in cases where we have trouble communicating to a board.
+                _allBoardsState.SetReadSensorsExceptionState(board);
+                CALog.LogErrorAndConsoleLn(LogID.A, "error reading data from {Title}-{board}", ex);
+            }
+        }
+
+        private async Task ReadSensors(MCUBoard board, SensorSample[] targetSamples, CancellationToken token)
+        {
+            bool hadDataAvailable = false, receivedValues = false;
+            var timeInLoop = Stopwatch.StartNew();
+            // We read all lines available, but only those we can start within 100ms to avoid being stuck when data with errors is continuously returned by the board.
+            // We use time instead of attempts as SafeHasDataInReadBuffer can continuously report there is data when a partial line is returned by a board that stalls,
+            // which then consistently times out in SafeReadLine, making each loop iteration 2 seconds (the regular read timeout).
+            while (await board.SafeHasDataInReadBuffer(token) && timeInLoop.ElapsedMilliseconds < 100)
+            {
+                hadDataAvailable = true;
+                var line = await board.SafeReadLine(token); // tries to read a full line for up to MCUBoard.ReadTimeout
+                try
+                {
+                    var numbers = TryParseAsDoubleList(board, line);
+                    if (numbers != null)
+                    {
+                        ProcessLine(numbers, board, targetSamples);
+                        receivedValues = true;
+                    }
+                    else if (!board.ConfigSettings.Parser.IsExpectedNonValuesLine(line))// mostly responses to commands or headers on reconnects.
+                        CALog.LogInfoAndConsoleLn(LogID.B, $"Unexpected board response {board}: {line}");
+                }
+                catch (Exception ex)
+                {
+                    CALog.LogErrorAndConsoleLn(LogID.B, $"Failed handling board response {board}: " + line, ex);
+                }
+            }
+
+            _allBoardsState.SetReadSensorsState(board, hadDataAvailable, receivedValues);
+            if (!hadDataAvailable) 
+                // we expect data on every cycle (each 100 ms), as the boards normally write a line every 100 ms.
+                CALog.LogData(LogID.B, "No data available for " + board.ToString());
         }
 
         /// <returns>the list of doubles, otherwise <c>null</c></returns>
         protected virtual List<double> TryParseAsDoubleList(MCUBoard board, string line) => 
             board.ConfigSettings.Parser.TryParseAsDoubleList(line);
 
-        private void CheckFails()
+        private bool CheckFails(MCUBoard board, SensorSample[] values)
         {
-            // late initialization for these 2, avoiding instance when there are no failures
-            List<string> failedPorts = null;
-            HashSet<MCUBoard> lostConnectionBoards = null; 
-            foreach (var item in _values)
+            bool hasStaleValues = false;
+            foreach (var item in values)
             {
                 var msSinceLastRead = DateTime.UtcNow.Subtract(item.TimeStamp).TotalMilliseconds;
-                if (_lostBoards.Contains(item.Input.Map?.Board) || (lostConnectionBoards?.Contains(item.Input.Map?.Board) ?? false)) 
-                    continue; // ignore boards already reported as lost
-                var settings = item.Input.Map?.Board?.ConfigSettings ?? BoardSettings.Default;
-                if (msSinceLastRead <= settings.MaxMillisecondsWithoutNewValues || item.Input.Skip)
+                if (msSinceLastRead <= item.Input.Map.Board.ConfigSettings.MaxMillisecondsWithoutNewValues)
                     continue;
-                CALog.LogErrorAndConsoleLn(LogID.A, $"{Title} stale value detected for port: {item.Input.Name}{Environment.NewLine}{msSinceLastRead} milliseconds since last read - closing serial port to restablish connection");
-                if (item.Input.Map == null) continue;
-                var board = item.Input.Map.Board;
-                _allBoardsState.SetAttemptingReconnectState(board);
-                if (board.SafeReopen()) 
-                    continue;
-                _allBoardsState.SetDisconnectedState(board);
-                LateInit(ref lostConnectionBoards).Add(board);
-                LateInit(ref failedPorts).Add(item.Input.Name);
+                hasStaleValues = true; 
+                CALog.LogErrorAndConsoleLn(LogID.A, $"Stale sensor detected: {Title} - {item.Input.Name}. {msSinceLastRead} milliseconds since last read");
             }
 
-            if (lostConnectionBoards != null)
-                HandleLostConnectionToBoards(lostConnectionBoards, failedPorts);
+            return hasStaleValues;
         }
 
-        private void HandleLostConnectionToBoards(HashSet<MCUBoard> lostConnectionBoards, List<string> failedPorts)
+        private async Task ReconnectBoard(MCUBoard board, SensorSample[] targetSamples, CancellationToken token)
         {
-            var stopWhenLosingSensor = lostConnectionBoards.Any(b => b.ConfigSettings.StopWhenLosingSensor);
-            if (stopWhenLosingSensor)
+            _allBoardsState.SetAttemptingReconnectState(board);
+            CALog.LogInfoAndConsoleLn(LogID.A, $"Attempting to reconnect to {Title} - {board}");
+            var lostSensorAttempts = 100;
+            var delayBetweenAttempts = TimeSpan.FromSeconds(board.ConfigSettings.SecondsBetweenReopens);
+            while (!(await board.SafeReopen(token)))
             {
-                _cmd.Execute("escape");
-                _running = false;
-                CALog.LogErrorAndConsoleLn(LogID.A, $"Shutting down: {Title} unable to read from port: {string.Join(", ", failedPorts)}{Environment.NewLine}Reconnection limit exceeded");
-                return;
+                _allBoardsState.SetDisconnectedState(board);
+                if (ExactSensorAttemptsCheck(ref lostSensorAttempts)) 
+                { // we run this once when there has been 100 attempts
+                    var reconnecMsg = $"{Title} - {board}: reconnect limit exceeded, reducing reconnect frequency to 15 minutes";
+                    CALog.LogErrorAndConsoleLn(LogID.A, reconnecMsg);
+                    _cmd.FireAlert(reconnecMsg);
+                    delayBetweenAttempts = TimeSpan.FromMinutes(15); // 4 times x hour = 96 times x day
+                    if (board.ConfigSettings.StopWhenLosingSensor)
+                    {
+                        CALog.LogErrorAndConsoleLn(LogID.A, $"Emergency shutdown: {Title}-{board} reconnect limit exceeded");
+                        _cmd.Execute("emergencyshutdown");
+                    }
+                }
+
+                await Task.Delay(delayBetweenAttempts, token);
             }
 
-            var lostBoardsNames = string.Join(Environment.NewLine, lostConnectionBoards);
-            CALog.LogErrorAndConsoleLn(LogID.A, $"{Title}: reconnect limit exceeded, these boards will be ignored: {Environment.NewLine}{lostBoardsNames}");
-            _boards.RemoveAll(lostConnectionBoards.Contains);
-            _lostBoards.UnionWith(lostConnectionBoards);
-            foreach (var board in lostConnectionBoards)
-            {
-                try { board.Dispose(); }
-                catch (Exception e) { CALog.LogException(LogID.A, e); }
-            }
+            _allBoardsState.SetConnectedState(board);
+            CALog.LogInfoAndConsoleLn(LogID.A, $"{Title} - {board}: board reconnection succeeded.");
+        }
+
+        private bool ExactSensorAttemptsCheck(ref int lostSensorAttempts)
+        {
+             if (lostSensorAttempts > 0)
+                lostSensorAttempts--;
+            else if (lostSensorAttempts == 0) 
+                return true;
+            return false;
         }
 
         protected bool Stop(List<string> args)
         {
-            _running = false;
+            _boardLoopsStopTokenSource.Cancel();
             return true;
         }
 
-        public virtual void ProcessLine(IEnumerable<double> numbers, MCUBoard board)
+        public virtual void ProcessLine(IEnumerable<double> numbers, MCUBoard board, SensorSample[] targetSamples)
         {
             int i = 1;
             var timestamp = DateTime.UtcNow;
             foreach (var value in numbers)
             {
-                var sensor = _values.SingleOrDefault(x => x.Input.BoxName == board.BoxName && x.Input.PortNumber == i);
+                var sensor = targetSamples.SingleOrDefault(x => x.Input.PortNumber == i);
                 if (sensor != null)
                 {
                     sensor.Value = value;
@@ -249,9 +265,6 @@ namespace CA_DataUploaderLib
             }
         }
 
-        private T LateInit<T>(ref T value) where T : new()
-            => value = value ?? new T();
-
         private void HandleSaltLeakage(SensorSample sensor)
         {
             if (sensor.GetType() == typeof(IOconfSaltLeakage))
@@ -261,7 +274,7 @@ namespace CA_DataUploaderLib
                     CALog.LogErrorAndConsoleLn(LogID.A, $"Salt leak detected from {sensor.Input.Name}={sensor.Value} {DateTime.Now:dd-MMM-yyyy HH:mm}");
                     sensor.Value = 1d;
                     if (_cmd != null)
-                        _cmd.Execute("escape"); // make the whole system shut down. 
+                        _cmd.Execute("emergencyshutdown"); // make the whole system shut down. 
                 }
                 else
                 {
@@ -276,7 +289,7 @@ namespace CA_DataUploaderLib
             return true;
         }
 
-        protected virtual void Dispose(bool disposing) => _running = false;
+        protected virtual void Dispose(bool disposing) => _boardLoopsStopTokenSource.Cancel();
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method. See https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose#dispose-and-disposebool
@@ -302,6 +315,7 @@ namespace CA_DataUploaderLib
                 {
                     _sensorNames[i] = _boards[i].BoxName + "_state";
                     _boardsIndexes[_boards[i]] = i;
+                    _states[i] = ConnectionState.Connected;
                 }
             }
 
@@ -314,11 +328,12 @@ namespace CA_DataUploaderLib
             public void SetReadSensorsExceptionState(MCUBoard board) => SetState(board, ConnectionState.ReadError);
             public void SetAttemptingReconnectState(MCUBoard board) => SetState(board, ConnectionState.Connecting);
             public void SetDisconnectedState(MCUBoard board) => SetState(board, ConnectionState.Disconnected);
+            public void SetConnectedState(MCUBoard board) => SetState(board, ConnectionState.Connected);
             public void SetReadSensorsState(MCUBoard board, bool hadDataAvailable, bool receivedValues)
             {
                 var lastState = GetLastState(board);
                 var newState = 
-                    receivedValues ? ConnectionState.Connected :
+                    receivedValues ? ConnectionState.ReceivingValues :
                     hadDataAvailable && lastState == ConnectionState.Connecting ? ConnectionState.Connecting :
                     hadDataAvailable ? ConnectionState.ReturningNonValues : 
                     ConnectionState.NoDataAvailable;
@@ -336,10 +351,11 @@ namespace CA_DataUploaderLib
         {
             Disconnected = 0,
             Connecting = 1,
-            ReadError = 2,
-            NoDataAvailable = 3,
-            ReturningNonValues = 4, // we are getting data from the box, but these are not values lines
-            Connected = 5,
+            Connected = 2,
+            ReadError = 3,
+            NoDataAvailable = 4,
+            ReturningNonValues = 5, // we are getting data from the box, but these are not values lines
+            ReceivingValues = 6
         }
     }
 }

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -25,7 +25,7 @@ namespace CA_DataUploaderLib
         protected readonly AllBoardsState _allBoardsState;
         private readonly string commandHelp;
         private readonly CancellationTokenSource _boardLoopsStopTokenSource = new CancellationTokenSource();
-        private readonly Dictionary<MCUBoard, SensorSample[]> _boardSamples;
+        private readonly Dictionary<MCUBoard, SensorSample[]> _boardSamplesLookup = new Dictionary<MCUBoard, SensorSample[]>();
 
         public BaseSensorBox(
             CommandHandler cmd, string commandName, string commandArgsHelp, string commandDescription, IEnumerable<IOconfInput> values)
@@ -268,9 +268,9 @@ namespace CA_DataUploaderLib
         public void ProcessLine(IEnumerable<double> numbers, MCUBoard board) => ProcessLine(numbers, board, GetSamples(board));
         private SensorSample[] GetSamples(MCUBoard board)
         {
-            if (_boardSamples.TryGetValue(board, out var samples))
+            if (_boardSamplesLookup.TryGetValue(board, out var samples))
                 return samples;
-            _boardSamples[board] = samples = _values.Where(s => s.Input.BoxName == board.BoxName).ToArray();
+            _boardSamplesLookup[board] = samples = _values.Where(s => s.Input.BoxName == board.BoxName).ToArray();
             return samples;
         }
 

--- a/CA_DataUploaderLib/CALog.cs
+++ b/CA_DataUploaderLib/CALog.cs
@@ -77,6 +77,12 @@ namespace CA_DataUploaderLib
             WriteToFile(logID, error + Environment.NewLine + ex.ToString() + Environment.NewLine);
         }
 
+        public static void LogError(LogID logID, string error, Exception ex)
+        {
+            error = DateTime.UtcNow.ToString("MM.dd HH:mm:ss.fff - ") + error;
+            WriteToFile(logID, error + Environment.NewLine + ex.ToString() + Environment.NewLine);
+        }
+
         private static void WriteToFile(LogID logID, string msg)
         {
             try

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -25,6 +25,7 @@ namespace CA_DataUploaderLib
         private Lazy<VectorFilterAndMath> _fullsystemFilterAndMath;
 
         public event EventHandler<NewVectorReceivedArgs> NewVectorReceived;
+        public event EventHandler<AlertFiredArgs> AlertFired;
         public bool IsRunning { get { return _running; } }
 
         public CommandHandler(SerialNumberMapper mapper = null)
@@ -99,6 +100,10 @@ namespace CA_DataUploaderLib
         public void OnNewVectorReceived(IEnumerable<SensorSample> vector) =>
             NewVectorReceived?.Invoke(this, new NewVectorReceivedArgs(vector.ToDictionary(v => v.Name, v => v.Value)));
         
+        public void FireAlert(string msg)
+        {
+            AlertFired?.Invoke(this, new AlertFiredArgs(msg));
+        }
         private bool Stop(List<string> args)
         {
             _running = false;

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -66,9 +66,9 @@ namespace CA_DataUploaderLib
         public void Dispose()
         { // class is sealed without unmanaged resources, no need for the full disposable pattern.
             if (_disposed) return;
-            _switchboardController.Dispose();
-            _ovenCmd.Dispose();
-            _heaterCmd.Dispose();
+            _switchboardController?.Dispose();
+            _ovenCmd?.Dispose();
+            _heaterCmd?.Dispose();
             _disposed = true;
         }
  

--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -22,12 +22,12 @@ namespace CA_DataUploaderLib.IOconf
         public class LineParser
         {
             public static LineParser Default { get; } = new LineParser();
-            private static readonly Regex _startsWithDigitRegex = new Regex(@"^\s*(-|\d+)\s*");
+            private static readonly Regex _hasCommaSeparatedNumbers = new Regex(@"^\s*-?(?:[0-9]*[.])?[0-9]+\s*(?:,\s*(?:[0-9]*[.])?[0-9]+\s*)*,?\s*$");
 
             /// <returns>the list of doubles, or null when the line did not match the expected format</returns>
             public virtual List<double> TryParseAsDoubleList(string line)
             {
-                if (!_startsWithDigitRegex.IsMatch(line))
+                if (!_hasCommaSeparatedNumbers.IsMatch(line))
                     return null;
 
                 return line.Split(",".ToCharArray())
@@ -37,7 +37,7 @@ namespace CA_DataUploaderLib.IOconf
                     .ToList();
             }
 
-            public virtual bool MatchesValuesFormat(string line) => _startsWithDigitRegex.IsMatch(line);
+            public virtual bool MatchesValuesFormat(string line) => _hasCommaSeparatedNumbers.IsMatch(line);
 
             public virtual bool IsExpectedNonValuesLine(string line) => false;
         }

--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -22,7 +22,7 @@ namespace CA_DataUploaderLib.IOconf
         public class LineParser
         {
             public static LineParser Default { get; } = new LineParser();
-            private static readonly Regex _hasCommaSeparatedNumbers = new Regex(@"^\s*-?(?:[0-9]*[.])?[0-9]+\s*(?:,\s*(?:[0-9]*[.])?[0-9]+\s*)*,?\s*$");
+            private static readonly Regex _hasCommaSeparatedNumbers = new Regex(@"^\s*-?(?:[0-9]*[.])?[0-9]+\s*(?:,\s*-?(?:[0-9]*[.])?[0-9]+\s*)*,?\s*$");
 
             /// <returns>the list of doubles, or null when the line did not match the expected format</returns>
             public virtual List<double> TryParseAsDoubleList(string line)

--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -14,7 +14,7 @@ namespace CA_DataUploaderLib.IOconf
         public int ExpectedHeaderLines { get; set; } = 8;
         public int MaxMillisecondsWithoutNewValues { get; set; } = 2000;
         public int SecondsBetweenReopens { get; set; } = 3;
-        public bool StopWhenLosingSensor { get; set; } = true;
+        public bool StopWhenLosingSensor { get; set; } = false;
         public bool SkipBoardAutoDetection { get; set; } = false;
         public LineParser Parser { get; set; } = LineParser.Default;
         public string ValuesEndOfLineChar { get; set; } = "\n";

--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -28,6 +28,7 @@ namespace CA_DataUploaderLib.IOconf
             if (parseBoxName) 
             {
                 BoxName = list[2];
+                BoardStateSensorName = BoxName + "_state"; // this must match the state sensor names returned by BaseSensorBox
                 SetMap(BoxName, boardSettings, Skip) ;
             }
         }
@@ -36,6 +37,7 @@ namespace CA_DataUploaderLib.IOconf
         public string Name { get; set; }
         public string BoxName { get; set; }
         /// <summary>the 1-based port number</summary>
+        public string BoardStateSensorName { get; } 
         public int PortNumber = 1;
         public bool Skip { get; set; }
         public IOconfMap Map { get; set; }

--- a/CA_DataUploaderLib/IOconf/IOconfMath.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMath.cs
@@ -37,5 +37,34 @@ namespace CA_DataUploaderLib.IOconf
             // note that some expression may even return different values depending on the branch hit i.e. when using if(...)
             return new SensorSample(this, Convert.ToDouble(expression.Evaluate())) { TimeStamp = DateTime.UtcNow };
         }
+
+        public List<string> GetSources() 
+        {
+            HashSet<string> parameters = new HashSet<string>();
+            expression.EvaluateFunction += EvalFunction; 
+            expression.EvaluateParameter += EvalParameter;
+            try
+            {
+                expression.Evaluate();              
+            }
+            finally
+            {
+                expression.EvaluateFunction -= EvalFunction; 
+                expression.EvaluateParameter -= EvalParameter;
+            }
+            return new List<string>(parameters);
+
+            void EvalFunction(string name, NCalc.FunctionArgs args) 
+            {
+                args.EvaluateParameters();
+                args.Result = 1;
+            };
+
+            void EvalParameter(string name, NCalc.ParameterArgs args) 
+            {
+                parameters.Add(name);
+                args.Result = 1;
+            };
+        }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfOven.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOven.cs
@@ -32,12 +32,14 @@ namespace CA_DataUploaderLib.IOconf
                 if (TypeKs.Count == 0)
                     throw new Exception($"Failed to find temperature sensor {TemperatureSensorName} for oven");
             }
+            BoardStateSensorNames = TypeKs.Select(k => k.BoardStateSensorName).ToList().AsReadOnly();
         }
 
         public int OvenArea;
         public IOconfHeater HeatingElement;
         public bool IsTemperatureSensorInitialized => TypeKs.All(k => k.IsInitialized());
         public string TemperatureSensorName { get; }
+        public IReadOnlyCollection<string> BoardStateSensorNames {get;}
         private readonly List<IOconfTypeK> TypeKs;
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOxygen.cs
@@ -16,7 +16,6 @@ namespace CA_DataUploaderLib.IOconf
                 MaxMillisecondsWithoutNewValues = 10000,
                 MillisecondsBetweenReads = 1200,
                 SecondsBetweenReopens = 10,
-                StopWhenLosingSensor = false,
                 Parser = LineParser.Default
             })
         {

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -142,15 +142,10 @@ namespace CA_DataUploaderLib
             }
         }
 
-        public string ToDebugString(string seperator)
-        {
-            return $"{BoxNameHeader}{BoxName}{seperator}Port name: {PortName}{seperator}Baud rate: {BaudRate}{seperator}{serialNumberHeader}{serialNumber}{seperator}{productTypeHeader}{productType}{seperator}{pcbVersionHeader}{pcbVersion}{seperator}{softwareVersionHeader}{softwareVersion}{seperator}";
-        }
-
-        public override string ToString()
-        {
-            return $"{productTypeHeader}{productType,-20} {serialNumberHeader}{serialNumber,-12} Port name: {PortName}";
-        }
+        public string ToDebugString(string seperator) => 
+            $"{BoxNameHeader}{BoxName}{seperator}Port name: {PortName}{seperator}Baud rate: {BaudRate}{seperator}{serialNumberHeader}{serialNumber}{seperator}{productTypeHeader}{productType}{seperator}{pcbVersionHeader}{pcbVersion}{seperator}{softwareVersionHeader}{softwareVersion}{seperator}";
+        public override string ToString() => $"{productTypeHeader}{productType,-20} {serialNumberHeader}{serialNumber,-12} Port name: {PortName}";
+        public string ToShortDescription() => $"{BoxName} {productType} {serialNumber} {PortName}";
 
         /// <summary>
         /// Reopens the connection skipping the header.

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -109,7 +109,7 @@ namespace CA_DataUploaderLib
 
         }
 
-        public bool IsEmpty()
+        private bool IsEmpty()
         {
             // pcbVersion is included in this list because at the time of writting is the last value in the readEEPROM header, 
             // which avoids the rest of the header being treated as "values".
@@ -141,11 +141,6 @@ namespace CA_DataUploaderLib
         public override string ToString()
         {
             return $"{productTypeHeader}{productType,-20} {serialNumberHeader}{serialNumber,-12} Port name: {PortName}";
-        }
-
-        public string ToStringSimple(string seperator)
-        {
-            return $"{PortName}{seperator}{serialNumber}{seperator}{productType}";
         }
 
         /// <summary>
@@ -205,6 +200,7 @@ namespace CA_DataUploaderLib
                     LogID.B, 
                     $"Failure reopening port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header lines '{string.Join("§",lines)}'",
                     ex);
+                return true;
             }
 
             CALog.LogData(LogID.B, $"Reopened port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header lines '{string.Join("§", lines)}'");
@@ -350,14 +346,14 @@ namespace CA_DataUploaderLib
                     if (IsOpen)
                         return action();
 
-                    Thread.Sleep(100);
-                    Open();
+                    // Thread.Sleep(100);
+                    // Open();
 
-                    if (IsOpen)
-                        return action();
+                    // if (IsOpen)
+                    //     return action();
                 }
 
-                CALog.LogErrorAndConsoleLn(LogID.A, $"Failed to open port to {actionName}(): {PortName} {productType} {serialNumber}{Environment.NewLine}");
+                CALog.LogErrorAndConsoleLn(LogID.A, $"Unable to {actionName}() - port closed: {PortName} {productType} {serialNumber}{Environment.NewLine}");
             }
             catch (Exception ex)
             {

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -188,7 +188,7 @@ namespace CA_DataUploaderLib
             }
             catch (Exception ex)
             {
-                CALog.LogErrorAndConsoleLn(
+                CALog.LogError(
                     LogID.B, 
                     $"Failure reopening port {PortName} {productType} {serialNumber} - {bytesToRead500ms} bytes in read buffer.{Environment.NewLine}Skipped header lines '{string.Join("§",lines)}'",
                     ex);

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -48,6 +48,8 @@ namespace CA_DataUploaderLib
                 new Thread(() => this.LoopForever()).Start();
                 _cmd = cmd;
                 cmd?.AddCommand("escape", Stop);
+                if (cmd != null)
+                    cmd.AlertFired += SendAlert;
             }
             catch (Exception ex)
             {
@@ -56,6 +58,7 @@ namespace CA_DataUploaderLib
             }
         }
 
+        private void SendAlert(object sender, AlertFiredArgs e) => SendAlert(e.Message);
         internal void SendAlert(string message)
         {
             lock (_alertQueue)

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -59,13 +59,18 @@ namespace CA_DataUploaderLib
         private async Task BoardLoop(MCUBoard board, List<IOconfOut230Vac> ports, CancellationToken token)
         {
             var lastActions = new SwitchboardAction[ports.Count];
+            var boardStateName = board.BoxName + "_state";
+            var waitingBoardReconnect = false;
             while (!token.IsCancellationRequested)
             {
                 try
                 {
                     var vector = await _cmd.When(_ => true, token);
+                    if (!CheckConnectedStateInVector(board, boardStateName, waitingBoardReconnect, vector)) 
+                        continue; // no point trying to send commands while there is no connection to the board.
+
                     foreach (var port in ports)
-                        DoPortActions(vector, board, port, lastActions, token);
+                        await DoPortActions(vector, board, port, lastActions, token);
                 }
                 catch (TaskCanceledException ex)
                 {
@@ -79,6 +84,16 @@ namespace CA_DataUploaderLib
             }
             
             AllOff(board, ports);
+        }
+
+        private static bool CheckConnectedStateInVector(MCUBoard board, string boardStateName, bool waitingBoardReconnect, NewVectorReceivedArgs vector)
+        {
+            var connected = (BaseSensorBox.ConnectionState)(int)vector[boardStateName] >= BaseSensorBox.ConnectionState.Connected;
+            if (waitingBoardReconnect && connected)
+                CALog.LogErrorAndConsoleLn(LogID.A, $"resuming switchboard actions after reconnect on {board}");
+            else if (!waitingBoardReconnect && !connected)
+                CALog.LogErrorAndConsoleLn(LogID.A, $"stopping switchboard actions while connection is reestablished on {board}");
+            return connected;
         }
 
         private async Task RunBoardControlLoops(List<IOconfOut230Vac> ports)
@@ -103,7 +118,7 @@ namespace CA_DataUploaderLib
             }
         }
         
-        private void DoPortActions(NewVectorReceivedArgs vector, MCUBoard board, IOconfOut230Vac port, SwitchboardAction[] lastActions, CancellationToken token)
+        private async Task DoPortActions(NewVectorReceivedArgs vector, MCUBoard board, IOconfOut230Vac port, SwitchboardAction[] lastActions, CancellationToken token)
         {
             if (token.IsCancellationRequested)
                 return;
@@ -115,11 +130,11 @@ namespace CA_DataUploaderLib
                 
                 var onSeconds = action.GetRemainingOnSeconds(vector.GetVectorTime());
                 if (onSeconds <= 0)
-                    board.SafeWriteLine($"p{port.PortNumber} off");
+                    await board.SafeWriteLine($"p{port.PortNumber} off", token);
                 else if (onSeconds == int.MaxValue)
-                    board.SafeWriteLine($"p{port.PortNumber} on");
+                    await board.SafeWriteLine($"p{port.PortNumber} on", token);
                 else
-                    board.SafeWriteLine($"p{port.PortNumber} on {onSeconds}");
+                    await board.SafeWriteLine($"p{port.PortNumber} on {onSeconds}", token);
                 lastActions[port.PortNumber - 1] = action;
             }
             catch (Exception)
@@ -133,10 +148,10 @@ namespace CA_DataUploaderLib
         {
             try
             {
-                board.SafeWriteLine("off"); 
+                board.SafeWriteLine("off", CancellationToken.None); 
                 foreach (var port in ports)
                     if (port.HasOnSafeState)
-                        board.SafeWriteLine($"p{port.PortNumber} on");
+                        board.SafeWriteLine($"p{port.PortNumber} on", CancellationToken.None);
             }
             catch (Exception ex)
             {

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -66,7 +66,7 @@ namespace CA_DataUploaderLib
                 try
                 {
                     var vector = await _cmd.When(_ => true, token);
-                    if (!CheckConnectedStateInVector(board, boardStateName, waitingBoardReconnect, vector)) 
+                    if (!CheckConnectedStateInVector(board, boardStateName, ref waitingBoardReconnect, vector)) 
                         continue; // no point trying to send commands while there is no connection to the board.
 
                     foreach (var port in ports)
@@ -86,13 +86,16 @@ namespace CA_DataUploaderLib
             AllOff(board, ports);
         }
 
-        private static bool CheckConnectedStateInVector(MCUBoard board, string boardStateName, bool waitingBoardReconnect, NewVectorReceivedArgs vector)
+        private static bool CheckConnectedStateInVector(MCUBoard board, string boardStateName, ref bool waitingBoardReconnect, NewVectorReceivedArgs vector)
         {
             var connected = (BaseSensorBox.ConnectionState)(int)vector[boardStateName] >= BaseSensorBox.ConnectionState.Connected;
             if (waitingBoardReconnect && connected)
-                CALog.LogErrorAndConsoleLn(LogID.A, $"resuming switchboard actions after reconnect on {board}");
+                CALog.LogInfoAndConsoleLn(LogID.A, $"resuming switchboard actions after reconnect on {board}");
             else if (!waitingBoardReconnect && !connected)
-                CALog.LogErrorAndConsoleLn(LogID.A, $"stopping switchboard actions while connection is reestablished on {board}");
+            {
+                CALog.LogInfoAndConsoleLn(LogID.A, $"stopping switchboard actions while connection is reestablished on {board}");
+                waitingBoardReconnect = true;
+            }
             return connected;
         }
 

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -90,7 +90,10 @@ namespace CA_DataUploaderLib
         {
             var connected = (BaseSensorBox.ConnectionState)(int)vector[boardStateName] >= BaseSensorBox.ConnectionState.Connected;
             if (waitingBoardReconnect && connected)
+            {
                 CALog.LogInfoAndConsoleLn(LogID.A, $"resuming switchboard actions after reconnect on {board}");
+                waitingBoardReconnect = false;
+            }
             else if (!waitingBoardReconnect && !connected)
             {
                 CALog.LogInfoAndConsoleLn(LogID.A, $"stopping switchboard actions while connection is reestablished on {board}");

--- a/CA_DataUploaderLib/TimeThrottle.cs
+++ b/CA_DataUploaderLib/TimeThrottle.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CA_DataUploaderLib
+{
+    ///<summary>Throttle calls to mantain a given frequency</summary>
+    public class TimeThrottle
+    {
+        private Stopwatch _watch = Stopwatch.StartNew();
+        private long _nextTriggerElapsedMilliseconds;
+        private readonly int _milliseconds;
+
+        ///<param name="milliseconds">this is how many milliseconds it will attempt to keep between each call</param>
+        public TimeThrottle(int milliseconds)
+        {
+            _milliseconds = milliseconds;
+        }
+
+        public Task WaitAsync() => Task.Delay(GetWaitMilliseconds());
+        public void Wait() => Thread.Sleep(GetWaitMilliseconds());
+
+        private int GetWaitMilliseconds()
+        {
+            _nextTriggerElapsedMilliseconds += _milliseconds;
+            return (int)Math.Max(0, _nextTriggerElapsedMilliseconds - _watch.ElapsedMilliseconds);
+        }
+    }
+}

--- a/UnitTests/DefaultResponseParserTests.cs
+++ b/UnitTests/DefaultResponseParserTests.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CA_DataUploaderLib.IOconf;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class DefaultResponseParserTests
+    {
+        [TestMethod]
+        public void PressureLineIsParsed()
+        {
+            string testString = "0.00, 0.05, -1.80, -1.80, -1.80, -1.78\r";
+            var values = BoardSettings.Default.Parser.TryParseAsDoubleList(testString);
+            Assert.IsNotNull(values);
+            CollectionAssert.AreEqual(new [] {0d, 0.05, -1.8, -1.8, -1.8, -1.78}, values);
+        }
+    }
+}

--- a/UnitTests/HeaterElementTests.cs
+++ b/UnitTests/HeaterElementTests.cs
@@ -13,7 +13,8 @@ namespace UnitTests
         private HeaterElementConfigBuilder NewConfig => new HeaterElementConfigBuilder();
         private Dictionary<string, double> NewVectorSamples => new Dictionary<string, double>
         {
-            {"box_state", (int)BaseSensorBox.ConnectionState.Connected},
+            {"box_state", (int)BaseSensorBox.ConnectionState.ReceivingValues},
+            {"temperature_state", (int)BaseSensorBox.ConnectionState.ReceivingValues},
             {"heater_current", 0.1},
             {"temp", 44},
             {"heater_switchon", 0},
@@ -69,13 +70,84 @@ namespace UnitTests
             Assert.AreEqual(true, action.IsOn);
         }
 
+        [TestMethod, Description("avoiding making action changes when we don't have connection to the switchboard anyway")]
+        //Note that the switchboard controller would ignore the action regardless of what we send due to the disconnect.
+        //However, having the decision logic explicitely indicate there is no action change better reflects the situation.
+        public void DisconnectedSwitchBoardDoesNotChangeCurrentAction()
+        { 
+            var element = new HeaterElement(NewConfig.Build());
+            element.SetTargetTemperature(45);
+            NewVectorReceivedArgs vector = new NewVectorReceivedArgs(NewVectorSamples);
+            var firstAction = element.MakeNextActionDecision(vector);
+            var newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(10).ToVectorDouble();
+            newSamples["box_state"] = (int)BaseSensorBox.ConnectionState.Connecting;
+            var newAction = element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            Assert.AreEqual(firstAction, newAction);
+        }
+
+        [TestMethod]
+        public void DisconnectedTemperatureLessThan2SecondsKeepsExistingAction()
+        { 
+            var element = new HeaterElement(NewConfig.Build());
+            element.SetTargetTemperature(45);
+            NewVectorReceivedArgs vector = new NewVectorReceivedArgs(NewVectorSamples);
+            var firstAction = element.MakeNextActionDecision(vector);
+            var newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(1).ToVectorDouble();
+            newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.Connecting;
+            var newAction = element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            Assert.AreEqual(firstAction, newAction);
+        }
+
+        [TestMethod]
+        public void ReconnectedUnderTargetTemperatureKeepsOnAction()
+        { 
+            var element = new HeaterElement(NewConfig.Build());
+            element.SetTargetTemperature(45);
+            NewVectorReceivedArgs vector = new NewVectorReceivedArgs(NewVectorSamples);
+            var firstAction = element.MakeNextActionDecision(vector);
+            var newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(1).ToVectorDouble();
+            newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.Connecting;
+            element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(3).ToVectorDouble();
+            newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.ReceivingValues;
+            var newAction = element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            Assert.IsTrue(newAction.IsOn); 
+            Assert.AreEqual(firstAction, newAction);
+        }
+
+        [TestMethod]
+        public void ReconnectedOverTargetTemperatureTurnsOff()
+        { 
+            var element = new HeaterElement(NewConfig.Build());
+            element.SetTargetTemperature(45);
+            NewVectorReceivedArgs vector = new NewVectorReceivedArgs(NewVectorSamples);
+            var firstAction = element.MakeNextActionDecision(vector);
+            var newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(1).ToVectorDouble();
+            newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.Connecting;
+            var disconnectedAction = element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(3).ToVectorDouble();
+            newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.ReceivingValues;
+            newSamples["temp"] = 46;
+            var newAction = element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            Assert.IsFalse(newAction.IsOn);
+            Assert.AreEqual(firstAction, disconnectedAction, "initial and disconnected action unexpectedly were different");
+            Assert.AreNotEqual(disconnectedAction, newAction, "initial and disconnected action unexpectedly were the same");
+        }
+
         private class HeaterElementConfigBuilder
         {
             public HeaterElement.Config Build() =>
                 new HeaterElement.Config
                 {
                     Area = 0,
-                    BoardStateSensorName = "box_state",
+                    SwitchBoardStateSensorName = "box_state",
+                    TemperatureBoardStateSensorNames = new List<string>{ "temperature_state" },
                     CurrentSensingNoiseTreshold = 0.5,
                     CurrentSensorName = "heater_current",
                     MaxTemperature = 800,

--- a/UnitTests/IOconfMathTests.cs
+++ b/UnitTests/IOconfMathTests.cs
@@ -52,5 +52,22 @@ namespace UnitTests
             Assert.AreEqual("IOconfMath: wrong format - expression: Math;MyName;MyValue + 123,222", ex.Message);
         }
 
+        [DataRow("Math;MyName;MyValue + 123", "MyValue")]
+        [DataRow("Math;MyName;2 / MyValue", "MyValue")]
+        [DataRow("Math;MyName;Sin(MyValue*PI/180)", "MyValue,PI")]//note PI is not predefined so it is also an argument
+        [DataRow("Math;MyName;Round(MyValue % 1, 4)", "MyValue")]
+        [DataRow("Math;MyName;Round(Abs(MyValue % 1), 4)", "MyValue")]
+        [DataRow("Math;MyName;Max(MyValue, 124)", "MyValue")]
+        [DataRow("Math;MyName;Truncate(MyValue)", "MyValue")]
+        [DataRow("Math;MyName;if(MyValue > 120,MyValue,2)", "MyValue")]
+        [DataRow("Math;MyName;Abs(MyValue % 1)", "MyValue")]
+        [DataRow("Math;MyName;Sqrt(MyValue)", "MyValue")]
+        [DataRow("Math;MyName;10/(MyValue - 1)", "MyValue")]//because GetSources replaces MyValue with 1 while processing the expression, this test case checks a division by 0 does not prevent getting sources
+        [DataTestMethod]
+        public void CanParseSources(string row, string expectedSources) 
+        {
+            var math = new IOconfMath(row, 0);
+            Assert.AreEqual(expectedSources, string.Join(',', math.GetSources()));
+        }
     }
 }

--- a/UnitTests/SerialPortTests.cs
+++ b/UnitTests/SerialPortTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CA_DataUploaderLib;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace UnitTests
 {
@@ -8,7 +10,7 @@ namespace UnitTests
     public class SerialPortTests
     {
         [TestMethod]
-        public void Scale()
+        public async Task Scale()
         {
             //Set the scale in RS232 mode by holding MODE until display show Prt, then press TARA. 
             //Then press MODE until you see 'Cont in', then press TARA. Then connect to COM port with 9600 baud.
@@ -21,7 +23,7 @@ namespace UnitTests
                 string str = string.Empty;
                 foreach(var scale in list)
                 {
-                    str += scale.SafeReadLine().Replace("\r", "      ");
+                    str += (await scale.SafeReadLine(CancellationToken.None)).Replace("\r", "      ");
                 }
 
                 Debug.Print(str);


### PR DESCRIPTION
Breaking Change: 
- plugins must now take into account the system will not auto shutdown when losing temperature/heater boards. So in applications where a minimum temperature must be mantained the plugin can set alerts with emergency shutdown with the minimum operating temperature. If no emergency shutdown is desired, the plugin can track the temperature directly and do corresponding actions. When doing so, the temperature boards connection state must be taken into account in order to react appropiately when losing a connection board (which in the absence of temperature/heater redundancy would cause the temperature to drop).

Changes:
- loop now sends an alert instead of stopping the program on recurrent errors reaching a box i.e. could not recover connection to a board. This  happens if 5+ mins pass without being able to reach the box (100 attempts every 3 seconds). After this, it always continues trying to reconnect but approx. 4 times x hour (96 x day).
- oven decision logic now treats disconnected temperature boards like we do the 10k errors, which means it postpones making decision changes for up to 2 seconds, after which it turns off the heater until we get valid reads again.
- fixed unexpected extra switching time regression by avoiding reads blocking writes to the same board (which meant waiting for the next current print cycle to be done before acting). Note switching time is still delayed due to vector based decision, but that much is expected by design.
- recurrent reconnects now report the board states 0 (disconnected) and 1 (connecting). For this the receiving data (fully connected) state is now 6, while the initial connection gives the state 2 (connected).
- improved sensor independence across boards of the same type (unrelated read loops)
- rpi temperatures read loops no longer affect the thermocouples read loops
- more controlled reconnect attempts that avoids writing/reading while the reconnects and excessive messages caused by it.
- safe valves conf can now return all the board states names used for the sensor so that decision logic can detect the sensor boxes disconnects
- reduced amount of messages in the display when we lose connection to a box and attempt to reconnect
- fixed: states report boards one off no data reads states every few mins (which can unnecesarily affect decision logic). The fix also avoids the up to 2 second delay the existing implementation had in some cases before reporting no data is coming back. Also added early detection of hard disconnects in cases where the API was explicit about it, entering the improved reconnect logic right away.
- improved some of the errors messages by moving the board info to the end (making the relevant text more visible)
- improved incorrectly formatted lines detection, which avoids unnecesary exceptions being logged when broken lines are returned by temp hubs on reconnects