### PR TITLE
Attempt at fixing log spamming due to time out writing to switchboards

### DIFF
--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -208,6 +208,7 @@ namespace CA_DataUploaderLib
         { 
             if (IsOn || vectorTime < LastOff.AddSeconds(5) || !CurrentIsOn(current)) return false;
             LogRepeatCommand("off", temp, current, switchboardOnOffState);
+            LastOff = vectorTime;
             return true;
         }
         private bool CurrentIsOn(double current) => current > _config.CurrentSensingNoiseTreshold;


### PR DESCRIPTION
- reduced write frequency when time outs writing to switch boards are observed, to give extra time of read loop to notice and recover connection
- avoid repeat off on every cycle after the 5 seconds check when there is no current