### PR TITLE
decisions plugins - not uploading specific fields

### DIFF
--- a/CA.LoopControlPluginBase/LoopControlDecision.cs
+++ b/CA.LoopControlPluginBase/LoopControlDecision.cs
@@ -31,9 +31,10 @@ namespace CA.LoopControlPluginBase
         public virtual void SetConfig(IDecisionConfig config) { }
     }
     public enum FieldType { Input = 1, State = 2, Output = 3 }
-    public record PluginField(string Name, FieldType Type)
+    public record PluginField(string Name, FieldType Type = FieldType.State)
     {
-        public static implicit operator PluginField(string name) => new(name, FieldType.State);
+        public bool Upload { get; init; } = true;
+        public static implicit operator PluginField(string name) => new(name);
         public static implicit operator PluginField((string name, FieldType type) tuple) => new(tuple.name, tuple.type);
     }
 }


### PR DESCRIPTION
updated decisions plugins so they can now state whether their fields should be or not uploaded to the plots