### PR TITLE
added ChannelReaderExtensions.ReadWithSoftTimeout

### DIFF
--- a/CA_DataUploaderLib/Extensions/ChannelReaderExtensions.cs
+++ b/CA_DataUploaderLib/Extensions/ChannelReaderExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Channels;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CA_DataUploaderLib.Extensions
+{
+    public static class ChannelReaderExtensions
+    {
+        public static async Task<T?> ReadWithSoftTimeout<T>(this ChannelReader<T> reader, int timeoutMs, CancellationToken token)
+        {
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            linkedCts.CancelAfter(timeoutMs);
+            var nextVectorTask = await Task.WhenAny(reader.ReadAsync(linkedCts.Token).AsTask()); //Task.Any avoids an exception so we can return null on timeouts instead
+            return nextVectorTask.IsCompletedSuccessfully ? await nextVectorTask : default;
+        }
+    }
+}

--- a/UnitTests/ChannelReaderExtensionsTests.cs
+++ b/UnitTests/ChannelReaderExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿#nullable enable
+using CA_DataUploaderLib;
+using CA_DataUploaderLib.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class ChannelReaderExtensionsTests
+    {
+        [TestMethod]
+        public async Task ReadWithSoftTimeoutReturnsNull()
+        {
+            var channel = Channel.CreateUnbounded<DataVector>();
+            Assert.IsNull(await channel.Reader.ReadWithSoftTimeout(10, CancellationToken.None));
+        }
+
+        [TestMethod]
+        public async Task ReadWithSoftTimeoutAndCancellationTokenReturnsNull()
+        {
+            using var cts = new CancellationTokenSource();
+            var channel = Channel.CreateUnbounded<DataVector>();
+            Assert.IsNull(await channel.Reader.ReadWithSoftTimeout(10, cts.Token));
+        }
+
+        [TestMethod]
+        public async Task ReadBeforeTimeoutReturnsData()
+        {
+            var channel = Channel.CreateUnbounded<DataVector>();
+            var task = channel.Reader.ReadWithSoftTimeout(10, CancellationToken.None);
+            channel.Writer.TryWrite(new(new[]{1d}, new(2021,1,1)));
+            Assert.IsNotNull(await task);
+        }
+    }
+}


### PR DESCRIPTION
this is mainly used when using the channel reader returned by the CommandHandler, so that custom actuation subsystems can react to situations where a node loses connection to the cluster or for any other reason the decision logic stops making progress