### PR TITLE
fixing unstable test

### DIFF
--- a/UnitTests/MCUBoardTests.cs
+++ b/UnitTests/MCUBoardTests.cs
@@ -78,7 +78,7 @@ namespace UnitTests
             await detectTask;
         }
 
-        private static Task<string> ReadLine(PipeReader reader) => MCUBoard.ReadLine(reader, "abc", 5, TryReadLine);
+        private static Task<string> ReadLine(PipeReader reader) => MCUBoard.ReadLine(reader, "abc", 16, TryReadLine);
         private static ValueTask<FlushResult> Write(PipeWriter writer, string data) => Write(writer, Encoding.ASCII.GetBytes(data));
         private static ValueTask<FlushResult> Write(PipeWriter writer, byte[] bytes)
         {


### PR DESCRIPTION
We just hit the second time where Processes4SingleValueLines times out within 5 ms

Increased the timeout to 16 ms. This last time github actions is undergoing "degraded performance", so that might have played a part.