### PR TITLE
fix serialport memoryleak by updating to .net 6

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v1.8.2
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
@@ -44,7 +44,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v1.8.2
       with:
         dotnet-version: 6.0.x
     - name: Generate DataUploader - linux-x64

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1.8.2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 6.0
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -46,7 +46,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1.8.2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 6.0
     - name: Generate DataUploader - linux-x64
       run: dotnet publish CA_DataUploader -c Release -o out/linux-x64/uploader -r linux-x64 -p:PublishSingleFile=true
     - name: Generate DataUploader - linux-arm

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -46,7 +46,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Generate DataUploader - linux-x64
       run: dotnet publish CA_DataUploader -c Release -o out/linux-x64/uploader -r linux-x64 -p:PublishSingleFile=true
     - name: Generate DataUploader - linux-arm

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1.8.2
       with:
-        dotnet-version: 6.0
+        dotnet-version: '6.0'
+        include-prerelease: True
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -46,7 +47,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1.8.2
       with:
-        dotnet-version: 6.0
+        dotnet-version: '6.0'
+        include-prerelease: True
     - name: Generate DataUploader - linux-x64
       run: dotnet publish CA_DataUploader -c Release -o out/linux-x64/uploader -r linux-x64 -p:PublishSingleFile=true
     - name: Generate DataUploader - linux-arm

--- a/CA_DataUploader/CA_DataUploader.csproj
+++ b/CA_DataUploader/CA_DataUploader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Copenhagen Atomics</Company>
     <Authors>Thomas Jam Pedersen + others</Authors>

--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -43,9 +43,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Ports" Version="5.0.0" />
+    <PackageReference Include="System.IO.Ports" Version="6.0.0-rc.1.21451.13" />
     <PackageReference Include="CA.LoopControlPluginBase" Version="0.0.2" />
-    <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.0-rc.1.21451.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -368,7 +368,7 @@ namespace CA_DataUploaderLib
 
             public byte[] GetPublicKey() => _rsaWriter.ExportCspBlob(false);
 
-            public byte[] GetSignature(byte[] data) => _rsaWriter.SignData(data, new SHA1CryptoServiceProvider());
+            public byte[] GetSignature(byte[] data) => _rsaWriter.SignData(data, SHA1.Create());
         }
     }
 }

--- a/CommandHandlerTester/CommandHandlerTester.csproj
+++ b/CommandHandlerTester/CommandHandlerTester.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/CommandHandlerTesterLib/CommandHandlerTesterLib.csproj
+++ b/CommandHandlerTesterLib/CommandHandlerTesterLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ ____
 
 ## How to run this datalogger from RaspberryPi (Linux):
 
-This software runs on .Net 5 and you do not need Mono any more. 
+This software runs on .Net 6 and you do not need Mono any more. 
 
 You can download the latest release files here.
 
-Or build the source code with the .net 5 sdk installed:
+Or build the source code with the .net 6 sdk installed (note to build from VS you need to upgrade to 2022):
 * on a command line in the repository folder, run (replacing linux-arm with your target platform): 
   * dotnet publish CA_DataUploader -c Release -p:PublishSingleFile=true --runtime linux-arm --self-contained
   * other options for target are: linux-x64, osx-x64, win-arm, win-x64, win-x86

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This software runs on .Net 6 and you do not need Mono any more.
 
 You can download the latest release files here.
 
-Or build the source code with the .net 6 sdk installed (note to build from VS you need to upgrade to 2022 and enable previews at Tools -> Options -> Environment -> Preview Features -> Use previews of the .NET SDK):
+Or build the source code with the .net 6 sdk installed (note to build from VS you need to upgrade to 2022 and [enable previews](https://docs.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1045?f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(NETSDK1045)%26rd%3Dtrue#preview-not-enabled)):
 * on a command line in the repository folder, run (replacing linux-arm with your target platform): 
   * dotnet publish CA_DataUploader -c Release -p:PublishSingleFile=true --runtime linux-arm --self-contained
   * other options for target are: linux-x64, osx-x64, win-arm, win-x64, win-x86

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This software runs on .Net 6 and you do not need Mono any more.
 
 You can download the latest release files here.
 
-Or build the source code with the .net 6 sdk installed (note to build from VS you need to upgrade to 2022):
+Or build the source code with the .net 6 sdk installed (note to build from VS you need to upgrade to 2022 and enable previews at Tools -> Options -> Environment -> Preview Features -> Use previews of the .NET SDK):
 * on a command line in the repository folder, run (replacing linux-arm with your target platform): 
   * dotnet publish CA_DataUploader -c Release -p:PublishSingleFile=true --runtime linux-arm --self-contained
   * other options for target are: linux-x64, osx-x64, win-arm, win-x64, win-x86

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<ProjectGuid>{C74C4DFC-74A1-40D4-A8DB-A0546ED810FD}</ProjectGuid>
 		<TestProjectType>UnitTest</TestProjectType>
 		<LangVersion>8.0</LangVersion>


### PR DESCRIPTION
After #124 a second leak was found. Dump analysis showed it being in SerialPort and already fixed in dotnet 6. See https://github.com/dotnet/runtime/issues/55146#issuecomment-927344824.

This PR updates to .net 6. Note that:

- this means the repository now requires vs 2022 and additionally to enable preview builds via Tools -> Options -> Environment -> Preview Features -> Use previews of the .NET SDK
- CA.LoopControlPluginBase was left untouched still targetting .net 5, so that can continue using the same plugins during the transition. Most plugins don't use features that had breaking changes in the move from .net 5 to 6 and initial testing was positive, so it makes more sense to wait until we have a reason to do a breaking change for plugins.
- initial testing shows very clearly that the managed memory leak is gone. However, early testing still showed an increase of native memory, although at a much slower rate i.e. 3 MB in 5 hours. That rate is still problematic as it would imply above 400MB x month, although it slowed down to approx 120MB x month. Additionally another system explored running an older version also showed a memory growth pattern that stabilized later in the run.   