### PR TITLE
Prevent LoopControl stall from VFD not responding 

### DIFF
--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -279,7 +279,7 @@ namespace CA_DataUploaderLib
 
             // A cancellation token is made here rather than a simple timer since the ReadAsync function can hang
             // if a device never sends a line for it to read.
-            int millisecondsTimeout = 3000;
+            int millisecondsTimeout = 5000;
             using var cts = new CancellationTokenSource(millisecondsTimeout);
             var token = cts.Token;
 
@@ -391,7 +391,7 @@ namespace CA_DataUploaderLib
 
             // A cancellation token is made here rather than a simple timer since the ReadAsync function can hang
             // if a device never sends a line for it to read.
-            int millisecondsTimeout = 3000;
+            int millisecondsTimeout = 5000;
             using var cts = new CancellationTokenSource(millisecondsTimeout);
             var token = cts.Token;
             foreach (var detector in customProtocolDetectors)
@@ -418,11 +418,7 @@ namespace CA_DataUploaderLib
                     } 
                     catch (OperationCanceledException ex)
                     {
-                        if (ex.CancellationToken == token)
-                        {
-                            CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {portName} ({baudRate}): " + ex.Message);
-                            break;
-                        }
+                        break;
                     }
                 }
             }

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -391,7 +391,7 @@ namespace CA_DataUploaderLib
 
             // A cancellation token is made here rather than a simple timer since the ReadAsync function can hang
             // if a device never sends a line for it to read.
-            int millisecondsTimeout = 5000;
+            int millisecondsTimeout = 3000;
             using var cts = new CancellationTokenSource(millisecondsTimeout);
             var token = cts.Token;
             foreach (var detector in customProtocolDetectors)
@@ -418,7 +418,10 @@ namespace CA_DataUploaderLib
                     } 
                     catch (OperationCanceledException ex)
                     {
-                        break;
+                        if (ex.CancellationToken == token)
+                            break;
+                        else
+                            throw;
                     }
                 }
             }


### PR DESCRIPTION
During the initial detection of boards connected to the system the system stall because the VFD never sends a line back. To overcome this CancellationTokens are passed where the library function .ReadAsync is used. 

The program catches an OperationCanceledException and returns values that indicate it was not able to receive anything from that port.

A UnitTest "ProcessingEmptyLineDoesNotStallInitialization" is created to ensure this does not stall the program for more than 4 seconds.

