### PR TITLE
added ICommandRunner as an extension point for the CommandHandler

### DIFF
--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -162,6 +162,10 @@ namespace CA_DataUploaderLib
 
         private void HandleCommand(string cmdString, bool isUserCommand)
         {
+            //this ensures any command output, including a confirmation is shown in a separate line
+            //user commands: when the user presses enter the cursor does not go automatically to the next line, so the below ensures that even without output it shows correctly
+            //non user commands: this causes any text typed by the user before the non user command to show on a separate line
+            CALog.LogInfoAndConsoleLn(LogID.A, ""); 
             cmdString = cmdString.Trim();
             if (_commandRunner.Run(cmdString, isUserCommand) && isUserCommand)
                 OnUserCommandAccepted(cmdString);

--- a/CA_DataUploaderLib/DefaultCommandRunner.cs
+++ b/CA_DataUploaderLib/DefaultCommandRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace CA_DataUploaderLib
 {
@@ -26,9 +27,14 @@ namespace CA_DataUploaderLib
             };
         }
 
-        public bool Run(string cmdString, List<string> cmd)
+        public bool Run(string cmdString, bool isUserCommand)
         {
             CALog.LogInfoAndConsoleLn(LogID.A, ""); // this ensures that next command start on a new line. 
+
+            var cmd = cmdString.Trim().Split(' ').Select(x => x.Trim()).ToList();
+
+            if (!cmd.Any())
+                return false;
 
             string commandName = cmd[0].ToLower();
             if (!_commands.TryGetValue(commandName, out var commandFunctions))

--- a/CA_DataUploaderLib/DefaultCommandRunner.cs
+++ b/CA_DataUploaderLib/DefaultCommandRunner.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CA_DataUploaderLib
+{
+    /// <remarks>
+    /// runs the registered commands directly on the calling thread (the input handling thread),
+    /// showing accept/reject messages on the screen and A.log.
+    /// </remarks>
+    public class DefaultCommandRunner : ICommandRunner
+    {
+        private readonly Dictionary<string, List<Func<List<string>, bool>>> _commands = new();
+        public Action AddCommand(string name, Func<List<string>, bool> func)
+        {
+            name = name.ToLower();
+            if (_commands.ContainsKey(name))
+                _commands[name].Add(func);
+            else
+                _commands.Add(name, new List<Func<List<string>, bool>> { func });
+
+            return () =>
+            {
+                _commands[name].Remove(func);
+                if (_commands[name].Count == 0)
+                    _commands.Remove(name);
+            };
+        }
+
+        public bool Run(string cmdString, List<string> cmd)
+        {
+            string commandName = cmd[0].ToLower();
+            if (!_commands.TryGetValue(commandName, out var commandFunctions))
+            {
+                CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - unknown command");
+                return false;
+            }
+
+            var res = RunCommandFunctions(cmdString, cmd, commandFunctions);
+            if (commandName == "help")
+                CALog.LogInfoAndConsoleLn(LogID.A, "-------------------------------------");  // end help menu divider
+            else if (res == false)
+                CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - bad command");
+            else if (res == true)
+                CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - command accepted");
+            else
+                CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - bad command / accepted by some subsystems");
+
+            return res ?? true; //note we also return true when res is null, which means some executions succeeded and one failed
+        }
+
+        /// <returns><c>true</c> if all functions executed the command, <c>false</c> if all functions rejected the command, <c>null</c> for a mix of executed/rejected</returns>
+        /// <remarks>
+        /// If a command is rejected, we do not run the rest of the commands. This runs on the order the commands were registered.
+        /// </remarks>
+        private static bool? RunCommandFunctions(string cmdString, List<string> cmd, List<Func<List<string>, bool>> commandFunctions)
+        {
+            for (int i = 0; i < commandFunctions.Count; i++)
+            {
+                try
+                {
+                    if (!commandFunctions[i](cmd))
+                        return i == 0 ? false : null;
+                }
+                catch (ArgumentException ex)
+                {
+                    CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - invalid arguments", ex);
+                    return i == 0 ? false : null;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/CA_DataUploaderLib/DefaultCommandRunner.cs
+++ b/CA_DataUploaderLib/DefaultCommandRunner.cs
@@ -29,8 +29,6 @@ namespace CA_DataUploaderLib
 
         public bool Run(string cmdString, bool isUserCommand)
         {
-            CALog.LogInfoAndConsoleLn(LogID.A, ""); // this ensures that next command start on a new line. 
-
             var cmd = cmdString.Trim().Split(' ').Select(x => x.Trim()).ToList();
 
             if (!cmd.Any())

--- a/CA_DataUploaderLib/DefaultCommandRunner.cs
+++ b/CA_DataUploaderLib/DefaultCommandRunner.cs
@@ -28,6 +28,8 @@ namespace CA_DataUploaderLib
 
         public bool Run(string cmdString, List<string> cmd)
         {
+            CALog.LogInfoAndConsoleLn(LogID.A, ""); // this ensures that next command start on a new line. 
+
             string commandName = cmd[0].ToLower();
             if (!_commands.TryGetValue(commandName, out var commandFunctions))
             {

--- a/CA_DataUploaderLib/ICommandRunner.cs
+++ b/CA_DataUploaderLib/ICommandRunner.cs
@@ -6,6 +6,6 @@ namespace CA_DataUploaderLib
     public interface ICommandRunner
     {
         Action AddCommand(string name, Func<List<string>, bool> func);
-        bool Run(string cmdString, List<string> cmd);
+        bool Run(string cmdString, bool isUserCommand);
     }
 }

--- a/CA_DataUploaderLib/ICommandRunner.cs
+++ b/CA_DataUploaderLib/ICommandRunner.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CA_DataUploaderLib
+{
+    public interface ICommandRunner
+    {
+        Action AddCommand(string name, Func<List<string>, bool> func);
+        bool Run(string cmdString, List<string> cmd);
+    }
+}

--- a/CA_DataUploaderLib/PluginsCommandHandler.cs
+++ b/CA_DataUploaderLib/PluginsCommandHandler.cs
@@ -23,6 +23,8 @@ namespace CA_DataUploaderLib
             remove { cmd.NewVectorReceived -= value; lock(subscribedNewVectorReceivedEvents) subscribedNewVectorReceivedEvents.Remove(value); }
         }
         public void AddCommand(string name, Func<List<string>, bool> func) => removeCommandActions.Add(cmd.AddCommand(name, func));
+        //the addToCommandHistory should be renamed isUserCommand, but not changing now to avoid a new plugins base version just for an arg name change
+        //note addToCommandHistory is always false, as sent by: LoopControlCommand.ExecuteCommand
         public void Execute(string command, bool addToCommandHistory) => cmd.Execute(command, addToCommandHistory);
         public async Task<NewVectorReceivedArgs> When(Predicate<NewVectorReceivedArgs> condition, CancellationToken token)
         {

--- a/CA_DataUploaderLib/RunningCommandEventArgs.cs
+++ b/CA_DataUploaderLib/RunningCommandEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace CA_DataUploaderLib
+{
+    public class RunningCommandEventArgs : CancelEventArgs
+    {
+        public RunningCommandEventArgs(string rawCommand, List<string> parsedCommand)
+        {
+            RawCommand = rawCommand;
+            ParsedCommand = parsedCommand;
+        }
+
+        public string RawCommand { get; }
+        public List<string> ParsedCommand { get; }
+    }
+}


### PR DESCRIPTION
The host can pass a different command runner to the CommandHandler constructor, allowing the replace or extend the way the DefaultCommandRunner works.

Also:
* fixed: non user commands were clearing the user input (biggest offender would be the commands ran by the plugins)
* fixed: help displayed during startup is no longer added to the event log and command history
* the distinction of user vs. non user commands is now more explicit in CommandHandler 
* small refactor around handling of escape vs. abort for commands in the private CommandHandler.GetCommand