### PR TITLE
compatibility with socat ports

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Text;
 using CA_DataUploaderLib.IOconf;
-using Humanizer;
 using System.Diagnostics;
 using System.Collections;
 using System.Threading.Tasks;
@@ -204,7 +203,7 @@ namespace CA_DataUploaderLib
                 var loops = StartLoops(boards, token);
                 await Task.WhenAll(loops);
                 if (loops.Count > 0) //we only report the exit when we actually ran loops with detected boards. If a board was not detected StartReadLoops already reports the missing boards.
-                    CALog.LogInfoAndConsoleLn(LogID.A, $"Exiting {Title}.RunBoardLoops() " + DateTime.Now.Subtract(start).Humanize(5));
+                    CALog.LogInfoAndConsoleLn(LogID.A, $"Exiting {Title}.RunBoardLoops() " + DateTime.Now.Subtract(start));
             }
             catch (Exception ex)
             {

--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -38,7 +38,6 @@
 
   <ItemGroup>
     <PackageReference Include="CoreCLR-NCalc" Version="2.2.101" />
-    <PackageReference Include="Humanizer.Core" Version="2.14.1" /> 
     <PackageReference Include="MinVer" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -2,7 +2,6 @@
 using CA.LoopControlPluginBase;
 using CA_DataUploaderLib.Helpers;
 using CA_DataUploaderLib.IOconf;
-using Humanizer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -300,7 +299,7 @@ namespace CA_DataUploaderLib
                 }
             }
 
-            CALog.LogInfoAndConsoleLn(LogID.A, "Exiting CommandHandler.LoopForever() " + DateTime.Now.Subtract(_start).Humanize(5));
+            CALog.LogInfoAndConsoleLn(LogID.A, "Exiting CommandHandler.LoopForever() " + DateTime.Now.Subtract(_start));
         }
 
         private void HandleCommand(string cmdString, bool isUserCommand)
@@ -399,7 +398,7 @@ namespace CA_DataUploaderLib
         }
 
         public void Uptime(List<string> _) => 
-            CALog.LogInfoAndConsoleLn(LogID.A, $"{GetCurrentNode().Name} - {DateTime.Now.Subtract(_start).Humanize(5)}");
+            CALog.LogInfoAndConsoleLn(LogID.A, $"{GetCurrentNode().Name} - {DateTime.Now.Subtract(_start)}");
 
         public void GetVersion(List<string> _)
         {

--- a/CA_DataUploaderLib/RpiVersion.cs
+++ b/CA_DataUploaderLib/RpiVersion.cs
@@ -75,14 +75,6 @@ $@"{hostAssembly?.GetName()}
             return "Unknown hardware";
         }
 
-        public static string[] GetUSBports()
-        {
-            if (_OS.Platform == PlatformID.Unix)
-                return DULutil.ExecuteShellCommand("ls -1a /dev/USB*").Split("\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Select(x => x.Replace("\r", "").Trim()).ToArray();
-
-            return SerialPort.GetPortNames();
-        }
-                
         private static Dictionary<string, string> GetVersions()
         {
             // load csv table from embedded resources

--- a/CA_DataUploaderLib/SerialNumberMapper.cs
+++ b/CA_DataUploaderLib/SerialNumberMapper.cs
@@ -21,7 +21,7 @@ namespace CA_DataUploaderLib
         public async static Task<SerialNumberMapper> DetectDevices()
         {
             var logLevel = File.Exists("IO.conf") ? IOconfFile.GetOutputLevel() : CALogLevel.Normal;
-            var boards = await Task.WhenAll(RpiVersion.GetUSBports().Select(name => AttemptToOpenDeviceConnection(name, logLevel)));
+            var boards = await Task.WhenAll(MCUBoard.GetUSBports().Select(name => AttemptToOpenDeviceConnection(name, logLevel)));
             return new SerialNumberMapper(boards.OfType<Board>());
         }
 


### PR DESCRIPTION
The system only currently supports usb serial ports sources for sensor data. With socat (https://manpages.org/socat ) you can map other type of sources to pseudo terminals  (PTY) in linux that can be used in place of the usb serial ports.

To use the feature, add a subfolder called vports and use socat to map your source to a PTY linked to a path under the vports folder (replace 'source' with the source type/address/options want to use): `socat source PTY,link=vports/mydevice,rawer,b115200,wait-slave,nonblock`

Then in IO.conf add:
```
Map;vports/mydevice;mydevicebox
GenericSensor;value1;mydevicebox;1
GenericSensor;value2;mydevicebox;2
```

Limitations:
1. data must come as lines of text separated by a newline character '\n'
2. only numbers are considered valid values and uploaded to the plot
3. decimals must be separated by a '.'. We store float level precision, but plots are only displaying 2 decimals.
4. each line can contain multiple values separated by ','
5. lines must always contain the same amount of values
6. inf/nan and other special float values are not supported
7. data is reported at 10 Hz / every 100 ms. Any extra data coming in between reported cycles will be ignored.
8. non numeric data is considered an error and reported as such to the event log. Only the first 2 errors are every 5 mins are reported though.

Other changes:

- Humanizer and corresponding time formatting has been removed. It does not run in hosts that have internationalization support disabled.