### PR TITLE
allow using in applications not published as a single file

### DIFF
--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -181,7 +181,7 @@ namespace CA_DataUploaderLib
                         isFirstAccepted = false;
                         OnCommandAccepted(cmdString, addToCommandHistory); // track it in the history if at least one execution accepted the command
                     }
-                    else
+                    else if (!accepted)
                         break; // avoid running the command on another subsystem when it was already rejected
                 }
                 catch (ArgumentException ex)


### PR DESCRIPTION
**breaking change:** plugins run from the "plugins" subfolder 

reason: dotnet/runtime#59961

Also fixed regression in #127 preventing the full help from showing in the help command.