### PR TITLE
fixed switchboard comms regression introduced by #132

### DIFF
--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -43,9 +43,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Ports" Version="6.0.0-rc.1.21451.13" />
+    <PackageReference Include="System.IO.Ports" Version="6.0.0-rc.2.21480.5" />
     <PackageReference Include="CA.LoopControlPluginBase" Version="0.0.2" />
-    <PackageReference Include="System.IO.Pipelines" Version="6.0.0-rc.1.21451.13" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -97,7 +97,8 @@ namespace CA_DataUploaderLib
             foreach (var subsystem in _subsystems)
             {
                 var subsystemItems = subsystem.GetVectorDescriptionItems();
-                CALog.LogInfoAndConsoleLn(LogID.A, $"{subsystemItems.Count,2} datapoints from {subsystem.Title}");
+                if (subsystemItems.Count > 0)
+                    CALog.LogInfoAndConsoleLn(LogID.A, $"{subsystemItems.Count,2} datapoints from {subsystem.Title}");
                 items.AddRange(subsystemItems);
             }
 

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -52,10 +52,12 @@ namespace CA_DataUploaderLib
 
         public Task Run(CancellationToken token)
         {
+            //we only report detected config alerts after all subsystems are initialized (and alerts can be delivered).
+            //the actual read and actuation is done by the SwitchBoardController subsystem.
             foreach (var heater in _heaters)
                 heater.ReportDetectedConfigAlerts(_cmdUnwrapped);
 
-            return _switchboardController.Run(token);
+            return Task.CompletedTask; 
         }
 
         public IEnumerable<SensorSample> GetInputValues() => Enumerable.Empty<SensorSample>();


### PR DESCRIPTION
The problem was SwitchBoardController.Run was explicitely running the _reader loop while it already automatically ran as it is registered as a subsystem

The controller also now registers itself as a subsystem removing unnecesary locking and also making the subtle requirement on _reader vs. actuation loops start explicit.