### PR TITLE
Allow multiple board entries to share one boardsettings instance.

### DIFF
--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -51,7 +51,10 @@ namespace CA_DataUploaderLib.IOconf
             Map = maps.SingleOrDefault(x => x.BoxName == boxName);
             if (Map == null) 
                 throw new Exception($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
-            if (!skipBoardSettings)
+
+            // Map.BoardSettings == BoardSettings.Default is there since some boards need separate board settings, but have multiple sensor entries. 
+            // This check means a new BoardSettings instance will be created with first entry of board, but not updated (i.e. shared) among the rest of the board entries.    
+            if (!skipBoardSettings && Map.BoardSettings == BoardSettings.Default)
                 Map.BoardSettings = settings;
         }
     }


### PR DESCRIPTION
The pressure board needs to be calibrated according to the sensors used. 

The pressure boards need a separate BoardSettings instance than the base settings to not impose the sensor calibration line on other boards. However, since the IOconfPressure class is called for every pressure sensor line in the IO.conf file many instances of BoardSettings are created.

This pull request allows boards to have one shared non-default BoardSettings instance associated with many sensors.  

