### PR TITLE
fixed: switchboards that don't report pin state and temperature send alert about disconnected sensors

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -330,7 +330,7 @@ namespace CA_DataUploaderLib
 
         private void DetectAndWarnSensorDisconnects(MCUBoard board, SensorSample sensor)
         {
-            if (sensor.Value < 10000)
+            if (!sensor.HasSpecialDisconnectValue())
             {//we reset the attempts when we get valid values, both to avoid recurring but temporary errors firing the warning + to re-enable the warning when the issue is fixed.
                 sensor.InvalidReadsRemainingAttempts = 3000;
                 return;

--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -33,6 +33,7 @@ namespace CA_DataUploaderLib.IOconf
             }
         }
 
+        public virtual bool IsSpecialDisconnectValue(double value) => false;
 
         public string Name { get; set; }
         public string BoxName { get; set; }

--- a/CA_DataUploaderLib/IOconf/IOconfTypeK.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfTypeK.cs
@@ -21,5 +21,7 @@ namespace CA_DataUploaderLib.IOconf
             else if (!Skip && (PortNumber < 1 || PortNumber > 34)) 
                 throw new Exception("IOconfTypeK: invalid port number: " + row);
         }
+
+        public override bool IsSpecialDisconnectValue(double value) => value >= 10000;
     }
 }

--- a/CA_DataUploaderLib/SensorSample.cs
+++ b/CA_DataUploaderLib/SensorSample.cs
@@ -44,5 +44,7 @@ namespace CA_DataUploaderLib
                 ReadSensor_LoopTime = ReadSensor_LoopTime
             };
         }
+
+        public bool HasSpecialDisconnectValue() => Input != null ? Input.IsSpecialDisconnectValue(Value) : false;
     }
 }


### PR DESCRIPTION
Added IOconfInput.IsSpecialDisconnectValue that can be used to detect special values that signal a disconnect of a given sensor in a connected board. Note: only enabled for the temp sensors in this PR.