### PR TITLE
allows specifying the decisions plugins order

### DIFF
--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -27,6 +27,7 @@ namespace CA_DataUploaderLib.IOconf
             ("GenericSensor", (r, l) => new IOconfGeneric(r, l)),
             ("SwitchboardSensor", (r, l) => new IOconfSwitchboardSensor(r, l)),
             ("Node", (r, l) => new IOconfNode(r, l)),
+            ("Code", (r, l) => new IOconfCode(r, l)),
         };
 
         public static (List<string>, IEnumerable<IOconfRow>) Load()

--- a/CA_DataUploaderLib/IOconf/IOconfCode.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfCode.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace CA_DataUploaderLib.IOconf
+{
+    public class IOconfCode : IOconfRow
+    {
+        private static byte _nodeInstances;
+
+        public IOconfCode(string row, int lineNum) : base(row, lineNum, "Code")
+        {
+            Format = "Code;Name;Version";
+            var list = ToList();
+            if (list.Count < 3) throw new FormatException($"Missing version in Code line in IO.conf: {row} {Environment.NewLine}{Format}");
+            if (!Version.TryParse(list[2], out var v)) throw new FormatException($"Invalid version format in Code line in IO.conf: {row} {Environment.NewLine}{Format}");
+            Version = v;
+            Index = _nodeInstances++;
+        }
+
+        public int Index { get; }
+        public Version Version { get; }
+
+        /// <summary>resets the node instance count used to determine the node index, can be used for testing purposes</summary>
+        public static void ResetNodeIndexCount() => _nodeInstances = 0;
+    }
+}


### PR DESCRIPTION
To do this, list the plugins and the version in order in IO.conf, by using the new Code lines: Code;Name;Version