### PR TITLE
alerts no longer trigger on temporary thermocouples disconnects / 10k values

### DIFF
--- a/CA_DataUploaderLib/Alerts.cs
+++ b/CA_DataUploaderLib/Alerts.cs
@@ -109,7 +109,10 @@ namespace CA_DataUploaderLib
             message = timestamp + message;
             logger.LogError(message);
             if (a.Command != default)
-                ExecuteCommand(a.Command);
+            {
+                foreach (var commands in a.Command.Split('|'))
+                    ExecuteCommand(a.Command);
+            }
 
             _cmd.FireAlert(message);            
         }

--- a/CA_DataUploaderLib/Alerts.cs
+++ b/CA_DataUploaderLib/Alerts.cs
@@ -34,8 +34,8 @@ namespace CA_DataUploaderLib
                 logger.LogError($"ERROR in {Directory.GetCurrentDirectory()}\\IO.conf:{Environment.NewLine} Alert: {alert.Name} points to missing sensor: {alert.Sensor}");
             if (alertsWithoutItem.Count > 0)
                 throw new InvalidOperationException("Misconfigured alerts detected");
-            if (alerts.Any(a => a.TriggersEmergencyShutdown) && cmd == null)
-                throw new InvalidOperationException("Alert with emergency shutdown is configured, but command handler is not available to trigger it");
+            if (alerts.Any(a => a.Command != default) && cmd == null)
+                throw new InvalidOperationException("Alert with command is configured, but command handler is not available to trigger it");
             return alerts;
         }
 
@@ -108,8 +108,8 @@ namespace CA_DataUploaderLib
         {
             message = timestamp + message;
             logger.LogError(message);
-            if (a.TriggersEmergencyShutdown)
-                ExecuteCommand("emergencyshutdown");
+            if (a.Command != default)
+                ExecuteCommand(a.Command);
 
             _cmd.FireAlert(message);            
         }

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -331,7 +331,7 @@ namespace CA_DataUploaderLib
         private void DetectAndWarnSensorDisconnects(MCUBoard board, SensorSample sensor)
         {
             if (sensor.Value < 10000)
-            {//we reset the attempts when we get valid values, both to avoid recurring but temporary errors firing the warning + to re-enabling the warning when the issue is fixed.
+            {//we reset the attempts when we get valid values, both to avoid recurring but temporary errors firing the warning + to re-enable the warning when the issue is fixed.
                 sensor.InvalidReadsRemainingAttempts = 3000;
                 return;
             }
@@ -339,7 +339,7 @@ namespace CA_DataUploaderLib
             var remainingAttempts = sensor.InvalidReadsRemainingAttempts;
             if (ExactSensorAttemptsCheck(ref remainingAttempts))
             {
-                var lostSensorMsg = $"sensor {sensor.Name} has been unreachable for at least 5 minutes (10k+ values)";
+                var lostSensorMsg = $"sensor {sensor.Name} has been unreachable for at least 5 minutes (returning 10k+ values)";
                 LogError(board, lostSensorMsg);
                 _cmd.FireAlert(lostSensorMsg + " - title - " + board.ToShortDescription());
             }

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -320,13 +320,33 @@ namespace CA_DataUploaderLib
                 if (sensor != null)
                 {
                     sensor.Value = value;
-
+                    DetectAndWarnSensorDisconnects(board, sensor);
                     HandleSaltLeakage(board, sensor);
                 }
 
                 i++;
             }
         }
+
+        private void DetectAndWarnSensorDisconnects(MCUBoard board, SensorSample sensor)
+        {
+            if (sensor.Value < 10000)
+            {//we reset the attempts when we get valid values, both to avoid recurring but temporary errors firing the warning + to re-enabling the warning when the issue is fixed.
+                sensor.InvalidReadsRemainingAttempts = 3000;
+                return;
+            }
+
+            var remainingAttempts = sensor.InvalidReadsRemainingAttempts;
+            if (ExactSensorAttemptsCheck(ref remainingAttempts))
+            {
+                var lostSensorMsg = $"sensor {sensor.Name} has been unreachable for at least 5 minutes (10k+ values)";
+                LogError(board, lostSensorMsg);
+                _cmd.FireAlert(lostSensorMsg + " - title - " + board.ToShortDescription());
+            }
+
+            sensor.InvalidReadsRemainingAttempts = remainingAttempts;
+        }
+
         public void ProcessLine(IEnumerable<double> numbers, MCUBoard board) => ProcessLine(numbers, board, GetSamples(board));
         private SensorSample[] GetSamples(MCUBoard board)
         {

--- a/CA_DataUploaderLib/HeaterElement.cs
+++ b/CA_DataUploaderLib/HeaterElement.cs
@@ -160,12 +160,12 @@ namespace CA_DataUploaderLib
             return (false, double.MaxValue);
         }
 
-        private bool TemperatureBoardsAreConnected(NewVectorReceivedArgs vector, IReadOnlyCollection<string> boardStateSensorNames)
+        private static bool TemperatureBoardsAreConnected(NewVectorReceivedArgs vector, IReadOnlyCollection<string> boardStateSensorNames)
         {
             foreach (var board in boardStateSensorNames)
             {
-                if (!vector.TryGetValue(_config.SwitchBoardStateSensorName, out var state))
-                    throw new InvalidOperationException($"missing temperature board's connection state: {_config.SwitchBoardStateSensorName}");
+                if (!vector.TryGetValue(board, out var state))
+                    throw new InvalidOperationException($"missing temperature board's connection state: {board}");
                 if (state != (int)BaseSensorBox.ConnectionState.ReceivingValues)
                     return false;
             }

--- a/CA_DataUploaderLib/IOconf/IOconfAlert.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAlert.cs
@@ -64,7 +64,7 @@ namespace CA_DataUploaderLib.IOconf
         public bool CheckValue(double newValue, DateTime vectorTime)
         {
             //don't alert for invalid values.
-            //Sensor readers are responsible from reporting fully lost sensors, while actuating logic is responsible for only doing targetted reactions.
+            //Sensor readers are responsible for reporting fully lost sensors, while actuating logic is responsible for only doing targetted reactions.
             //Limitation: emergency shutdown alerts ignore board disconnects or lost sensors (10k+ thermocouple errors),
             //            for the earlier separate alerts can be set on the disconnects, for the later use alert + Math like this (filter length controls how long before the alert sees the 10k and triggers): Math;MyFilterDisconnected;MyFilter >= 10000
             //            Also note that some redundant alerts can be added so that if one sensor fails the problem can still be detected by other sensors/boards.

--- a/CA_DataUploaderLib/IOconf/IOconfAlert.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAlert.cs
@@ -24,15 +24,14 @@ namespace CA_DataUploaderLib.IOconf
             if (list[0] != "Alert" || list.Count < 3) throw new Exception("IOconfAlert: wrong format: " + row);
             Name = list[1];
             (Sensor, Value, MessageTemplate, type) = ParseExpression(
-                Name, list[2], "IOconfAlert: wrong format: " + row + ". Format: Alert;Name;SensorName comparison value;[rateMinutes];[emergencyshutdown].");
+                Name, list[2], "IOconfAlert: wrong format: " + row + ". Format: Alert;Name;SensorName comparison value;[rateMinutes];[command].");
             Message = MessageTemplate;
             if (list.Count <= 3)
-                (RateLimitMinutes, TriggersEmergencyShutdown) = (DefaultRateLimitMinutes, false);
-            else 
-            {
-                TriggersEmergencyShutdown = list[3] == "emergencyshutdown" || list.Count > 4 && list[4] == "emergencyshutdown";
-                RateLimitMinutes = !TriggersEmergencyShutdown || list.Count > 4 ? list[3].ToInt() : DefaultRateLimitMinutes;
-            }
+                (RateLimitMinutes, Command) = (DefaultRateLimitMinutes, default);
+            else if (int.TryParse(list[3], out var rateLimitMins))
+                (RateLimitMinutes, Command) = (rateLimitMins, list.Count > 4 ? list[4] : default);
+            else
+                (RateLimitMinutes, Command) = (DefaultRateLimitMinutes, list[3]);
         }
 
         public IOconfAlert(string name, string expression, int? rateLimit = DefaultRateLimitMinutes, bool triggersEmergencyShutdown = true) : base("DynamicAlert", 0, "DynamicAlert")
@@ -42,13 +41,13 @@ namespace CA_DataUploaderLib.IOconf
                 name, expression, "alert expression - wrong format: " + expression + ". Expression format: SensorName comparison value.");
             Message = MessageTemplate;
             RateLimitMinutes = rateLimit ?? DefaultRateLimitMinutes;
-            TriggersEmergencyShutdown = triggersEmergencyShutdown;
+            Command = "emergencyshutdown";
         }
 
         public string Name { get; set; }
         public string Sensor { get; set; }
         public string Message { get; private set; }
-        public bool TriggersEmergencyShutdown { get; private set; }
+        public string Command { get; private set; }
         private readonly AlertCompare type;
         private readonly double Value;
         private double LastValue;

--- a/CA_DataUploaderLib/IOconf/IOconfAlert.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAlert.cs
@@ -63,6 +63,12 @@ namespace CA_DataUploaderLib.IOconf
 
         public bool CheckValue(double newValue, DateTime vectorTime)
         {
+            //don't alert for invalid values.
+            //Sensor readers are responsible from reporting fully lost sensors, while actuating logic is responsible for only doing targetted reactions.
+            //Limitation: emergency shutdown alerts ignore board disconnects or lost sensors (10k+ thermocouple errors),
+            //            for the earlier separate alerts can be set on the disconnects, for the later use alert + Math like this (filter length controls how long before the alert sees the 10k and triggers): Math;MyFilterDisconnected;MyFilter >= 10000
+            //            Also note that some redundant alerts can be added so that if one sensor fails the problem can still be detected by other sensors/boards.
+            if (newValue >= 10000) return false;
             Message = MessageTemplate + newValue.ToString(CultureInfo.InvariantCulture) + ")";
             bool newMatches = RawCheckValue(newValue);
             bool lastMatches = !_isFirstCheck && RawCheckValue(LastValue); // there is no lastValue to check on the first call

--- a/CA_DataUploaderLib/SensorSample.cs
+++ b/CA_DataUploaderLib/SensorSample.cs
@@ -22,6 +22,7 @@ namespace CA_DataUploaderLib
             set { ReadSensor_LoopTime = value.Subtract(_timeStamp).TotalMilliseconds; _timeStamp = value; }
         } 
         public double ReadSensor_LoopTime { get; private set; }  // in miliseconds. 
+        internal int InvalidReadsRemainingAttempts { get; set; } = 3000; //3k attempts = 5 (mins) x 60 (seconds) x 10 (cycles x second). The attempts are reset whenever we get valid values
 
         public SensorSample(IOconfInput input, double value = 0)
         {

--- a/UnitTests/HeaterElementTests.cs
+++ b/UnitTests/HeaterElementTests.cs
@@ -96,8 +96,31 @@ namespace UnitTests
             var newSamples = NewVectorSamples;
             newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(1).ToVectorDouble();
             newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.Connecting;
+            element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(2).ToVectorDouble();// only 1 second after detecting the disconnect for the first time
+            newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.Connecting;
             var newAction = element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
             Assert.AreEqual(firstAction, newAction);
+        }
+
+        [TestMethod]
+        public void DisconnectedTemperatureOven2SecondsTurnsOff()
+        { 
+            var element = new HeaterElement(NewConfig.Build());
+            element.SetTargetTemperature(45);
+            NewVectorReceivedArgs vector = new NewVectorReceivedArgs(NewVectorSamples);
+            var firstAction = element.MakeNextActionDecision(vector);
+            var newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(1).ToVectorDouble();
+            newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.Connecting;
+            element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            newSamples = NewVectorSamples;
+            newSamples["vectortime"] = vector.GetVectorTime().AddSeconds(4).ToVectorDouble();// 3 seconds after detecting the disconnect for the first time
+            newSamples["temperature_state"] = (int)BaseSensorBox.ConnectionState.Connecting;
+            var newAction = element.MakeNextActionDecision(new NewVectorReceivedArgs(newSamples)); 
+            Assert.IsFalse(newAction.IsOn);
+            Assert.AreNotEqual(firstAction, newAction);
         }
 
         [TestMethod]

--- a/UnitTests/IOconfAlertTests.cs
+++ b/UnitTests/IOconfAlertTests.cs
@@ -82,7 +82,7 @@ namespace UnitTests
         public void AlertRejectsInvalidConfiguration(string row)
         {
             var ex = Assert.ThrowsException<Exception>(() => new IOconfAlert(row, 0));
-            Assert.AreEqual($"IOconfAlert: wrong format: {row}. Format: Alert;Name;SensorName comparison value;[rateMinutes];[emergencyshutdown]. Supported comparisons: =,!=, >, <, >=, <=", ex.Message);
+            Assert.AreEqual($"IOconfAlert: wrong format: {row}. Format: Alert;Name;SensorName comparison value;[rateMinutes];[command]. Supported comparisons: =,!=, >, <, >=, <=", ex.Message);
         }
     }
 }


### PR DESCRIPTION
Note: a warning is still sent if a thermocouple has been disconnected for 5+ minutes.

Additionally:
- added support for using other commands than emergencyshutdown when an alert fires. To run multiple commands use | as a separator i.e. `Alert;MyName;Sensorx<123;oven off | pump 0`
- fixed: temperature board disconnect detection in heating control is being ignored