### PR TITLE
fixes #136

### DIFF
--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -167,7 +167,7 @@ namespace CA_DataUploaderLib
                 return;
             }
 
-            var cmd = cmdString.Split(' ').Select(x => x.Trim()).ToList();
+            var cmd = cmdString.Trim().Split(' ').Select(x => x.Trim()).ToList();
 
             CALog.LogInfoAndConsoleLn(LogID.A, ""); // this ensures that next command start on a new line. 
             if (!cmd.Any())


### PR DESCRIPTION
note that this only fixes issues where the extra spaces are all at the beginning or the end of the command line. It does *not* address a command with extra spaces within the arguments, such like this one:  oven 100     200 150

It is of course possible to solve, for example, by using a simple regex for the split. However, at that point we might as well consider using an existing solution to parse commands, such like https://github.com/dotnet/command-line-api