### PR TITLE
fixed: potentially slow reaction on nodes with multiple devices

### DIFF
--- a/CA_DataUploaderLib/Alerts.cs
+++ b/CA_DataUploaderLib/Alerts.cs
@@ -41,14 +41,15 @@ namespace CA_DataUploaderLib
         {
             _cmd = cmd;
             _alerts = GetAlerts(vectorDescription, cmd).ToArray();
-            _ = Task.Run(CheckAlertsOnReceivedVectors);
+            var reader = _cmd.GetReceivedVectorsReader();
+            _ = Task.Run(() => CheckAlertsOnReceivedVectors(reader));
         }
 
-        private async void CheckAlertsOnReceivedVectors()
+        private async void CheckAlertsOnReceivedVectors(ChannelReader<DataVector> reader)
         {
             try
             {
-                await foreach (var vector in _cmd.ReceivedVectorsReader.ReadAllAsync(_cmd.StopToken))
+                await foreach (var vector in reader.ReadAllAsync(_cmd.StopToken))
                 {
                     if (Disabled) continue;
 

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -91,7 +91,7 @@ namespace CA_DataUploaderLib
             }
 
             if (hasBoardWithBuildInActions)
-                _receivedVectors = _cmd.ReceivedVectorsReader;
+                _receivedVectors = _cmd.GetReceivedVectorsReader();
         }
 
         public Task Run(CancellationToken token) => RunBoardLoops(_boards, token);


### PR DESCRIPTION
It is expected the issue could cause slow downs of 0.1 to 1 second depending on the amount of devices used on a node and whether alarms are also in use.

root cause: each vector was only delivered to one of the subsystem, so they would take turns handling different vectors.

Note this is a regression in 4.x, so 3.x is unnaffected.