### PR TITLE
fix thread safety in PluginsCommandHandler.When

### DIFF
--- a/CA_DataUploaderLib/PluginsCommandHandler.cs
+++ b/CA_DataUploaderLib/PluginsCommandHandler.cs
@@ -9,8 +9,8 @@ namespace CA_DataUploaderLib
     public sealed class PluginsCommandHandler : IPluginCommandHandler
     {
         private readonly CommandHandler cmd;
-        private readonly List<Action> removeCommandActions = new List<Action>();
-        private readonly List<EventHandler<NewVectorReceivedArgs>> subscribedNewVectorReceivedEvents = new List<EventHandler<NewVectorReceivedArgs>>();
+        private readonly List<Action> removeCommandActions = new();
+        private readonly List<EventHandler<NewVectorReceivedArgs>> subscribedNewVectorReceivedEvents = new();
 
         public PluginsCommandHandler(CommandHandler cmd) 
         {
@@ -19,8 +19,8 @@ namespace CA_DataUploaderLib
 
         public event EventHandler<NewVectorReceivedArgs> NewVectorReceived 
         { 
-            add { cmd.NewVectorReceived += value; subscribedNewVectorReceivedEvents.Add(value); } 
-            remove { cmd.NewVectorReceived -= value; subscribedNewVectorReceivedEvents.Remove(value); }
+            add { cmd.NewVectorReceived += value; lock(subscribedNewVectorReceivedEvents) subscribedNewVectorReceivedEvents.Add(value); } 
+            remove { cmd.NewVectorReceived -= value; lock(subscribedNewVectorReceivedEvents) subscribedNewVectorReceivedEvents.Remove(value); }
         }
         public void AddCommand(string name, Func<List<string>, bool> func) => removeCommandActions.Add(cmd.AddCommand(name, func));
         public void Execute(string command, bool addToCommandHistory) => cmd.Execute(command, addToCommandHistory);
@@ -47,8 +47,9 @@ namespace CA_DataUploaderLib
 
         public void Dispose()
         {// class is sealed without unmanaged resources, no need for the full disposable pattern.
-            foreach (var subscribedEvent in subscribedNewVectorReceivedEvents.ToArray())
-                NewVectorReceived -= subscribedEvent;
+            lock(subscribedNewVectorReceivedEvents)  
+                foreach (var subscribedEvent in subscribedNewVectorReceivedEvents.ToArray())
+                    NewVectorReceived -= subscribedEvent;
             foreach (var removeAction in removeCommandActions)
                 removeAction();
         }


### PR DESCRIPTION
multiple threads were able to modify the non thread safety list of events kept for use during dispose.