### PR TITLE
small logging / events noise improvements

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -118,7 +118,8 @@ namespace CA_DataUploaderLib
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, _boardLoopsStopTokenSource.Token);
                 var readLoops = StartReadLoops(boards, linkedCts.Token);
                 await Task.WhenAll(readLoops);
-                CALog.LogInfoAndConsoleLn(LogID.A, $"Exiting {Title}.RunBoardReadLoops() " + DateTime.Now.Subtract(start).Humanize(5));
+                if (readLoops.Count > 0) //we only report the exit when we actually ran loops with detected boards. If a board was not detected StartReadLoops already reports the missing boards.
+                    CALog.LogInfoAndConsoleLn(LogID.A, $"Exiting {Title}.RunBoardReadLoops() " + DateTime.Now.Subtract(start).Humanize(5));
             }
             catch (Exception ex)
             {

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -23,7 +23,6 @@ namespace CA_DataUploaderLib
         protected readonly List<SensorSample> _localValues;
         private readonly (IOconfMap map, SensorSample[] values)[] _boards;
         protected readonly AllBoardsState _boardsState;
-        private readonly string commandHelp;
         private readonly CancellationTokenSource _boardLoopsStopTokenSource = new CancellationTokenSource();
         private readonly Dictionary<MCUBoard, SensorSample[]> _boardSamplesLookup = new Dictionary<MCUBoard, SensorSample[]>();
         private readonly string mainSubsystem;
@@ -41,9 +40,7 @@ namespace CA_DataUploaderLib
             if (cmd != null)
             {
                 mainSubsystem = commandName.ToLower();
-                commandHelp = $"{mainSubsystem + " " + commandArgsHelp,-26}- {commandDescription}";
                 SubscribeCommandsToSubsystems(cmd, mainSubsystem, _values);
-                cmd.AddCommand("help", HelpMenu);
                 cmd.AddCommand("escape", Stop);
                 cmd.AddSubsystem(this);
             }
@@ -383,13 +380,6 @@ namespace CA_DataUploaderLib
                 return samples;
             _boardSamplesLookup[board] = samples = _values.Where(s => s.Input.BoxName == board.BoxName).ToArray();
             return samples;
-        }
-
-
-        private bool HelpMenu(List<string> args)
-        {
-            CALog.LogInfoAndConsoleLn(LogID.A, commandHelp);
-            return true;
         }
 
         private void LogError(IOconfMap board, string message, Exception ex) 

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -414,8 +414,6 @@ namespace CA_DataUploaderLib
             public Signing(string loopName)
             {
                 var keyFilename = "Key" + loopName + ".bin";
-                CALog.LogInfoAndConsoleLn(LogID.A, loopName);
-
                 if (File.Exists(keyFilename))
                     _rsaWriter.ImportCspBlob(File.ReadAllBytes(keyFilename));
                 else

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -263,12 +263,19 @@ namespace CA_DataUploaderLib
             {
                 if (force || _badPackages.First().AddHours(1) < DateTime.UtcNow)
                 {
-                    CALog.LogInfoAndConsoleLn(LogID.A, $"Vector upload errors within the last hour:");
-                    foreach (var minutes in _badPackages.GroupBy(x => x.ToString("MMM dd HH:mm")))
-                        CALog.LogInfoAndConsoleLn(LogID.A, $"{minutes.Key} = {minutes.Count()}");
-
+                    var msg = GetBadPackagesErrorMessage(_badPackages);
+                    CALog.LogInfoAndConsoleLn(LogID.A, msg);
                     _badPackages.Clear();
                 }
+            }
+
+            static string GetBadPackagesErrorMessage(List<DateTime> times)
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("Vector upload errors within the last hour:");
+                foreach (var minutes in times.GroupBy(x => x.ToString("MMM dd HH:mm")))
+                    sb.AppendLine($"{minutes.Key} = {minutes.Count()}");
+                return sb.ToString();
             }
         }
 

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -239,7 +239,8 @@ namespace CA_DataUploaderLib
             static string ToShortEventData(SystemChangeNotificationData data)
             {
                 var sb = new StringBuilder(data.Boards.Count * 100);//allocate more than enough space to avoid slow unnecesary resizes
-                sb.AppendLine("Detected devices:");
+                sb.Append("Detected devices for ");
+                sb.AppendLine(data.NodeName);
                 foreach (var board in data.Boards)
                 {
                     sb.AppendFormat("{0} {1} {2} {3}", board.MappedBoardName, board.ProductType, board.SerialNumber, board.Port);

--- a/CA_DataUploaderLib/SystemChangeNotificationData.cs
+++ b/CA_DataUploaderLib/SystemChangeNotificationData.cs
@@ -7,6 +7,7 @@ namespace CA_DataUploaderLib
 {
     public class SystemChangeNotificationData
     {
+        public string NodeName { get; internal set; }
         public List<BoardInfo> Boards { get; init; }
         private static JsonSerializerOptions SerializerOptions { get; } = new JsonSerializerOptions(JsonSerializerDefaults.Web);
         internal string ToJson() => JsonSerializer.Serialize(this, SerializerOptions);
@@ -34,6 +35,7 @@ namespace CA_DataUploaderLib
                     writer.WriteString("PcbVersion", board.PcbVersion);
                     writer.WriteString("Calibration", board.Calibration);
                     writer.WriteString("TimeStamp", timeSpan);
+                    writer.WriteString("NodeName", NodeName);
                     writer.WriteEndObject();
                 }
                 writer.WriteEndArray();


### PR DESCRIPTION
* fixed: noise on startup for subsystems without (detected) boards

* removed log message that is noise for custom hosts

* phasing out help for local read commands / use the plots instead

* version and up now include the node name in their output (useful for distributed deployments)

* bad packages message is now logged as one event instead of multiple ones