### PR TITLE
added ability to change how/where user output is handled

### DIFF
--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -162,10 +162,6 @@ namespace CA_DataUploaderLib
 
         private void HandleCommand(string cmdString, bool isUserCommand)
         {
-            //this ensures any command output, including a confirmation is shown in a separate line
-            //user commands: when the user presses enter the cursor does not go automatically to the next line, so the below ensures that even without output it shows correctly
-            //non user commands: this causes any text typed by the user before the non user command to show on a separate line
-            CALog.LogInfoAndConsoleLn(LogID.A, ""); 
             cmdString = cmdString.Trim();
             if (_commandRunner.Run(cmdString, isUserCommand) && isUserCommand)
                 OnUserCommandAccepted(cmdString);
@@ -215,6 +211,7 @@ namespace CA_DataUploaderLib
                 info = Console.ReadKey(true);
             }
 
+            Console.WriteLine(string.Empty); //write the newline as the user pressed enter
             return inputCommand.ToString();
         }
 

--- a/CA_DataUploaderLib/DefaultCommandRunner.cs
+++ b/CA_DataUploaderLib/DefaultCommandRunner.cs
@@ -69,7 +69,7 @@ namespace CA_DataUploaderLib
                 }
                 catch (ArgumentException ex)
                 {
-                    CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - invalid arguments", ex);
+                    CALog.LogErrorAndConsoleLn(LogID.A, $"Command: {cmdString} - invalid arguments", ex);
                     return i == 0 ? false : null;
                 }
             }

--- a/CA_DataUploaderLib/EventType.cs
+++ b/CA_DataUploaderLib/EventType.cs
@@ -5,5 +5,7 @@
         Alert = 0,
         Command = 1,
         SystemChangeNotification = 2,
+        Log = 3,
+        LogError = 4
     }
 }

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -314,9 +314,6 @@ namespace CA_DataUploaderLib
 
                     while (IsEmpty() && TryReadLine(ref buffer, out var input))
                     {
-                        if (Debugger.IsAttached && input.Length > 0)
-                            CALog.LogColor(LogID.A, ConsoleColor.Green, input);
-
                         ableToRead |= input.Length >= 2;
                         input = input.Trim();
                         if (input.StartsWith(serialNumberHeader))
@@ -367,23 +364,23 @@ namespace CA_DataUploaderLib
 
                     if (res.IsCompleted)
                     {
-                        CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {PortName} ({port.BaudRate}): pipe reader was closed");
+                        CALog.LogErrorAndConsoleLn(LogID.A, $"Unable to read from {PortName} ({port.BaudRate}): pipe reader was closed");
                         break; // typically means the connection was closed.
                     }
                 }
                 catch (TimeoutException ex)
                 {
-                    CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {PortName} ({port.BaudRate}): " + ex.Message);
+                    CALog.LogErrorAndConsoleLn(LogID.A, $"Unable to read from {PortName} ({port.BaudRate}): " + ex.Message);
                     break;
                 }
                 catch (OperationCanceledException ex)
                 {
-                    CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {PortName} ({port.BaudRate}): " + ex.Message);
+                    CALog.LogErrorAndConsoleLn(LogID.A, $"Unable to read from {PortName} ({port.BaudRate}): " + ex.Message);
                     break;
                 }
                 catch (Exception ex)
                 {
-                    CALog.LogColor(LogID.A, ConsoleColor.Red, $"Unable to read from {PortName} ({port.BaudRate}): " + ex.Message);
+                    CALog.LogErrorAndConsoleLn(LogID.A, $"Unable to read from {PortName} ({port.BaudRate}): " + ex.Message);
                 }
             }
 


### PR DESCRIPTION
* CALog.LoggerForUserOutput can be used to share the output to the user through different means than the console output
* small simplification to CALog removing a few unused/low usage methods
* added CALog.EventLogger that can be used to send the user output to the event log
* during shutdown the uploader attempts to send any queued data + sends an extra event stating the uploader has stopped