### PR TITLE
accepted user commands and alerts are now registered as events

### DIFF
--- a/CA_DataUploaderLib/Alerts.cs
+++ b/CA_DataUploaderLib/Alerts.cs
@@ -72,7 +72,7 @@ namespace CA_DataUploaderLib
 
         public override void OnNewVectorReceived(object sender, NewVectorReceivedArgs e)
         {
-            var timestamp = e.GetVectorTime().ToString("yyyy.MM.dd HH:mm:ss");
+            var timestamp = e.GetVectorTime();
             var (alertsToTrigger, noSensorAlerts) = GetAlertsToTrigger(e); // we gather alerts separately from triggering, to reduce time locking the _alerts list
             
             foreach (var a in alertsToTrigger ?? Enumerable.Empty<IOconfAlert>())
@@ -104,17 +104,16 @@ namespace CA_DataUploaderLib
                 noSensorAlerts ?? Enumerable.Empty<IOconfAlert>());
         }
 
-        private void TriggerAlert(IOconfAlert a, string timestamp, string message)
+        private void TriggerAlert(IOconfAlert a, DateTime timestamp, string message)
         {
-            message = timestamp + message;
-            logger.LogError(message);
+            logger.LogError(timestamp.ToString("yyyy.MM.dd HH:mm:ss") + message);
             if (a.Command != default)
             {
                 foreach (var commands in a.Command.Split('|'))
-                    ExecuteCommand(a.Command);
+                    ExecuteCommand(commands);
             }
 
-            _cmd.FireAlert(message);            
+            _cmd.FireAlert(message, timestamp);            
         }
 
         private List<T> EnsureInitialized<T>(ref List<T> list) => list = list ?? new List<T>();

--- a/CA_DataUploaderLib/EventFiredArgs.cs
+++ b/CA_DataUploaderLib/EventFiredArgs.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace CA_DataUploaderLib
+{
+    public class EventFiredArgs : EventArgs
+    {
+        public EventFiredArgs(string data, EventType eventType, DateTime timespan) : this(data, (byte) eventType, timespan) { }
+        public EventFiredArgs(string data, byte eventType, DateTime timespan)
+        {
+            Data = data;
+            EventType = eventType;
+            TimeSpan = timespan;
+        }
+
+        public string Data { get; }
+        public byte EventType { get; }
+        public DateTime TimeSpan { get; }
+
+        public byte[] ToByteArray()
+        {
+            var timeTicks = TimeSpan.Ticks;
+            var encoding = Encoding.UTF8;
+            var dataBytesCount = encoding.GetByteCount(Data);
+            var bytes = new byte[1 + 1 + sizeof(long) + dataBytesCount]; //version + event type + time ticks + data bytes
+            bytes[0] = 0;
+            bytes[1] = EventType;
+            MemoryMarshal.Write(bytes.AsSpan()[2..], ref timeTicks);
+            var startOfDataIndex = 1 + 1 + sizeof(long);
+            if (dataBytesCount != encoding.GetBytes(Data, 0, Data.Length, bytes, startOfDataIndex))
+                throw new InvalidOperationException($"unexpected error getting utf8 bytes for event: {Data}");
+            return bytes;
+        }
+    }
+}

--- a/CA_DataUploaderLib/EventType.cs
+++ b/CA_DataUploaderLib/EventType.cs
@@ -1,0 +1,8 @@
+﻿namespace CA_DataUploaderLib
+{
+    public enum EventType : byte
+    {
+        Alert = 0,
+        Command = 1
+    }
+}

--- a/UnitTests/EventFiredArgsTests.cs
+++ b/UnitTests/EventFiredArgsTests.cs
@@ -1,0 +1,24 @@
+﻿using CA_DataUploaderLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class EventFiredArgsTests
+    {
+        [TestMethod]
+        public void ToByteArrayReturnsExpectedBytes()
+        {
+            const string Data = "my message";
+            DateTime timespan = new DateTime(2012, 1, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+            var args = new EventFiredArgs(Data, 2, timespan);
+            var bytes = args.ToByteArray();
+            CollectionAssert.AreEqual(new byte[] { 0, 2 }, bytes.Take(2).ToList());
+            CollectionAssert.AreEqual(BitConverter.GetBytes(timespan.Ticks), bytes.Skip(2).Take(sizeof(long)).ToList());
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes(Data), bytes.Skip(2).Skip(sizeof(long)).ToList());
+        }
+    }
+}


### PR DESCRIPTION
By registering these low frequency events it will be possible later to check relevant actions and alerts that have been triggered for the system

Also:
* fixed bug in multi command alerts
* CommandHandler.AlertFired has been removed, use CommandHandler.EventFired and check type == EventType.Alert instead