### PR TITLE
added dc switchboard sensor port outputs

### DIFF
--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -43,6 +43,7 @@ namespace CA_DataUploaderLib.IOconf
         public bool Skip { get; set; }
         public IOconfMap Map { get; set; }
         protected bool HasPort { get; }
+        public string SubsystemOverride { get; set; }
 
         private void SetMap(string boxName, BoardSettings settings, bool skipBoardSettings)
         {

--- a/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
@@ -6,8 +6,7 @@ namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfOut230Vac : IOconfOutput
     {
-        public IOconfOut230Vac(string row, int lineNum, string type, bool isSwitchboardControllerOutput = true) : base(row, lineNum, type, true, 
-            new BoardSettings() { Parser = new SwitchBoardResponseParser(!row.Contains("showConfirmations")), ValuesEndOfLineChar = "\r" }) 
+        public IOconfOut230Vac(string row, int lineNum, string type, bool isSwitchboardControllerOutput = true) : base(row, lineNum, type, true, GetNewSwitchboardBoardSettings(row)) 
         {
             CurrentSensorName = Name + "_current";
             SwitchboardOnOffSensorName = Name + "_SwitchboardOn/Off";
@@ -23,21 +22,23 @@ namespace CA_DataUploaderLib.IOconf
         public IEnumerable<IOconfInput> GetExpandedInputConf()
         { // note "_On/Off" is not included as its not an input but the current expected on/off state as seen by the control loop.
             yield return NewPortInput(CurrentSensorName, 0 + PortNumber);
-            yield return NewPortInput(SwitchboardOnOffSensorName, 4 + PortNumber);
         }
 
         /// <remarks>This config is general for the board, so caller must make sure to use a single instance x board</remarks>
-        public IOconfInput GetBoardTemperatureInputConf() => NewPortInput(Map.BoxName + "_temperature", 9);
+        public IOconfInput GetBoardTemperatureInputConf() => NewPortInput(Map.BoxName + "_temperature", 5);
+        public static BoardSettings GetNewSwitchboardBoardSettings(string row) => 
+            new BoardSettings() { Parser = new SwitchBoardResponseParser(!row.Contains("showConfirmations")), ValuesEndOfLineChar = "\r" };
         private IOconfInput NewPortInput(string name, int portNumber) => new IOconfInput(Row, LineNumber, Type, false, false, null) 
             { Name = name, BoxName = BoxName, Map = Map, PortNumber = portNumber };
 
         public class SwitchBoardResponseParser : BoardSettings.LineParser
         {
-            // "P1=0.06A P2=0.05A P3=0.05A P4=0.06A 0, 1, 0, 1, 25.87"
+            // old response format "P1=0.06A P2=0.05A P3=0.05A P4=0.06A 0, 1, 0, 1, 25.87"
             // first 4 are currents, then comes 4 switchboard on/off values and then temperature. 
-            // the last 5 values are not there in older versions of the switchboard software.
-            private const string _SwitchBoxPattern = "P1=(-?\\d\\.\\d\\d)A P2=(-?\\d\\.\\d\\d)A P3=(-?\\d\\.\\d\\d)A P4=(-?\\d\\.\\d\\d)A(?: ([01]), ([01]), ([01]), ([01])(?:, (-?\\d+.\\d\\d))?)?";
-            private static readonly Regex _switchBoxCurrentsRegex = new Regex(_SwitchBoxPattern);
+            // some versions of the old switchboards did not return the last 5 values
+            // the 4 switchboard on/off values will be ignored (non capturing groups) as we don't plan to use those moving forward
+            private const string _oldSwitchBoxPattern = @"P1=(-?\d\.\d\d)A P2=(-?\d\.\d\d)A P3=(-?\d\.\d\d)A P4=(-?\d\.\d\d)A(?: [01], [01], [01], [01](?:, (-?\d+.\d\d))?)?";
+            private static readonly Regex _oldswitchBoxCurrentsRegex = new Regex(_oldSwitchBoxPattern);
             private const string _commandConfirmationPattern = @"^\s*p[1-4] (?:(?:auto off)|(?:off)|(?:on(?: \d+)?))\s*$";
             private static readonly Regex _commandConfirmationRegex = new Regex(_commandConfirmationPattern);
             private readonly bool _expectCommandConfirmations;
@@ -50,47 +51,34 @@ namespace CA_DataUploaderLib.IOconf
                 _expectCommandConfirmations = expectCommandConfirmations;
             }
 
-            // returns currents 0-3, states 0-3, board temperature
+            // returns currents 0-3, board temperature (, sensorport_rms, sensorport_max)
             public override List<double> TryParseAsDoubleList(string line)
             {
-                var match = _switchBoxCurrentsRegex.Match(line);
+                var match = _oldswitchBoxCurrentsRegex.Match(line);
                 if (!match.Success) 
                     return TryParseOnlyNumbersAsDoubleList(line);
                 return GetValuesFromGroups(match.Groups);
             }
 
-            // returns currents 0-3, states 0-3, board temperature
+            // returns currents 0-3, board temperature (, sensorport_rms, sensorport_max)
             public List<double> TryParseOnlyNumbersAsDoubleList(string line)
             {
                 var numbers = base.TryParseAsDoubleList(line); //the base implementation deals with any amount of simple numbers separated by commas.
-                var missingValues = 0;
                 if (numbers == null)
                     return null;
+                if (numbers.Count < 4)
+                    return null; //invalid line, must have at least 4 currents
                 if (numbers.Count == 4)
-                    missingValues = 5; // missing states and board temperature
-                else if (numbers.Count == 5)
-                { // missing states, the temperature needs to go at the end
-                    for (int i = 0; i < 4; i++)
-                        numbers.Insert(4, 10000);// insert before the temp
-                    return numbers;
-                }
-                else if (numbers.Count == 8)
-                    missingValues = 1; // missing board temperature
-                else if (numbers.Count == 9)
-                    return numbers;
-                else
-                    return null; // invalid line 
-                
-                for (int i = 0; i < missingValues; i++)
-                    numbers.Add(10000);
+                    numbers.Add(10000);//some versions did not report temperature
                 return numbers;
             }
 
-            public override bool MatchesValuesFormat(string line) => _switchBoxCurrentsRegex.IsMatch(line);
+            public override bool MatchesValuesFormat(string line) => _oldswitchBoxCurrentsRegex.IsMatch(line);
+            // returns currents 0-3, board temperature
             private static List<double> GetValuesFromGroups(GroupCollection groups)
             {
-                var data = new List<double>(9);
-                for (int i = 1; i < 10; i++)
+                var data = new List<double>(5);
+                for (int i = 1; i < 6; i++)
                     data.Add(groups[i].Success ? groups[i].Value.ToDouble() : 10000d);
                 return data;
             }

--- a/CA_DataUploaderLib/IOconf/IOconfSwitchboardSensor.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfSwitchboardSensor.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace CA_DataUploaderLib.IOconf
+{
+    public class IOconfSwitchboardSensor : IOconfInput
+    {
+        private readonly string RmsName;
+        private readonly string MaxName;
+        private readonly string Subsystem;
+
+        public IOconfSwitchboardSensor(string row, int lineNum) : base(row, lineNum, "SwitchboardSensor", false, true, IOconfOut230Vac.GetNewSwitchboardBoardSettings(row))
+        {
+            format = "SwitchboardSensor;Name;BoxName;[SubsystemName]";
+            var list = ToList();
+            Subsystem = list.Count > 3 ? list[3].ToLower() : "vibration";
+        }
+
+        /// <summary>get expanded conf entries that include both the rms and max within the 100 milliseconds read cycle</summary>
+        /// <remarks>the returned entries have port numbers that correspond to the ones returned by the dc switchboard as parsed by the IOconfOut230Vac.SwitchBoardResponseParser</remarks>
+        public IEnumerable<IOconfInput> GetExpandedConf() => new [] {
+            NewPortInput($"{Name}_rms", 6),
+            NewPortInput($"{Name}_maxIn100ms", 7),
+            };
+
+        private IOconfInput NewPortInput(string name, int portNumber) => new IOconfInput(Row, LineNumber, Type, false, false, null)
+            { Name = name, BoxName = BoxName, Map = Map, PortNumber = portNumber, SubsystemOverride = Subsystem };
+    }
+}

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -27,7 +27,8 @@ namespace CA_DataUploaderLib
             _cmd = new PluginsCommandHandler(cmd);
             var ports = IOconfFile.GetEntries<IOconfOut230Vac>().Where(p => p.IsSwitchboardControllerOutput && p.Map.Board != null).ToList();
             var boardsTemperatures = ports.GroupBy(p => p.BoxName).Select(b => b.Select(p => p.GetBoardTemperatureInputConf()).FirstOrDefault());
-            var inputs = ports.SelectMany(p => p.GetExpandedInputConf()).Concat(boardsTemperatures);
+            var sensorPortsInputs = IOconfFile.GetEntries<IOconfSwitchboardSensor>().SelectMany(i => i.GetExpandedConf());
+            var inputs = ports.SelectMany(p => p.GetExpandedInputConf()).Concat(boardsTemperatures).Concat(sensorPortsInputs);
             _reader = new BaseSensorBox(cmd, "switchboards", string.Empty, "show switchboards inputs", inputs);
             _reader.Stopping += WaitForLoopStopped;
             cmd.AddCommand("escape", Stop);

--- a/UnitTests/SwitchBoardResponseParserTests.cs
+++ b/UnitTests/SwitchBoardResponseParserTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests
             string testString = "asdfP1=0.00A P2=0.00A P3=0.00A P4=0.00A ";
             var values = IOconfOut230Vac.SwitchBoardResponseParser.Default.TryParseAsDoubleList(testString);
             Assert.IsNotNull(values);
-            CollectionAssert.AreEqual(new [] {0d, 0, 0, 0, 10000, 10000, 10000, 10000, 10000}, values);
+            CollectionAssert.AreEqual(new [] {0d, 0, 0, 0, 10000}, values);
         }
 
         [TestMethod]
@@ -21,7 +21,7 @@ namespace UnitTests
             string testString = "asdfP1=3.20A P2=2.30A P3=3.40A P4=5.60A \rasdfP1=3.20A P2=2.30A P3=3.40A P4=5.60A ";
             var values = IOconfOut230Vac.SwitchBoardResponseParser.Default.TryParseAsDoubleList(testString);
             Assert.IsNotNull(values);
-            CollectionAssert.AreEqual(new [] {3.2d, 2.3d, 3.4, 5.6, 10000, 10000, 10000, 10000, 10000}, values);
+            CollectionAssert.AreEqual(new [] {3.2d, 2.3d, 3.4, 5.6, 10000}, values);
         }
 
         [TestMethod]
@@ -30,43 +30,34 @@ namespace UnitTests
             string testString = "ssP1=0.06A P2=0.05A P3=0.05A P4=0.06A 0, 1, 0, 1, 25.87 aa";
             var values = IOconfOut230Vac.SwitchBoardResponseParser.Default.TryParseAsDoubleList(testString);
             Assert.IsNotNull(values);
-            CollectionAssert.AreEqual(new [] {0.06d, 0.05d, 0.05d, 0.06d, 0, 1, 0, 1, 25.87d}, values);
+            CollectionAssert.AreEqual(new [] {0.06d, 0.05d, 0.05d, 0.06d, 25.87d}, values);
         }
 
         [TestMethod]
-        public void OnlyNumbersWithoutStatesAndTemperaturesIsParsed()
+        public void OnlyNumbersWithoutTemperatureOrSensorPort() 
         {
             string testString = "0.03,2.30,4.00,5.25";
             var values = IOconfOut230Vac.SwitchBoardResponseParser.Default.TryParseAsDoubleList(testString);
             Assert.IsNotNull(values);
-            CollectionAssert.AreEqual(new [] {0.03d,2.30,4.00,5.25,10000,10000,10000,10000,10000}, values);
+            CollectionAssert.AreEqual(new [] {0.03d,2.30,4.00,5.25,10000}, values); //temperature is not optional as it requires discovery during init sequence which we don't support
         }
 
         [TestMethod]
-        public void OnlyNumbersWithoutStatesIsParsed()
+        public void OnlyNumbersWithoutSensorPort()
         {
             string testString = "0.03,2.30,4.00,5.25,90";
             var values = IOconfOut230Vac.SwitchBoardResponseParser.Default.TryParseAsDoubleList(testString);
             Assert.IsNotNull(values);
-            CollectionAssert.AreEqual(new [] {0.03d,2.30,4.00,5.25,10000,10000,10000,10000,90}, values);
-        }
-
-        [TestMethod]
-        public void OnlyNumbersWithoutTemperatureIsParsed()
-        {
-            string testString = "0.03,2.30,4.00,5.25,1,0,1,1";
-            var values = IOconfOut230Vac.SwitchBoardResponseParser.Default.TryParseAsDoubleList(testString);
-            Assert.IsNotNull(values);
-            CollectionAssert.AreEqual(new [] {0.03d,2.30,4.00,5.25,1,0,1,1,10000}, values);
+            CollectionAssert.AreEqual(new [] {0.03d,2.30,4.00,5.25,90}, values);
         }
 
         [TestMethod]
         public void OnlyNumbersAllValuesIsParsed()
         {
-            string testString = "0.03,2.30,4.00,5.25,1,0,1,1,40";
+            string testString = "0.03,2.30,4.00,5.25,40,150.5,1045";
             var values = IOconfOut230Vac.SwitchBoardResponseParser.Default.TryParseAsDoubleList(testString);
             Assert.IsNotNull(values);
-            CollectionAssert.AreEqual(new [] {0.03d,2.30,4.00,5.25,1,0,1,1,40}, values);
+            CollectionAssert.AreEqual(new [] {0.03d,2.30,4.00,5.25,40,150.5,1045}, values);
         }
         
         [TestMethod]
@@ -96,7 +87,7 @@ namespace UnitTests
         [TestMethod]
         public void InvalidLineIncludingProperCommandAndBoardValuesLineIsRejected()
         {
-            string testString = "MISREAD: 0.03,2.30,4.00,5.25,1,0,1,1,40p1 on 60";
+            string testString = "MISREAD: 0.03,2.30,4.00,5.25,40p1 on 60";
             var values = IOconfOut230Vac.SwitchBoardResponseParser.Default.TryParseAsDoubleList(testString);
             Assert.IsNull(values);
         }
@@ -144,7 +135,7 @@ namespace UnitTests
         [TestMethod]
         public void MisreadIncludingProperCommandAndValuesLineIsNotRecognizedAsExpectedNonValuesLine()
         {
-            string testString = "MISREAD: 0.03,2.30,4.00,5.25,1,0,1,1,40p1 on 60";
+            string testString = "MISREAD: 0.03,2.30,4.00,5.25,40p1 on 60";
             var value = IOconfOut230Vac.SwitchBoardResponseParser.Default.IsExpectedNonValuesLine(testString);
             Assert.IsFalse(value);
         }


### PR DESCRIPTION
also:
- removed switchboard states reported values
- added subsystem override to input configs used by the BaseSensorBox. In this way the values of the switchboard sensor port can be shown under a different command.