### PR TITLE
uploader and command improvements

### DIFF
--- a/CA_DataUploader/Program.cs
+++ b/CA_DataUploader/Program.cs
@@ -33,8 +33,6 @@ namespace CA_DataUploader
                     using var cmd = new CommandHandler(serial);
                     var cloud = new ServerUploader(cmd);
                     using var usb = new ThermocoupleBox(cmd);
-                    cmd.EventFired += cloud.SendEvent;
-                    CALog.LogInfoAndConsoleLn(LogID.A, "Now connected to server...");
                     cmd.Execute("help");
                     _ = Task.Run(() => cmd.RunSubsystems());
 
@@ -43,7 +41,7 @@ namespace CA_DataUploader
                     while (cmd.IsRunning)
                     {
                         cmd.RunNextSingleNodeVector();
-                        Console.Write($"\r data points uploaded: {i++}"); // we don't want this in the log file. 
+                        Console.Write($"\r data points recorded: {i++}"); // we don't want this in the log file. 
                         uploadThrottle.Wait();
                         if (i == 20) DULutil.OpenUrl(cloud.GetPlotUrl());
                     }

--- a/CA_DataUploader/Program.cs
+++ b/CA_DataUploader/Program.cs
@@ -43,7 +43,7 @@ namespace CA_DataUploader
                         cmd.RunNextSingleNodeVector();
                         Console.Write($"\r data points recorded: {i++}"); // we don't want this in the log file. 
                         uploadThrottle.Wait();
-                        if (i == 20) DULutil.OpenUrl(cloud.GetPlotUrl());
+                        if (i == 20) _ = Task.Run(async () => DULutil.OpenUrl(await cloud.GetPlotUrl(cmd.StopToken)));
                     }
                 }
                 CALog.LogInfoAndConsoleLn(LogID.A, Environment.NewLine + "Bye..." + Environment.NewLine + "Press any key to exit");

--- a/CA_DataUploader/Program.cs
+++ b/CA_DataUploader/Program.cs
@@ -31,8 +31,8 @@ namespace CA_DataUploader
                     var email = IOconfSetup.UpdateIOconf(serial);
 
                     using var cmd = new CommandHandler(serial);
+                    var cloud = new ServerUploader(cmd);
                     using var usb = new ThermocoupleBox(cmd);
-                    using var cloud = new ServerUploader(cmd.GetFullSystemVectorDescription(), cmd);
                     cmd.EventFired += cloud.SendEvent;
                     CALog.LogInfoAndConsoleLn(LogID.A, "Now connected to server...");
                     cmd.Execute("help");
@@ -42,8 +42,7 @@ namespace CA_DataUploader
                     var uploadThrottle = new TimeThrottle(100);
                     while (cmd.IsRunning)
                     {
-                        var dataVector = cmd.GetFullSystemVectorValues();
-                        cloud.SendVector(dataVector);
+                        cmd.RunNextSingleNodeVector();
                         Console.Write($"\r data points uploaded: {i++}"); // we don't want this in the log file. 
                         uploadThrottle.Wait();
                         if (i == 20) DULutil.OpenUrl(cloud.GetPlotUrl());

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -49,43 +49,48 @@ namespace CA_DataUploaderLib
             }
 
             var allBoards = _values.Where(x => !x.Input.Skip).GroupBy(x => x.Input.Map).Select(g => (map: g.Key, values: g.ToArray())).ToArray();
+            foreach (var board in allBoards.Where(b => b.map.CustomWritesEnabled))
+                RegisterCustomBoardCommand(board.map, cmd, _boardCustomCommandsReceived);
             _boards = allBoards.Where(b => b.map.IsLocalBoard).ToArray();
             _boardsState = new AllBoardsState(_boards.Select(b => b.map));
-            foreach (var board in _boards.Where(b => b.map.CustomWritesEnabled))
-                RegisterCustomBoardCommand(board.map, cmd, _boardCustomCommandsReceived);
 
             static void RegisterCustomBoardCommand(IOconfMap map, CommandHandler cmd, Dictionary<MCUBoard, ChannelReader<string>> boardCustomCommandsReceived)
             {
-                if (map.McuBoard == null)
-                {
-                    CALog.LogData(LogID.A, $"missing local board detected with custom writes enabled: {map.BoxName}"); //the missing board will be already reported to the user later.
+                if (!map.IsLocalBoard)
+                {//if the board is not local we register the command validation with an empty action
+                    cmd.AddMultinodeCommand("custom", a => a.Count >= 3 && a[1] == map.BoxName, _ => { });
                     return;
                 }
 
+                if (map.McuBoard == null)
+                {
+                    CALog.LogData(LogID.A, $"missing local board detected with custom writes enabled: {map.BoxName}"); //the missing board will be already reported to the user later.
+                    cmd.AddMultinodeCommand(
+                        "custom", a => a.Count >= 3 && a[1] == map.BoxName, 
+                        _ => { CALog.LogData(LogID.A, $"custom command failed due to missing board: {map.BoxName}") });
+                    return;
+                }
+
+                //for local boards we instead register a multinode that sends the command to a local channel the write loop uses
                 var channel = Channel.CreateUnbounded<string>();
                 var channelWriter = channel.Writer;
                 boardCustomCommandsReceived.Add(map.McuBoard, channel.Reader);
-                cmd?.AddCommand("custom", CustomCommand); //note that the custom is a special command that the host needs to run only in the node that has the board.
-
-                bool CustomCommand(List<string> args)
-                {
-                    if (args.Count < 3) return false;
-                    if (args[1] != map.BoxName) return false;
-                    channelWriter.TryWrite(string.Join(' ', args.Skip(2)));
-                    return true;
-                }
+                cmd.AddMultinodeCommand(
+                    "custom", 
+                    a => a.Count >= 3 && a[1] == map.BoxName, 
+                    a => channelWriter.TryWrite(string.Join(' ', a.Skip(2))));
             }
         }
 
         public Task Run(CancellationToken token) => RunBoardLoops(_boards, token);
         private void SubscribeCommandsToSubsystems(CommandHandler cmd, string mainSubsystem, List<SensorSample> values)
         {
-            cmd.AddCommand(mainSubsystem, ShowQueue);
+            cmd.AddMultinodeCommand(mainSubsystem, _ => true, ShowQueue);
             var subsystemOverrides = values.Select(v => v.Input.SubsystemOverride).Where(v => v != default).Distinct();
             foreach (var subsystem in subsystemOverrides)
             {
                 if (subsystem == mainSubsystem) continue;
-                cmd.AddCommand(subsystem, ShowQueue);
+                cmd.AddMultinodeCommand(subsystem, _ => true, ShowQueue);
             }
         }
 
@@ -115,7 +120,7 @@ namespace CA_DataUploaderLib
             else actions.Add((writeAction, exitAction));
         }
 
-        protected bool ShowQueue(List<string> args)
+        private void ShowQueue(List<string> args)
         {
             var subsystem = args[0].ToLower();
             var isMainCommand = subsystem == mainSubsystem;
@@ -136,7 +141,6 @@ namespace CA_DataUploaderLib
             }
 
             CALog.LogInfoAndConsoleLn(LogID.A, sb.ToString());
-            return true;
         }
 
         private double GetAvgLoopTime() => _values.Average(x => x.ReadSensor_LoopTime);

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -67,7 +67,7 @@ namespace CA_DataUploaderLib
                     CALog.LogData(LogID.A, $"missing local board detected with custom writes enabled: {map.BoxName}"); //the missing board will be already reported to the user later.
                     cmd.AddMultinodeCommand(
                         "custom", a => a.Count >= 3 && a[1] == map.BoxName, 
-                        _ => { CALog.LogData(LogID.A, $"custom command failed due to missing board: {map.BoxName}") });
+                        _ => { CALog.LogData(LogID.A, $"custom command failed due to missing board: {map.BoxName}"); });
                     return;
                 }
 

--- a/CA_DataUploaderLib/CALog.cs
+++ b/CA_DataUploaderLib/CALog.cs
@@ -189,19 +189,17 @@ namespace CA_DataUploaderLib
                             enabled = false;
                         disabledCallback();
                     });
-                    cmd.EventFired += OnUserCommandEnableOutput;
+                    cmd.UserCommandReceived += OnUserCommandEnableOutput;
                     cmd.StopToken.Register(() =>
                     {//since we are not be able to deliver events after stopping, keep console output enabled
-                        cmd.EventFired -= OnUserCommandEnableOutput;
+                        cmd.UserCommandReceived -= OnUserCommandEnableOutput;
                         timer.Change(Timeout.Infinite, Timeout.Infinite);//disable the timer
                         lock (lockObj)
                             enabled = true;
                     });
 
-                    void OnUserCommandEnableOutput(object sender, EventFiredArgs e)
+                    void OnUserCommandEnableOutput(object sender, EventFiredArgs _)
                     {
-                        if (e.EventType != (byte)EventType.Command) return; //ignore commands
-
                         timer.Change(duration, Timeout.InfiniteTimeSpan); //triggers after duration (ignores a previous trigger if pending)
                         bool justEnabled;
                         lock (lockObj)

--- a/CA_DataUploaderLib/CALog.cs
+++ b/CA_DataUploaderLib/CALog.cs
@@ -189,7 +189,16 @@ namespace CA_DataUploaderLib
                             enabled = false;
                         disabledCallback();
                     });
-                    cmd.EventFired += (object sender, EventFiredArgs e) =>
+                    cmd.EventFired += OnUserCommandEnableOutput;
+                    cmd.StopToken.Register(() =>
+                    {//since we are not be able to deliver events after stopping, keep console output enabled
+                        cmd.EventFired -= OnUserCommandEnableOutput;
+                        timer.Change(Timeout.Infinite, Timeout.Infinite);//disable the timer
+                        lock (lockObj)
+                            enabled = true;
+                    });
+
+                    void OnUserCommandEnableOutput(object sender, EventFiredArgs e)
                     {
                         if (e.EventType != (byte)EventType.Command) return; //ignore commands
 
@@ -202,7 +211,7 @@ namespace CA_DataUploaderLib
                         }
                         if (justEnabled)
                             enabledCallback();
-                    };
+                    }
                 }
             }
         }

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -31,6 +31,7 @@ namespace CA_DataUploaderLib
         public event EventHandler<VectorDescription>? FullVectorDescriptionCreated;
         public event EventHandler<NewVectorWithEventsReceivedArgs>? NewVectorReceived;
         public event EventHandler<EventFiredArgs>? EventFired;
+        public event EventHandler<EventFiredArgs>? UserCommandReceived;
         public bool IsRunning => !_exitCts.IsCancellationRequested;
         public CancellationToken StopToken => _exitCts.Token;
         public Task RunningTask => _runningTaskTcs.Task;
@@ -224,6 +225,8 @@ namespace CA_DataUploaderLib
         private void HandleCommand(string cmdString, bool isUserCommand)
         {
             cmdString = cmdString.Trim();
+            if (isUserCommand)
+                UserCommandReceived?.Invoke(this, new(cmdString, EventType.Command, DateTime.UtcNow));
             if (_commandRunner.Run(cmdString, isUserCommand) && isUserCommand)
                 OnUserCommandAccepted(cmdString);
         }

--- a/CA_DataUploaderLib/DataVector.cs
+++ b/CA_DataUploaderLib/DataVector.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using System;
-using System.Linq;
 using System.Collections.Generic;
 
 namespace CA_DataUploaderLib
@@ -10,7 +9,7 @@ namespace CA_DataUploaderLib
         public readonly DateTime timestamp;
         public readonly List<double> vector;
 
-        public DataVector(List<double> input, DateTime time, IReadOnlyList<(byte nodeid, byte eventType, string data)>? events)
+        public DataVector(List<double> input, DateTime time, IReadOnlyList<EventFiredArgs>? events)
         {
             vector = input; timestamp = time;
             Events = events;
@@ -27,7 +26,7 @@ namespace CA_DataUploaderLib
             }
         }
 
-        public IReadOnlyList<(byte nodeid, byte eventType, string data)>? Events { get; }
+        public IReadOnlyList<EventFiredArgs>? Events { get; }
         public int Count => vector.Count;
     }
 }

--- a/CA_DataUploaderLib/DataVector.cs
+++ b/CA_DataUploaderLib/DataVector.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -9,18 +10,24 @@ namespace CA_DataUploaderLib
         public readonly DateTime timestamp;
         public readonly List<double> vector;
 
-        public DataVector(List<double> input, DateTime time) { vector = input; timestamp = time; }
+        public DataVector(List<double> input, DateTime time, IReadOnlyList<(byte nodeid, byte eventType, string data)>? events)
+        {
+            vector = input; timestamp = time;
+            Events = events;
+        }
 
+        /// <remarks>this does not include the events, which at the moment are reported separately by the uploader</remarks>
         public byte[] buffer {
             get
             {
-                var raw = new byte[vector.Count() * sizeof(double) + sizeof(long)];
+                var raw = new byte[vector.Count * sizeof(double) + sizeof(long)];
                 Buffer.BlockCopy(BitConverter.GetBytes(timestamp.Ticks), 0, raw, 0, 8);
                 Buffer.BlockCopy(vector.ToArray(), 0, raw, 8, raw.Length - sizeof(long));
                 return raw;
             }
         }
 
-        public int Count() { return vector == null?0:vector.Count(); }
+        public IReadOnlyList<(byte nodeid, byte eventType, string data)>? Events { get; }
+        public int Count => vector.Count;
     }
 }

--- a/CA_DataUploaderLib/DataVector.cs
+++ b/CA_DataUploaderLib/DataVector.cs
@@ -9,7 +9,7 @@ namespace CA_DataUploaderLib
         public readonly DateTime timestamp;
         public readonly List<double> vector;
 
-        public DataVector(List<double> input, DateTime time, IReadOnlyList<EventFiredArgs>? events)
+        public DataVector(List<double> input, DateTime time, IReadOnlyList<EventFiredArgs> events)
         {
             vector = input; timestamp = time;
             Events = events;
@@ -26,7 +26,7 @@ namespace CA_DataUploaderLib
             }
         }
 
-        public IReadOnlyList<EventFiredArgs>? Events { get; }
+        public IReadOnlyList<EventFiredArgs> Events { get; }
         public int Count => vector.Count;
     }
 }

--- a/CA_DataUploaderLib/DefaultCommandRunner.cs
+++ b/CA_DataUploaderLib/DefaultCommandRunner.cs
@@ -29,8 +29,7 @@ namespace CA_DataUploaderLib
 
         public bool Run(string cmdString, bool isUserCommand)
         {
-            var cmd = cmdString.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToList();
-
+            var cmd = ParseCommand(cmdString);
             if (!cmd.Any())
                 return false;
 
@@ -51,6 +50,9 @@ namespace CA_DataUploaderLib
 
             return res;
         }
+
+        public List<string> ParseCommand(string cmdString) => 
+            cmdString.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToList();
 
         /// <returns><c>true</c> if at least one function accepted the command, otherwise <c>false</c></returns>
         /// <remarks>If a command returns false or throws an ArgumentException we still run the other commands.</remarks>

--- a/CA_DataUploaderLib/Helpers/ExtendedVectorDescription.cs
+++ b/CA_DataUploaderLib/Helpers/ExtendedVectorDescription.cs
@@ -19,10 +19,7 @@ namespace CA_DataUploaderLib.Helpers
         /// </summary>
         public IReadOnlyList<(IOconfNode, IReadOnlyList<VectorDescriptionItem>)> InputsPerNode { get; set; }
 
-        public ExtendedVectorDescription(
-            List<(IOconfNode, IReadOnlyList<VectorDescriptionItem> values)> inputsPerNode,
-            List<VectorDescriptionItem> outputs,
-            string hardware, string software)
+        public ExtendedVectorDescription(List<(IOconfNode, IReadOnlyList<VectorDescriptionItem> values)> inputsPerNode, List<VectorDescriptionItem> outputs)
         {
             _logLevel = IOconfFile.GetOutputLevel();
             InputsPerNode = inputsPerNode;
@@ -34,7 +31,10 @@ namespace CA_DataUploaderLib.Helpers
             allItems.AddRange(_mathVectorExpansion.GetVectorDescriptionEntries());
             allItems.AddRange(outputs);
             _outputCount = outputs.Count;
-            VectorDescription = new VectorDescription(allItems, hardware, software);
+            var duplicates = allItems.GroupBy(x => x.Descriptor).Where(x => x.Count() > 1).Select(x => x.Key);
+            if (duplicates.Any())
+                throw new Exception("Title of datapoint in vector was listed twice: " + string.Join(", ", duplicates));
+            VectorDescription = new VectorDescription(allItems, RpiVersion.GetHardware(), RpiVersion.GetSoftware());
         }
 
         public int GetIndex(VectorDescriptionItem item) { return VectorDescription._items.IndexOf(item); }

--- a/CA_DataUploaderLib/ICommandRunner.cs
+++ b/CA_DataUploaderLib/ICommandRunner.cs
@@ -7,5 +7,6 @@ namespace CA_DataUploaderLib
     {
         Action AddCommand(string name, Func<List<string>, bool> func);
         bool Run(string cmdString, bool isUserCommand);
+        List<string> ParseCommand(string name);
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfNode.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfNode.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 
 namespace CA_DataUploaderLib.IOconf
@@ -12,7 +14,7 @@ namespace CA_DataUploaderLib.IOconf
         private readonly IPEndPoint _endPoint;
 
         private static readonly Lazy<IOconfNode> _singleNode = new(() => 
-            new IOconfNode(IOconfFile.GetLoopName()) { IsCurrentSystem = true }
+            new IOconfNode(IOconfFile.GetLoopName()) { IsCurrentSystem = true, IsUploader = true }
         );
         private static byte _nodeInstances;
 
@@ -29,6 +31,7 @@ namespace CA_DataUploaderLib.IOconf
             NodeIndex = _nodeInstances++;
             if (list.Count > 3)
                 Role = list[3];
+            IsUploader = Role == "uploader";
         }
 
         private IOconfNode(string name) : base($"Node;{name}", 0, "Node") { }
@@ -42,5 +45,8 @@ namespace CA_DataUploaderLib.IOconf
         /// <summary>position of the node in the config (starting at 0)</summary>
         public byte NodeIndex { get; }
         public string Role { get; }
+        public bool IsUploader { get; private init; }
+        public static bool IsCurrentSystemAnUploader(IReadOnlyCollection<IOconfNode> allNodes) => 
+            allNodes.SingleOrDefault(n => n.IsCurrentSystem)?.IsUploader ?? allNodes.Count == 0;
     }
 }

--- a/CA_DataUploaderLib/NewVectorWithEventsReceivedArgs.cs
+++ b/CA_DataUploaderLib/NewVectorWithEventsReceivedArgs.cs
@@ -1,0 +1,20 @@
+﻿#nullable enable
+using CA_DataUploaderLib.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CA_DataUploaderLib
+{
+    public class NewVectorWithEventsReceivedArgs : CA.LoopControlPluginBase.NewVectorReceivedArgs
+    {
+        public NewVectorWithEventsReceivedArgs(Dictionary<string, double> vector, DataVector dataVector) : base(vector) 
+            => Vector = dataVector;
+
+        public DataVector Vector { get; }
+        public static NewVectorWithEventsReceivedArgs From(IReadOnlyList<SensorSample> vector, DateTime vectorTime, List<EventFiredArgs>? events) => 
+            new(
+                vector.WithVectorTime(vectorTime).ToDictionary(v => v.Name, v => v.Value), 
+                new(vector.Select(v => v.Value).ToList(), vectorTime, events));
+    }
+}

--- a/CA_DataUploaderLib/NewVectorWithEventsReceivedArgs.cs
+++ b/CA_DataUploaderLib/NewVectorWithEventsReceivedArgs.cs
@@ -12,7 +12,7 @@ namespace CA_DataUploaderLib
             => Vector = dataVector;
 
         public DataVector Vector { get; }
-        public static NewVectorWithEventsReceivedArgs From(IReadOnlyList<SensorSample> vector, DateTime vectorTime, List<EventFiredArgs>? events) => 
+        public static NewVectorWithEventsReceivedArgs From(IReadOnlyList<SensorSample> vector, DateTime vectorTime, IReadOnlyList<EventFiredArgs> events) => 
             new(
                 vector.WithVectorTime(vectorTime).ToDictionary(v => v.Name, v => v.Value), 
                 new(vector.Select(v => v.Value).ToList(), vectorTime, events));

--- a/CA_DataUploaderLib/RpiVersion.cs
+++ b/CA_DataUploaderLib/RpiVersion.cs
@@ -166,7 +166,7 @@ $@"{hostAssembly.GetName()}
                 // return ExecuteShellCommand("df.bat").Trim();  Does not work -> need debugging. 
             }
 
-            return "unknown";
+            return string.Empty;
         }
 
         private static void WriteResourceToFile(string resourceName, string fileName)

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -168,6 +168,11 @@ namespace CA_DataUploaderLib
             var plot = await GetPlot(token);
             return await plot.PostAsync(requestUri, SignInfo.GetSignature(bytes).Concat(bytes).ToArray(), token);
         }
+        public async Task<HttpResponseMessage> DirectPut(string requestUri, byte[] bytes, CancellationToken token)
+        {
+            var plot = await GetPlot(token);
+            return await plot.PutAsync(requestUri, SignInfo.GetSignature(bytes).Concat(bytes).ToArray(), token);
+        }
 
         public async Task<string> GetPlotUrl(CancellationToken token)
         {
@@ -530,10 +535,12 @@ namespace CA_DataUploaderLib
 
             public string PlotName { get; set; }
             public int PlotId { get; }
-            public Task<HttpResponseMessage> PostVectorAsync(byte[] buffer, DateTime timestamp) => _client.PutAsJsonAsync($"/api/v2/Timeserie/UploadVectorRetroAsync?plotNameId={PlotId}&ticks={timestamp.Ticks}", buffer);
-            public Task<HttpResponseMessage> PostEventAsync(byte[] signedMessage) => _client.PutAsJsonAsync($"/api/v2/Event?plotNameId={PlotId}", signedMessage);
-            public Task<HttpResponseMessage> PostBoardsAsync(byte[] signedMessage) => _client.PutAsJsonAsync($"/api/v1/McuSerialnumber?plotNameId={PlotId}", signedMessage);
+            public Task<HttpResponseMessage> PostVectorAsync(byte[] buffer, DateTime timestamp) => PutAsync($"/api/v2/Timeserie/UploadVectorRetroAsync?plotNameId={PlotId}&ticks={timestamp.Ticks}", buffer);
+            public Task<HttpResponseMessage> PostEventAsync(byte[] signedMessage) => PutAsync($"/api/v2/Event?plotNameId={PlotId}", signedMessage);
+            public Task<HttpResponseMessage> PostBoardsAsync(byte[] signedMessage) => PutAsync($"/api/v1/McuSerialnumber?plotNameId={PlotId}", signedMessage);
             public Task<HttpResponseMessage> PostAsync(string requestUri, byte[] message, CancellationToken token = default) 
+                => _client.PostAsJsonAsync(requestUri, message, token);
+            internal Task<HttpResponseMessage> PutAsync(string requestUri, byte[] message, CancellationToken token = default)
                 => _client.PutAsJsonAsync(requestUri, message, token);
             public static async Task<PlotConnection> Establish(string loopName, byte[] publicKey, byte[] signedVectorDescription, TaskCompletionSource<PlotConnection> connectionEstablishedSource, CancellationToken cancellationToken)
             {

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -46,12 +46,15 @@ namespace CA_DataUploaderLib
         {
             _cmd = cmd;
             _loopname = IOconfFile.GetLoopName();
-            IsEnabled = IOconfNode.IsCurrentSystemAnUploader(IOconfFile.GetEntries<IOconfNode>().ToList());
+            var nodes = IOconfFile.GetEntries<IOconfNode>().ToList();
+            IsEnabled = IOconfNode.IsCurrentSystemAnUploader(nodes);
             if (!IsEnabled) 
                 return;
             _signInfo = new Signing(_loopname);
             cmd.FullVectorDescriptionCreated += DescriptionCreated;
             cmd.NewVectorReceived += (s,e) => SendVector(e.Vector);
+            if (nodes.Count == 0) //in 3.x, single node systems do not include events in NewVectorReceived
+                cmd.EventFired += SendEvent;
             cmd.AddSubsystem(this);
 
             void DescriptionCreated(object? sender, VectorDescription desc)

--- a/CommandHandlerTester/Program.cs
+++ b/CommandHandlerTester/Program.cs
@@ -15,7 +15,7 @@ namespace CommandHandlerTester
             int i = 0;
             while (cmd.IsRunning)
             {
-                cmd.OnNewVectorReceived(new List<SensorSample> { new SensorSample("IterationSensor", i++) });
+                cmd.OnNewVectorReceived(new List<SensorSample> { new SensorSample("IterationSensor", i++) }, DateTime.UtcNow, null);
                 Thread.Sleep(1000);
             }
 


### PR DESCRIPTION
uploader improvements:
- logs response details for rejected requests
- slow vector and cluster notifications are now sent to the event log
- slow upload vector/events detection now trigger after 5 seconds instead of 2.5
- improved messages when detecting slow upload of vectors/events or a slow local cluster
- other subsystems can be initialized while the uploader connection is being established
- other subsystems can run if there are failures connecting to the plots (already the case for multi node systems, as other nodes would still start).
- uploader keeps trying to reconnect on initial network failures
- added ServerUploader.DirectPost/Put

command improvements:
- fixed: console output is not enabled on time to see the output of the executed command
- added multinode support for most read commands i.e. temperatures, pressures, etc.
- added CommandHandler.FullVectorDescriptionCreated
- CommandHandler.GetFullSystemVectorValues is now called RunNextSingleNodeVector, as it has always ran the next single node vector iteration + the caller no longer needs to send the vector the uploader explicitely

Some of the changes above reduced complexity of custom hosts. More of these:
- moved 5 seconds of console output on local commands to the public CALog.EventsLogger + leaving console output enabled when the program is stopping
- moved multinode support of up/version/custom commands to their implementation in the public CommandHandler & BaseSensorBox (where)
- uploader runs as a standard subsystem
- the uploader subsystem can be added to all nodes and it only runs on "uploader" nodes or single node
- the uploader no longer requires the hosts to explicitely call SendVector/SendEvent.
