### PR TITLE
enable connecting devices to multiple distributed nodes

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -19,9 +19,11 @@ namespace CA_DataUploaderLib
         /// <remarks>some boards might be closed, specially if the system is stopping due to losing connection to one of the boards</remarks>
         public event EventHandler Stopping;
         private readonly CommandHandler _cmd;
-        protected readonly List<SensorSample> _values = new List<SensorSample>();
+        protected readonly List<SensorSample> _values;
+        protected readonly List<SensorSample> _localValues;
         private readonly (IOconfMap map, SensorSample[] values)[] _boards;
-        protected readonly AllBoardsState _allBoardsState;
+        protected readonly List<VectorDescriptionItem> _allBoardsDescriptionItems;
+        protected readonly AllBoardsState _boardsState;
         private readonly string commandHelp;
         private readonly CancellationTokenSource _boardLoopsStopTokenSource = new CancellationTokenSource();
         private readonly Dictionary<MCUBoard, SensorSample[]> _boardSamplesLookup = new Dictionary<MCUBoard, SensorSample[]>();
@@ -33,6 +35,7 @@ namespace CA_DataUploaderLib
             Title = commandName;
             _cmd = cmd;
             _values = values.Select(x => new SensorSample(x)).ToList();
+            _localValues = _values.Where(x => x.Input.Map.IsLocalBoard).ToList();
             if (!_values.Any())
                 return;  // no data
 
@@ -46,8 +49,12 @@ namespace CA_DataUploaderLib
                 cmd.AddSubsystem(this);
             }
 
-            _boards = _values.Where(x => !x.Input.Skip).GroupBy(x => x.Input.Map).Select(g => (map: g.Key, values: g.ToArray())).ToArray();
-            _allBoardsState = new AllBoardsState(_boards.Select(b => b.map));
+            var allBoards = _values.Where(x => !x.Input.Skip).GroupBy(x => x.Input.Map).Select(g => (map: g.Key, values: g.ToArray())).ToArray();
+            _allBoardsDescriptionItems = new AllBoardsState(allBoards.Select(b => b.map))
+                .Select(b => new VectorDescriptionItem("double", b.sensorName, DataTypeEnum.State))
+                .ToList();
+            _boards = allBoards.Where(b => b.map.IsLocalBoard).ToArray();
+            _boardsState = new AllBoardsState(_boards.Select(b => b.map));
         }
 
         public Task Run(CancellationToken token) => RunBoardReadLoops(_boards, token);
@@ -62,15 +69,20 @@ namespace CA_DataUploaderLib
             }
         }
 
-        public IEnumerable<SensorSample> GetInputValues() => _values
+        public IEnumerable<SensorSample> GetInputValues() => _localValues
             .Select(s => s.Clone())
-            .Concat(_allBoardsState.Select(b => new SensorSample(b.sensorName, (int)b.State)));
+            .Concat(_boardsState.Select(b => new SensorSample(b.sensorName, (int)b.State)));
 
         public IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs) => Enumerable.Empty<SensorSample>();
         public virtual List<VectorDescriptionItem> GetVectorDescriptionItems() =>
             _values
                 .Select(x => new VectorDescriptionItem("double", x.Input.Name, DataTypeEnum.Input))
-                .Concat(_allBoardsState.Select(b => new VectorDescriptionItem("double", b.sensorName, DataTypeEnum.State)))
+                .Concat(_allBoardsDescriptionItems)
+                .ToList();
+        public virtual List<VectorDescriptionItem> GetLocalInputsDescriptionItems() =>
+            _localValues
+                .Select(x => new VectorDescriptionItem("double", x.Input.Name, DataTypeEnum.Input))
+                .Concat(_boardsState.Select(b => new VectorDescriptionItem("double", b.sensorName, DataTypeEnum.State)))
                 .ToList();
 
         protected bool ShowQueue(List<string> args)
@@ -121,7 +133,7 @@ namespace CA_DataUploaderLib
                 {
                     using var closeTimeoutToken = new CancellationTokenSource(5000);
                     map.Board?.SafeClose(closeTimeoutToken.Token);
-                    _allBoardsState.SetDisconnectedState(map);
+                    _boardsState.SetDisconnectedState(map);
                 }
                 catch(Exception ex)
                 {
@@ -132,12 +144,11 @@ namespace CA_DataUploaderLib
 
         protected virtual List<Task> StartReadLoops((IOconfMap map, SensorSample[] values)[] boards, CancellationToken token)
         {
-            var localBoards = boards.Where(b => b.map.IsLocalBoard);
-            var missingBoards = localBoards.Where(h => h.map.Board == null).Select(b => b.map.BoxName).Distinct().ToList();
+            var missingBoards = boards.Where(h => h.map.Board == null).Select(b => b.map.BoxName).Distinct().ToList();
             if (missingBoards.Count > 0)
                 _cmd.FireAlert($"{Title} - missing boards detected {string.Join(",", missingBoards)}. Related sensors/actuators are disabled.");
 
-            return localBoards
+            return boards
                 .Where(b => b.map.Board != null) //we ignore the missing boards for now as we don't have auto reconnect logic yet for boards not detected during system start.
                 .Select(b => BoardLoop(b.map.Board, b.values, token))
                 .ToList();
@@ -157,14 +168,14 @@ namespace CA_DataUploaderLib
                 { //if the token is canceled we are about to exit the loop so we do nothing. Otherwise we consider it like any other exception and log it.
                     if (!token.IsCancellationRequested)
                     {
-                        _allBoardsState.SetReadSensorsExceptionState(board);
+                        _boardsState.SetReadSensorsExceptionState(board);
                         LogError(board, "unexpected error on board read loop", ex);
                     }
                 }
                 catch (Exception ex)
                 { // we expect most errors to be handled within SafeReadSensors and in the SafeReopen of the ReconnectBoard,
                   // so seeing this in the log is most likely a bug handling some error case.
-                    _allBoardsState.SetReadSensorsExceptionState(board);
+                    _boardsState.SetReadSensorsExceptionState(board);
                     LogError(board, "unexpected error on board read loop", ex);
                 }
             }
@@ -181,13 +192,13 @@ namespace CA_DataUploaderLib
             { 
                 if (token.IsCancellationRequested)
                     throw; // if the token is cancelled we bubble up the cancel so the caller can abort.
-                _allBoardsState.SetReadSensorsExceptionState(board);
+                _boardsState.SetReadSensorsExceptionState(board);
                 LogError(board, "error reading sensor data", ex);
                 return true; //ReadSensor normally should return false if the board is detected as disconnected, so we say the board is still connected here since the caller will still do stale values detection
             }
             catch (Exception ex)
             { // seeing this is the log is not unexpected in cases where we have trouble communicating to a board.
-                _allBoardsState.SetReadSensorsExceptionState(board);
+                _boardsState.SetReadSensorsExceptionState(board);
                 LogError(board, "error reading sensor data", ex);
                 return true; //ReadSensor normally should return false if the board is detected as disconnected, so we say the board is still connected here since the caller will still do stale values detection
             }
@@ -215,27 +226,27 @@ namespace CA_DataUploaderLib
                     {
                         ProcessLine(numbers, board, targetSamples);
                         timeSinceLastValidRead.Restart();
-                        _allBoardsState.SetState(board, ConnectionState.ReceivingValues);
+                        _boardsState.SetState(board, ConnectionState.ReceivingValues);
                     }
                     else if (!board.ConfigSettings.Parser.IsExpectedNonValuesLine(line))// mostly responses to commands or headers on reconnects.
                     {
                         LogInfo(board, $"unexpected board response {line.Replace("\r", "\\r")}"); // we avoid \r as it makes the output hard to read
                         if (timeSinceLastValidRead.ElapsedMilliseconds > msBetweenReads)
-                            _allBoardsState.SetState(board, ConnectionState.ReturningNonValues);
+                            _boardsState.SetState(board, ConnectionState.ReturningNonValues);
                     }
                 }
                 catch (Exception ex)
                 { //usually a parsing errors on non value data, we log it and consider it as such i.e. we set ReturningNonValues if we have not had a valid read in msBetweenReads
                     LogError(board, $"failed handling board response {line.Replace("\r", "\\r")}", ex); // we avoid \r as it makes the output hard to read
                     if (timeSinceLastValidRead.ElapsedMilliseconds > msBetweenReads)
-                        _allBoardsState.SetState(board, ConnectionState.ReturningNonValues);
+                        _boardsState.SetState(board, ConnectionState.ReturningNonValues);
                 }
             }
         }
 
         ///<returns>(<c>false</c> if the board was explicitely detected as disconnected, the line, or null/default string if it exceeded the MCUBoard.ReadTimeout).</returns>
         ///<remarks>
-        ///Notifies in _allBoardsState (which is reported to the next vector) if there is no data available within <param cref="msBetweenReads" /> 
+        ///Notifies in _localBoardsState (which is reported to the next vector) if there is no data available within <param cref="msBetweenReads" /> 
         ///and when that happens it waits up to MCUBoard.ReadTimeout for the board to return data.
         ///Both in the above case and when the MCUBoard.ReadTimeout is exceeded a message is written to the log (but not the console to reduce operational noise),
         ///specially as it can now be observed on the graphs if board these events are happening + CheckFailure & reconnects will display relevant messages if appropiate.
@@ -247,7 +258,7 @@ namespace CA_DataUploaderLib
             if (await Task.WhenAny(readLineTask, noDataAvailableTask) == noDataAvailableTask)
             {
                 LogData(board, "no data available");
-                _allBoardsState.SetState(board, ConnectionState.NoDataAvailable); //report the state early before waiting up to 2 seconds for the data (readLineTask)
+                _boardsState.SetState(board, ConnectionState.NoDataAvailable); //report the state early before waiting up to 2 seconds for the data (readLineTask)
             }
 
             try
@@ -295,13 +306,13 @@ namespace CA_DataUploaderLib
 
         private async Task ReconnectBoard(MCUBoard board, CancellationToken token)
         {
-            _allBoardsState.SetAttemptingReconnectState(board);
+            _boardsState.SetAttemptingReconnectState(board);
             LogInfo(board, "attempting to reconnect");
             var lostSensorAttempts = 100;
             var delayBetweenAttempts = TimeSpan.FromSeconds(board.ConfigSettings.SecondsBetweenReopens);
             while (!(await board.SafeReopen(token)))
             {
-                _allBoardsState.SetDisconnectedState(board);
+                _boardsState.SetDisconnectedState(board);
                 if (ExactSensorAttemptsCheck(ref lostSensorAttempts)) 
                 { // we run this once when there has been 100 attempts
                     _cmd.FireAlert($"reconnect limit exceeded, reducing reconnect frequency to 15 minutes - {Title} - {board.ToShortDescription()}");
@@ -316,7 +327,7 @@ namespace CA_DataUploaderLib
                 await Task.Delay(delayBetweenAttempts, token);
             }
 
-            _allBoardsState.SetConnectedState(board);
+            _boardsState.SetConnectedState(board);
             LogInfo(board, "board reconnection succeeded");
         }
 

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -476,13 +476,14 @@ namespace CA_DataUploaderLib
 
         public enum ConnectionState
         {
-            Disconnected = 0,
-            Connecting = 1,
-            Connected = 2,
-            ReadError = 3,
-            NoDataAvailable = 4,
+            NodeUnreachable = -1, // can be used by distributed deployments to indicate the node that has the board is unreachable
+            Disconnected = 0, // we are not currently connected to the board
+            Connecting = 1, // we are attempting to reconnect to the board
+            Connected = 2, // we have succesfully connected to the board and will soon be attempting to read from it
+            ReadError = 3, // there are unexpected exceptions communicating with the board
+            NoDataAvailable = 4, // we are connected to the box, but we have not received for 150ms+
             ReturningNonValues = 5, // we are getting data from the box, but these are not values lines
-            ReceivingValues = 6
+            ReceivingValues = 6 // we are connected & receiving values
         }
     }
 }

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -61,6 +61,7 @@ namespace CA_DataUploaderLib
         }
 
         public IEnumerable<SensorSample> GetInputValues() => Enumerable.Empty<SensorSample>();
+        public List<VectorDescriptionItem> GetLocalInputsDescriptionItems() => new();
         public List<VectorDescriptionItem> GetVectorDescriptionItems() => 
             _heaters.SelectMany(x => SwitchboardAction.GetVectorDescriptionItems(x.Name())).ToList();
         public IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs)

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -61,9 +61,8 @@ namespace CA_DataUploaderLib
         }
 
         public IEnumerable<SensorSample> GetInputValues() => Enumerable.Empty<SensorSample>();
-        public List<VectorDescriptionItem> GetLocalInputsDescriptionItems() => new();
-        public List<VectorDescriptionItem> GetVectorDescriptionItems() => 
-            _heaters.SelectMany(x => SwitchboardAction.GetVectorDescriptionItems(x.Name())).ToList();
+        public SubsystemDescriptionItems GetVectorDescriptionItems() => 
+            new (new (), _heaters.SelectMany(x => SwitchboardAction.GetVectorDescriptionItems(x.Name())).ToList());
         public IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs)
         { 
             foreach (var heater in _heaters)

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -35,13 +35,13 @@ namespace CA_DataUploaderLib.IOconf
             BaudRate = baudrate;
             DistributedNode = distributedNodeName != default 
                 ? IOconfFile.GetEntries<IOconfNode>().SingleOrDefault(n => n.Name == distributedNodeName) ?? throw new Exception($"Failed to find node in configuration for Map: {row}. Format: {format}")
-                : !IOconfFile.GetEntries<IOconfNode>().Any() ? default : throw new Exception($"The node name is not optional for distributed deployments: {row}. Format: {format}");
+                : !IOconfFile.GetEntries<IOconfNode>().Any() ? DistributedNode : throw new Exception($"The node name is not optional for distributed deployments: {row}. Format: {format}");
         }
 
         public event EventHandler<EventArgs> OnBoardDetected;
         public bool SetMCUboard(MCUBoard board)
         {
-            if (DistributedNode?.IsCurrentSystem == false)
+            if (DistributedNode.IsCurrentSystem == false)
                 return false; //when using a distributed deployment, the map entries are only valid in the specified node.
 
             if ((board.serialNumber == SerialNumber && SerialNumber != null) || board.PortName == USBPort)
@@ -70,8 +70,8 @@ namespace CA_DataUploaderLib.IOconf
         /// <remarks>check <see cref="BoardSettings" /> for additional baud rate set by configurations</remarks>
         public int BaudRate { get; private set; }
         /// <summary>the cluster node that is directly connected to the device or <c>default</c> when using </summary>
-        public IOconfNode DistributedNode { get; }
-        public bool IsLocalBoard => DistributedNode == null || DistributedNode.IsCurrentSystem;
+        public IOconfNode DistributedNode { get; } = IOconfNode.SingleNode;
+        public bool IsLocalBoard => DistributedNode.IsCurrentSystem;
 
         public MCUBoard Board;
         private BoardSettings _boardSettings = BoardSettings.Default;

--- a/CA_DataUploaderLib/IOconf/IOconfNode.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfNode.cs
@@ -7,8 +7,15 @@ namespace CA_DataUploaderLib.IOconf
     /// When used in a host that supports distributed deployments, the <see cref="IsCurrentSystem"/> property must be set to true on the node corresponding to the host process/computer.
     /// This allows the subsystems (including device detection) to know which boards must be physically connected to this system.
     /// </remarks>
-    public class IOconfNode: IOconfRow
+    public class IOconfNode : IOconfRow
     {
+        private readonly IPEndPoint _endPoint;
+
+        private static readonly Lazy<IOconfNode> _singleNode = new(() => 
+            new IOconfNode(IOconfFile.GetLoopName()) { IsCurrentSystem = true }
+        );
+        private static byte _nodeInstances;
+
         public IOconfNode(string row, int lineNum) : base(row, lineNum, "Node")
         {
             format = "Node;Name;ipaddress:port";
@@ -18,11 +25,20 @@ namespace CA_DataUploaderLib.IOconf
             Name = list[1];
             if (!IPEndPoint.TryParse(list[2], out var endPoint))
                 throw new Exception($"IOconfNode: failed to parse the passed ip address. format: {row} {format}");
-            EndPoint = endPoint;
+            _endPoint = endPoint;
+            NodeIndex = _nodeInstances++;
         }
 
+        private IOconfNode(string name) : base($"Node;{name}", 0, "Node")
+        {
+            Name = name;
+        }
+
+        public static IOconfNode SingleNode => _singleNode.Value;
         public string Name { get; }
-        public IPEndPoint EndPoint { get; }
+        public IPEndPoint EndPoint => _endPoint ?? throw new InvalidOperationException($"Endpoint is only supported when running with distributed configuration");
         public bool IsCurrentSystem { get; set; }
+        /// <summary>position of the node in the config (starting at 0)</summary>
+        public byte NodeIndex { get; }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfNode.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfNode.cs
@@ -18,7 +18,7 @@ namespace CA_DataUploaderLib.IOconf
 
         public IOconfNode(string row, int lineNum) : base(row, lineNum, "Node")
         {
-            format = "Node;Name;ipaddress:port";
+            format = "Node;Name;ipaddress:port;[role]";
             var list = ToList();
             if (list.Count < 3)
                 throw new Exception($"IOconfNode: wrong format: {row} {format}");
@@ -27,6 +27,8 @@ namespace CA_DataUploaderLib.IOconf
                 throw new Exception($"IOconfNode: failed to parse the passed ip address. format: {row} {format}");
             _endPoint = endPoint;
             NodeIndex = _nodeInstances++;
+            if (list.Count > 3)
+                Role = list[3];
         }
 
         private IOconfNode(string name) : base($"Node;{name}", 0, "Node")
@@ -40,5 +42,6 @@ namespace CA_DataUploaderLib.IOconf
         public bool IsCurrentSystem { get; set; }
         /// <summary>position of the node in the config (starting at 0)</summary>
         public byte NodeIndex { get; }
+        public string Role { get; }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfRPiTemp.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRPiTemp.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace CA_DataUploaderLib.IOconf
 {
@@ -17,7 +18,9 @@ namespace CA_DataUploaderLib.IOconf
         public IEnumerable<IOconfInput> GetDistributedExpandedInputConf()
         { 
             if (Disabled) yield break;
-            foreach (var node in IOconfFile.GetEntries<IOconfNode>())
+            var nodes = IOconfFile.GetEntries<IOconfNode>().ToList();
+            nodes = nodes.Count > 0 ? nodes : new() { IOconfNode.SingleNode };
+            foreach (var node in nodes)
             {
                 //note there is no map entry for the IOconfRpiTemp as it is grabbed it is not an external box, but at the moment we only expose the IOconfNode through it
                 var map = Map = new IOconfMap("Map;RpiFakeBox;{Name}_{node.Name}Box;", LineNumber);

--- a/CA_DataUploaderLib/IOconf/IOconfRPiTemp.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRPiTemp.cs
@@ -18,12 +18,20 @@ namespace CA_DataUploaderLib.IOconf
         public IEnumerable<IOconfInput> GetDistributedExpandedInputConf()
         { 
             if (Disabled) yield break;
+            //note there is no map entry for the IOconfRpiTemp as it is not an external box, but at the moment we only expose the IOconfNode through it
             var nodes = IOconfFile.GetEntries<IOconfNode>().ToList();
-            nodes = nodes.Count > 0 ? nodes : new() { IOconfNode.SingleNode };
+            if (nodes.Count == 0)
+            {
+                var map = Map = new IOconfMap($"Map;RpiFakeBox;{Name}Box", LineNumber);
+                yield return new IOconfInput($"RPiTemp;{Name}Gpu", LineNumber, Type, false, false, BoardSettings.Default) { Map = map, Skip = true };
+                yield return new IOconfInput($"RPiTemp;{Name}Cpu", LineNumber, Type, false, false, BoardSettings.Default) { Map = map, Skip = true };
+                yield break;
+            }
+
             foreach (var node in nodes)
             {
-                //note there is no map entry for the IOconfRpiTemp as it is grabbed it is not an external box, but at the moment we only expose the IOconfNode through it
-                var map = Map = new IOconfMap("Map;RpiFakeBox;{Name}_{node.Name}Box;", LineNumber);
+                //note there is no map entry for the IOconfRpiTemp as it not an external box, but at the moment we only expose the IOconfNode through it
+                var map = Map = new IOconfMap($"Map;RpiFakeBox;{Name}_{node.Name}Box;{node.Name}", LineNumber);
                 yield return new IOconfInput($"RPiTemp;{Name}_{node.Name}Gpu", LineNumber, Type, false, false, BoardSettings.Default) { Map = map, Skip = true };
                 yield return new IOconfInput($"RPiTemp;{Name}_{node.Name}Cpu", LineNumber, Type, false, false, BoardSettings.Default) { Map = map, Skip = true };
             }

--- a/CA_DataUploaderLib/ISubsystemWithVectorData.cs
+++ b/CA_DataUploaderLib/ISubsystemWithVectorData.cs
@@ -1,19 +1,24 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CA.LoopControlPluginBase;
+using CA_DataUploaderLib.IOconf;
 
 namespace CA_DataUploaderLib
 {
     public interface ISubsystemWithVectorData
     {
         string Title { get; }
-        List<VectorDescriptionItem> GetVectorDescriptionItems();
-        /// <returns>the vector description items for items related to local boards in the same order as <see cref="GetVectorDescriptionItems"/></returns>
-        List<VectorDescriptionItem> GetLocalInputsDescriptionItems();
+        SubsystemDescriptionItems GetVectorDescriptionItems();
         /// <returns>The input values coming from local boards</returns>
         IEnumerable<SensorSample> GetInputValues();
         IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs);
         Task Run(CancellationToken token);
+    }
+
+    public record SubsystemDescriptionItems(List<(IOconfNode node, List<VectorDescriptionItem> items)> Inputs, List<VectorDescriptionItem> Outputs)
+    {
+        public IEnumerable<VectorDescriptionItem> GetNodeInputs(IOconfNode node) => Inputs.Where(n => n.node == node).SelectMany(n => n.items);
     }
 }

--- a/CA_DataUploaderLib/IVectorDataProvider.cs
+++ b/CA_DataUploaderLib/IVectorDataProvider.cs
@@ -9,6 +9,9 @@ namespace CA_DataUploaderLib
     {
         string Title { get; }
         List<VectorDescriptionItem> GetVectorDescriptionItems();
+        /// <returns>the vector description items for items related to local boards in the same order as <see cref="GetVectorDescriptionItems"/></returns>
+        List<VectorDescriptionItem> GetLocalInputsDescriptionItems();
+        /// <returns>The input values coming from local boards</returns>
         IEnumerable<SensorSample> GetInputValues();
         IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs);
         Task Run(CancellationToken token);

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -207,7 +207,8 @@ namespace CA_DataUploaderLib
             CALog.LogData(LogID.A, "finished waiting for switchboards loops");
         }
 
-        public List<VectorDescriptionItem> GetVectorDescriptionItems() => new List<VectorDescriptionItem>();
+        public List<VectorDescriptionItem> GetLocalInputsDescriptionItems() => new();
+        public List<VectorDescriptionItem> GetVectorDescriptionItems() => new();
         public IEnumerable<SensorSample> GetInputValues() => Enumerable.Empty<SensorSample>();
         public IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs) => Enumerable.Empty<SensorSample>();
     }

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -207,8 +207,7 @@ namespace CA_DataUploaderLib
             CALog.LogData(LogID.A, "finished waiting for switchboards loops");
         }
 
-        public List<VectorDescriptionItem> GetLocalInputsDescriptionItems() => new();
-        public List<VectorDescriptionItem> GetVectorDescriptionItems() => new();
+        public SubsystemDescriptionItems GetVectorDescriptionItems() => new(new (), new ());
         public IEnumerable<SensorSample> GetInputValues() => Enumerable.Empty<SensorSample>();
         public IEnumerable<SensorSample> GetDecisionOutputs(NewVectorReceivedArgs inputVectorReceivedArgs) => Enumerable.Empty<SensorSample>();
     }


### PR DESCRIPTION
* ISubsystemWithVectorData.GetInputValues now only reports inputs for local boards
* ISubsystemWithVectorData.GetVectorDescriptionItems now returns inputs and outputs separately + inputs are grouped by node
* added ExtendedVectorDescription.InputsPerNode (class was called VectorFilterAndMath before)
* added CommandHandler.GetExtendedVectorDescription
* added IOconfNode.SingleNode to be used in cases where there are no nodes configured
* removed data points x subsystem output during initialization, as it no longer gives an indication of detected boards
* IOconfNode now allows specifying a role string for the node
* added BaseSensorBox.ConnectionState.NodeUnreachable