### PR TITLE
enabler needed by distributed hosts doing a partial cross check of a decision

### DIFF
--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -100,7 +100,23 @@ namespace CA_DataUploaderLib
         {
             var extendedDesc = _fullsystemFilterAndMath.Value;
             DataVector.InitializeOrUpdateTime(ref vector, extendedDesc.VectorDescription.Length, vectorTime);
-            extendedDesc.Apply(inputs, vector);
+            extendedDesc.ApplyInputsAndFilters(inputs, vector);
+            MakeDecisionsAfterInputsAndFilters(vector, events, extendedDesc);
+        }
+
+        public void MakeDecisionUsingInputsAndFiltersFromNewVector(DataVector newVector, DataVector vector, List<string> events)
+        {
+            var extendedDesc = _fullsystemFilterAndMath.Value;
+            DataVector.InitializeOrUpdateTime(ref vector, extendedDesc.VectorDescription.Length, newVector.Timestamp);
+            var data = vector.Data;
+            for (int i = 0; i < extendedDesc.InputsAndFiltersCount; i++)
+                data[i] = newVector[i];
+            MakeDecisionsAfterInputsAndFilters(vector, events, extendedDesc);
+        }
+
+        private void MakeDecisionsAfterInputsAndFilters(DataVector vector, List<string> events, ExtendedVectorDescription extendedDesc)
+        {
+            extendedDesc.ApplyMath(vector);
             var decisionsVector = new CA.LoopControlPluginBase.DataVector(vector.Timestamp, vector.Data);
             foreach (var decision in _decisions)
                 decision.MakeDecision(decisionsVector, events);


### PR DESCRIPTION
CommandHandler.MakeDecisionUsingInputsAndFiltersFromNewVector runs the same decision logic as MakeDecision, but uses the inputs (with filters applied) of the supplied "newVector" applying the decision to the supplied previous vector. Distributed hosts can use this to cross check in different nodes this part of the decision.