### PR TITLE
added decisions configuration support

### DIFF
--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -43,7 +43,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />
-	  <PackageReference Include="CA.LoopControlPluginBase" Version="1.0.0-alpha.0" />
+	  <PackageReference Include="CA.LoopControlPluginBase" Version="1.0.0-alpha.0.4" />
 	  <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
   </ItemGroup>
 

--- a/CA_DataUploaderLib/DecisionConfig.cs
+++ b/CA_DataUploaderLib/DecisionConfig.cs
@@ -1,0 +1,21 @@
+﻿using CA.LoopControlPluginBase;
+using System.Collections.Generic;
+
+namespace CA_DataUploaderLib
+{
+    public class DecisionConfig : IDecisionConfig
+    {
+        private readonly string decision;
+        private readonly Dictionary<string, string> values;
+
+        public DecisionConfig(string decision, Dictionary<string, string> values)
+        {
+            this.decision = decision;
+            this.values = values;
+        }
+
+        public string Decision => decision;
+        public IEnumerable<string> Fields => values.Keys;
+        public bool TryGet(string fieldName, out string val) => values.TryGetValue(fieldName, out val);
+    }
+}

--- a/CA_DataUploaderLib/Extensions/StringExtensions.cs
+++ b/CA_DataUploaderLib/Extensions/StringExtensions.cs
@@ -27,7 +27,7 @@ namespace CA_DataUploaderLib.Extensions
         {
             int pos = s.IndexOf(match);
             if (pos == -1)
-                return String.Empty;
+                return string.Empty;
             else
                 return s.Substring(0, pos);
         }

--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -62,7 +62,7 @@ namespace CA_DataUploaderLib.IOconf
             {
                 var separatorIndex = row.IndexOf(';');
                 var rowType = separatorIndex > -1 ? row.AsSpan()[..separatorIndex].Trim() : row;
-                var loader = GetLoader(rowType) ?? ((r, l) => new IOconfRow(r, l, "Unknown"));
+                var loader = GetLoader(rowType) ?? ((r, l) => new IOconfRow(r, l, "Unknown", true));
                 return loader(row, lineNum);
             }
             catch (Exception ex)

--- a/CA_DataUploaderLib/IOconf/IOconfRow.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRow.cs
@@ -7,21 +7,23 @@ namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfRow
     {
-        public IOconfRow(string row, int lineNum, string type)
+        public IOconfRow(string row, int lineNum, string type, bool isUnknown = false)
         {
             Row = row;
-            Type = type;
             LineNumber = lineNum;
+            IsUnknown = isUnknown;
             var list = ToList();
-            if (list[0] != Type) throw new Exception("IOconfRow: wrong format: " + Row);
+            if (!isUnknown && list[0] != type) throw new Exception("IOconfRow: wrong format: " + row);
+            Type = list[0];
             Name = list[1]; // could be overwritten elsewhere. 
         }
 
-        protected readonly string Row;
-        protected readonly string Type;
+        public string Row { get; }
+        public string Type { get; }
         protected readonly int LineNumber;
         public string Name { get; init; }
         protected string Format { get; init; } = string.Empty;
+        public bool IsUnknown { get; }
 
         public List<string> ToList() => RowWithoutComment().Split(";".ToCharArray()).Select(x => x.Trim()).ToList();
 


### PR DESCRIPTION
breaking changes:
- IOconfFile no longer throws an exception if there are unknown/mistyped entries. The CommandHandler still rejects those configurations, but custom code running in a host that does not use the CommandHandler now must explicitely use IOconfFile.GetEntries and check for entries with IsUnknown to validate the configuration does not have invalid entries