### PR TITLE
improved command feedback

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -66,15 +66,12 @@ namespace CA_DataUploaderLib
                 var channel = Channel.CreateUnbounded<string>();
                 var channelWriter = channel.Writer;
                 boardCustomCommandsReceived.Add(map.McuBoard, channel.Reader);
-                cmd?.AddCommand("custom", CustomCommand);
+                cmd?.AddCommand("custom", CustomCommand); //note that the custom is a special command that the host needs to run only in the node that has the board.
 
                 bool CustomCommand(List<string> args)
                 {
                     if (args.Count < 3) return false;
-                    if (args[1] != map.BoxName)
-                        //note we only reject the command if the board name is invalid,
-                        //which not only avoids bad command being reported but prevents further command execution from being aborted in the default command runner
-                        return localBoards.Contains(args[1]); 
+                    if (args[1] != map.BoxName) return false; 
                     channelWriter.TryWrite(string.Join(' ', args.Skip(2)));
                     return true;
                 }

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -11,6 +11,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
+using CA_DataUploaderLib.Extensions;
+using System.Globalization;
 
 namespace CA_DataUploaderLib
 {
@@ -65,9 +67,27 @@ namespace CA_DataUploaderLib
             {
                 //This just avoids the commands being reported as rejected for now, but the way to go about in the long run is to add detection of the executed commands by looking at the vectors.
                 //Note that even then, the decisions are not reporting which commands they actually handled or ignore, specially as they are receiving all commands and then handle what applies to the decision.
-                var firstWhitespace = e.IndexOf(' ');
-                var firstWordInEvent = firstWhitespace != -1 ? e[..firstWhitespace] : e;
-                AddCommand(firstWordInEvent, _ => true);
+                var expectedArgs = e.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                var firstWordInEvent = expectedArgs[0];
+                AddCommand(firstWordInEvent, args =>
+                {
+                    if (args.Count != expectedArgs.Length && args.Count != expectedArgs.Length + 1) 
+                        return false;
+
+                    for (int i = 1; i < expectedArgs.Length; i++)
+                    {
+                        if (!args[i].Equals(expectedArgs[i], StringComparison.OrdinalIgnoreCase))
+                            return false;
+                    }
+
+                    if (args.Count == expectedArgs.Length) 
+                        return true;
+
+                    var target = args[expectedArgs.Length];
+                    return target.TryToDouble(out _) || 
+                        target.StartsWith("0x") && uint.TryParse(target[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _) ||
+                        target.StartsWith("#") && uint.TryParse(target[1..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _);
+                });
             }
 
             targetList.AddRange(decisions);

--- a/CA_DataUploaderLib/DefaultCommandRunner.cs
+++ b/CA_DataUploaderLib/DefaultCommandRunner.cs
@@ -28,7 +28,7 @@ namespace CA_DataUploaderLib
 
         public bool Run(string cmdString, bool isUserCommand)
         {
-            var cmd = cmdString.Trim().Split(' ').Select(x => x.Trim()).ToList();
+            var cmd = cmdString.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToList();
 
             if (!cmd.Any())
                 return false;
@@ -43,37 +43,32 @@ namespace CA_DataUploaderLib
             var res = RunCommandFunctions(cmdString, cmd, commandFunctions);
             if (commandName.Equals("help", StringComparison.OrdinalIgnoreCase))
                 CALog.LogInfoAndConsoleLn(LogID.A, "-------------------------------------");  // end help menu divider
-            else if (res == false)
+            else if (!res)
                 CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - bad command");
-            else if (res == true)
-                CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - command accepted");
             else
-                CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - bad command / accepted by some subsystems");
+                CALog.LogInfoAndConsoleLn(LogID.A, $"Command: {cmdString} - command accepted");
 
-            return res ?? true; //note we also return true when res is null, which means some executions succeeded and one failed
+            return res;
         }
 
-        /// <returns><c>true</c> if all functions executed the command, <c>false</c> if all functions rejected the command, <c>null</c> for a mix of executed/rejected</returns>
-        /// <remarks>
-        /// If a command is rejected, we do not run the rest of the commands. This runs on the order the commands were registered.
-        /// </remarks>
-        private static bool? RunCommandFunctions(string cmdString, List<string> cmd, List<Func<List<string>, bool>> commandFunctions)
+        /// <returns><c>true</c> if at least one function accepted the command, otherwise <c>false</c></returns>
+        /// <remarks>If a command returns false or throws an ArgumentException we still run the other commands.</remarks>
+        private static bool RunCommandFunctions(string cmdString, List<string> cmd, List<Func<List<string>, bool>> commandFunctions)
         {
+            bool accepted = false;
             for (int i = 0; i < commandFunctions.Count; i++)
             {
                 try
                 {
-                    if (!commandFunctions[i](cmd))
-                        return i == 0 ? false : null;
+                    accepted |= commandFunctions[i](cmd);
                 }
                 catch (ArgumentException ex)
                 {
                     CALog.LogErrorAndConsoleLn(LogID.A, $"Command: {cmdString} - invalid arguments", ex);
-                    return i == 0 ? false : null;
                 }
             }
 
-            return true;
+            return accepted;
         }
     }
 }


### PR DESCRIPTION
Breaking Change: the oven command with multiple areas has been removed. This is how it now works:
- `oven singletarget` is still supported
- `ovenarea all singletarget` does the same thing
- ovenarea area target

It is now checked that the full decision command matches + an optional target.

Note this mainly validates the command format is correct, but the decision logic can have other additional reasons to reject a command, including only the range of values accepted for the target. Check the plots to see if the system started executing the command.