### PR TITLE
fixed: enabling custom writes in one board prevents other boards from working

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -199,7 +199,12 @@ namespace CA_DataUploaderLib
                     if (customWritesEnabled && customCommandsChannel.TryRead(out var command))
                         await board.SafeWriteLine(command, token);
 
-                    if (!buildInActionsEnabled) continue;
+                    if (!buildInActionsEnabled)
+                    {
+                        EnsureResumeAfterTimeoutIsReported();
+                        await customCommandsChannel.WaitToReadAsync(token);
+                        continue;
+                    }
 
                     var vector = await _cmdAdvanced.When(_ => true, token);
                     if (!CheckConnectedStateInVector(board, boardStateName, ref waitingBoardReconnect, vector))


### PR DESCRIPTION
The issue triggered when using the [customwrites feature](https://github.com/copenhagenatomics/CA_DataUploader/pull/169) on boards without build in actions. 

Specifically BaseSensorBox.BoardWriteLoop would keep calling customCommandsChannel.TryRead in a tight loop. This caused 2 issues:
1. 100% usage of one of the cores
2. the calling thread never got released during initialization, so CommandHandler.RunSubsystems gets stuck and does not finish initializing the rest of the subsystem

The fix uses customCommandsChannel.WaitToReadAsync to wait for custom commands to arrive. This properly releases the thread while we wait for a custom command, solving both problems described above. Note the fix is not applied when build in actions are enabled for the board as the loop already has proper delays waiting for vectors in that case.

Also fixed a missing resume after timeout message for boards using custom writes.