### PR TITLE
fixed unclear message

### DIFF
--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -115,7 +115,8 @@ namespace CA_DataUploaderLib
 
         private static bool CheckConnectedStateInVector(MCUBoard board, string boardStateName, ref bool waitingBoardReconnect, NewVectorReceivedArgs vector)
         {
-            var connected = (BaseSensorBox.ConnectionState)(int)vector[boardStateName] >= BaseSensorBox.ConnectionState.Connected;
+            var vectorState = (BaseSensorBox.ConnectionState)(int)vector[boardStateName];
+            var connected = vectorState >= BaseSensorBox.ConnectionState.Connected;
             if (waitingBoardReconnect && connected)
             {
                 CALog.LogData(LogID.B, $"resuming switchboard actions after reconnect on {board.ToShortDescription()}");
@@ -123,7 +124,7 @@ namespace CA_DataUploaderLib
             }
             else if (!waitingBoardReconnect && !connected)
             {
-                CALog.LogData(LogID.B, $"stopping switchboard actions while connection is reestablished on {board.ToShortDescription()}");
+                CALog.LogData(LogID.B, $"stopping switchboard actions while connection is reestablished - state: {vectorState} - {board.ToShortDescription()}");
                 waitingBoardReconnect = true;
             }
             return connected;

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -118,12 +118,12 @@ namespace CA_DataUploaderLib
             var connected = (BaseSensorBox.ConnectionState)(int)vector[boardStateName] >= BaseSensorBox.ConnectionState.Connected;
             if (waitingBoardReconnect && connected)
             {
-                CALog.LogInfo(LogID.B, $"resuming switchboard actions after reconnect on {board.ToShortDescription()}");
+                CALog.LogData(LogID.B, $"resuming switchboard actions after reconnect on {board.ToShortDescription()}");
                 waitingBoardReconnect = false;
             }
             else if (!waitingBoardReconnect && !connected)
             {
-                CALog.LogInfo(LogID.B, $"stopping switchboard actions while connection is reestablished on {board.ToShortDescription()}");
+                CALog.LogData(LogID.B, $"stopping switchboard actions while connection is reestablished on {board.ToShortDescription()}");
                 waitingBoardReconnect = true;
             }
             return connected;

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -118,12 +118,12 @@ namespace CA_DataUploaderLib
             var connected = (BaseSensorBox.ConnectionState)(int)vector[boardStateName] >= BaseSensorBox.ConnectionState.Connected;
             if (waitingBoardReconnect && connected)
             {
-                CALog.LogInfoAndConsoleLn(LogID.A, $"resuming switchboard actions after reconnect on {board.ToShortDescription()}");
+                CALog.LogInfo(LogID.B, $"resuming switchboard actions after reconnect on {board.ToShortDescription()}");
                 waitingBoardReconnect = false;
             }
             else if (!waitingBoardReconnect && !connected)
             {
-                CALog.LogInfoAndConsoleLn(LogID.A, $"stopping switchboard actions while connection is reestablished on {board.ToShortDescription()}");
+                CALog.LogInfo(LogID.B, $"stopping switchboard actions while connection is reestablished on {board.ToShortDescription()}");
                 waitingBoardReconnect = true;
             }
             return connected;


### PR DESCRIPTION
- added the connection state to the message about stopping switchboard actions, so that it states NodeUnreachable in cases where the whole node is detected as such (instead of communication problems with the board)
- the stopping/resuming switchboard actions message now only show in the B.log instead of in the screen for the operator. While it signals the point in time where actions actually resume, it was normally redundant as other messages from the read loop are usually shown (attempting to reconnect / reconnected). In this way, there is less noise in the screen without removing the ability of doing postmortem analysis with both the log entries. Operators can still look at the connection state in the plots without looking at the logs.