### PR TITLE
reduced risk of slowing down application cycles

### DIFF
--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -41,7 +41,11 @@ namespace CA_DataUploaderLib
         public CommandHandler(SerialNumberMapper? mapper = null, ICommandRunner? runner = null)
         {
             _receivedVectorsWriter = _receivedVectorsChannel.Writer;
-            _exitCts.Token.Register(() => _runningTaskTcs.TrySetCanceled());
+            _exitCts.Token.Register(() =>
+            {
+                _runningTaskTcs.TrySetCanceled();
+                _receivedVectorsWriter.TryComplete();
+            });
             _commandRunner = runner ?? new DefaultCommandRunner();
             _mapper = mapper;
             _fullsystemFilterAndMath = new Lazy<ExtendedVectorDescription>(GetFullSystemFilterAndMath);
@@ -197,8 +201,9 @@ namespace CA_DataUploaderLib
 
         public void OnNewVectorReceived(DataVector args)
         {
-            if (!_receivedVectorsWriter.TryWrite(args))
+            if (!_receivedVectorsWriter.TryWrite(args) && IsRunning)
                 //at the time of writing the channel was unbounded, so it is not supposed to fail to add vectors to the channel
+                //note one case TryWrite may return false is when the channel is flagged as completed when we are stopping, thus the check for IsRunning above
                 throw new InvalidOperationException("unexpected failure to write to the received vectors channel"); 
         }
 

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Channels;
 
 namespace CA_DataUploaderLib
 {
@@ -27,8 +28,10 @@ namespace CA_DataUploaderLib
         private readonly Lazy<ExtendedVectorDescription> _fullsystemFilterAndMath;
         private readonly CancellationTokenSource _exitCts = new();
         private readonly TaskCompletionSource _runningTaskTcs = new();
+        private readonly Channel<DataVector> _receivedVectorsChannel = Channel.CreateUnbounded<DataVector>();
+        private readonly ChannelWriter<DataVector> _receivedVectorsWriter;
 
-        public event EventHandler<DataVector>? NewVectorReceived;
+        public ChannelReader<DataVector> ReceivedVectorsReader => _receivedVectorsChannel.Reader;
         public event EventHandler<EventFiredArgs>? EventFired;
         public event EventHandler<IReadOnlyDictionary<string, int>>? FullVectorIndexesCreated;
         public bool IsRunning => !_exitCts.IsCancellationRequested;
@@ -37,6 +40,7 @@ namespace CA_DataUploaderLib
 
         public CommandHandler(SerialNumberMapper? mapper = null, ICommandRunner? runner = null)
         {
+            _receivedVectorsWriter = _receivedVectorsChannel.Writer;
             _exitCts.Token.Register(() => _runningTaskTcs.TrySetCanceled());
             _commandRunner = runner ?? new DefaultCommandRunner();
             _mapper = mapper;
@@ -191,7 +195,13 @@ namespace CA_DataUploaderLib
             return nodes.Count > 0 ? nodes : new() { IOconfNode.SingleNode };
         }
 
-        public void OnNewVectorReceived(DataVector args) => NewVectorReceived?.Invoke(this, args);
+        public void OnNewVectorReceived(DataVector args)
+        {
+            if (!_receivedVectorsWriter.TryWrite(args))
+                //at the time of writing the channel was unbounded, so it is not supposed to fail to add vectors to the channel
+                throw new InvalidOperationException("unexpected failure to write to the received vectors channel"); 
+        }
+
         public void FireAlert(string msg, DateTime timespan)
         {
             CALog.LogErrorAndConsoleLn(LogID.A, msg);

--- a/CA_DataUploaderLib/GenericSensorBox.cs
+++ b/CA_DataUploaderLib/GenericSensorBox.cs
@@ -4,6 +4,6 @@ namespace CA_DataUploaderLib
 {
     public class GenericSensorBox : BaseSensorBox
     {
-        public GenericSensorBox(CommandHandler cmd) : base(cmd, "Generic", string.Empty, "show values for generic sensors", IOconfFile.GetGeneric()) { }
+        public GenericSensorBox(CommandHandler cmd) : base(cmd, "Generic", IOconfFile.GetGeneric()) { }
     }
 }

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -20,7 +20,7 @@ namespace CA_DataUploaderLib
             var boardsTemperatures = ports.GroupBy(p => p.BoxName).Select(g => g.First().GetBoardTemperatureInputConf());
             var sensorPortsInputs = IOconfFile.GetEntries<IOconfSwitchboardSensor>().SelectMany(i => i.GetExpandedConf());
             var inputs = ports.SelectMany(p => p.GetExpandedInputConf()).Concat(boardsTemperatures).Concat(sensorPortsInputs);
-            var boardsLoops = new BaseSensorBox(cmd, "switchboards", string.Empty, "show switchboards inputs", inputs);
+            var boardsLoops = new BaseSensorBox(cmd, "switchboards", inputs);
             //we ignore remote boards and boards missing during the start sequence (as we don't have auto reconnect logic yet for those). Note the BaseSensorBox already reports the missing local boards.
             foreach (var board in ports.Where(p => p.Map.IsLocalBoard && p.Map.Board != null).GroupBy(v => v.Map.Board))
                 RegisterBoardWriteActions(cmd, boardsLoops, board.Key, board.ToList());

--- a/CA_DataUploaderLib/ThermocoupleBox.cs
+++ b/CA_DataUploaderLib/ThermocoupleBox.cs
@@ -13,7 +13,7 @@ namespace CA_DataUploaderLib
     {
         private readonly SensorSample _rpiGpuSample;
         private readonly SensorSample _rpiCpuSample;
-        public ThermocoupleBox(CommandHandler cmd) : base(cmd, "Temperatures", string.Empty, "show all temperatures in input queue", GetSensors()) 
+        public ThermocoupleBox(CommandHandler cmd) : base(cmd, "Temperatures", GetSensors()) 
         { // these are disabled / null when RpiTemp is disabled
             _rpiGpuSample = _values.FirstOrDefault(x => IOconfRPiTemp.IsLocalGpuSensor(x.Input));
             _rpiCpuSample = _values.FirstOrDefault(x => IOconfRPiTemp.IsLocalCpuSensor(x.Input));


### PR DESCRIPTION
removed CommandHandler.NewVectorReceived

use CommandHandler.ReceviedVectorsReader instead. This avoids consumers logic slowing down the application cycles. Similar to the concern described at https://github.com/copenhagenatomics/CA_DataUploader/issues/142

other changes:
- removed unused arguments from BaseSensorBox's constructor
- fixed regression handlign built in actions in BaseSensorBox