### PR TITLE
allow built-in decisions not uploading specific fields

### DIFF
--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -43,7 +43,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />
-	  <PackageReference Include="CA.LoopControlPluginBase" Version="1.0.0-alpha.0.4" />
+	  <PackageReference Include="CA.LoopControlPluginBase" Version="1.0.0-alpha.0.6" />
 	  <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
   </ItemGroup>
 

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -156,7 +156,7 @@ namespace CA_DataUploaderLib
             foreach (var decision in decisions)
                 if (configEntriesLookup.Contains(decision.Name))
                     decision.SetConfig(new DecisionConfig(decision.Name, configEntriesLookup[decision.Name].ToDictionary(e => e.Name, e => string.Join(';', e.ToList().Skip(2)))));
-            var outputs = decisions.SelectMany(d => d.PluginFields.Select(f => new VectorDescriptionItem("double", f.Name, (DataTypeEnum)f.Type))).ToList();
+            var outputs = decisions.SelectMany(d => d.PluginFields.Select(f => new VectorDescriptionItem("double", f.Name, (DataTypeEnum)f.Type) { Upload = f.Upload })).ToList();
             var desc = new ExtendedVectorDescription(inputsPerNode, outputs, RpiVersion.GetHardware(), RpiVersion.GetSoftware());
             foreach (var decision in decisions)
                 decision.Initialize(new(desc.VectorDescription._items.Select(i => i.Descriptor).ToArray()));

--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -44,7 +44,8 @@ namespace CA_DataUploaderLib
             private readonly Config _config;
             private Indexes? _indexes;
             public override string Name => _config.Name;
-            public override PluginField[] PluginFields => new PluginField[] { $"state_{Name}", ($"{Name}_onoff", FieldType.Output), $"{Name}_nextcontrolperiod", $"{Name}_controlperiodtimeoff" };
+            public override PluginField[] PluginFields => new PluginField[] { 
+                $"state_{Name}", ($"{Name}_onoff", FieldType.Output), new($"{Name}_nextcontrolperiod") { Upload = false }, new($"{Name}_controlperiodtimeoff") { Upload = false} };
             public override string[] HandledEvents => new List<string>(_eventsMap.Keys).ToArray();
             public HeaterDecision(IOconfHeater heater, IOconfOven? oven) : this(ToConfig(heater, oven)) { }
             public HeaterDecision(Config config)

--- a/CA_DataUploaderLib/VectorDescription.cs
+++ b/CA_DataUploaderLib/VectorDescription.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Serialization;
 
 namespace CA_DataUploaderLib
 {
@@ -33,7 +34,6 @@ namespace CA_DataUploaderLib
 
             return msg;
         }
-
     }
 
     [Serializable]
@@ -44,6 +44,13 @@ namespace CA_DataUploaderLib
         public string Descriptor { get; set; }  // Name of data line in webchart. 
         public DataTypeEnum DirectionType { get; set; }
         public string DataType { get; set; }
-
+        /// <summary>whether the item should be included in the description and vector uploaded and available in the plots</summary>
+        /// <remarks>
+        /// The <see cref="Upload"/> property itself is not included in the uploaded <see cref="VectorDescriptionItem"/>
+        /// 
+        /// Note that even though the property is not uploaded to the plots, it is still available in the local vector and distributed hosts must include it in the vector information used by the decisions in the cluster
+        /// </remarks>
+        [XmlIgnore]
+        public bool Upload { get; init; } = true;
     }
 }


### PR DESCRIPTION
The heater decision no longer uploads the nextcontrolperiod and controlperiodtimeoff.

The uploaded fields suffer precision loss that is significant for their odate format + plots are only displaying the raw odate value. Due to this, they have no diagnostic value which was their main use case. The fields also had very little operator value to begin with, and no value for plugin authors.