### PR TITLE
plugins can now report alerts/errors

### DIFF
--- a/CA_DataUploader/Program.cs
+++ b/CA_DataUploader/Program.cs
@@ -1,7 +1,6 @@
 ﻿using CA_DataUploaderLib;
 using CA_DataUploaderLib.Helpers;
 using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
@@ -34,7 +33,7 @@ namespace CA_DataUploader
                     using var cmd = new CommandHandler(serial);
                     var cloud = new ServerUploader(cmd);
                     _ = new ThermocoupleBox(cmd);
-                    var runTask = SingleNodeRunner.Run(cmd, cloud, cmd.GetFullSystemVectorDescription(), cmd.StopToken);
+                    var runTask = SingleNodeRunner.Run(cmd, cloud, cmd.StopToken);
                     await Task.Delay(2000);
                     _ = Task.Run(async () => DULutil.OpenUrl(await cloud.GetPlotUrl(cmd.StopToken)));
                     await runTask;

--- a/CA_DataUploaderLib/IOconf/IOconfAlert.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAlert.cs
@@ -19,13 +19,15 @@ namespace CA_DataUploaderLib.IOconf
 
     public class IOconfAlert : IOconfRow
     {
-        public IOconfAlert(string row, int lineNum) : base(row, lineNum, "Alert")
+        public IOconfAlert(string row, int lineNum, EventType eventType = EventType.Alert) : base(row, lineNum, "Alert")
         {
+            Format = "Alert;Name;SensorName comparison value;[rateMinutes];[command]";
+            EventType = eventType;
             var list = ToList();
             if (list[0] != "Alert" || list.Count < 3) throw new Exception("IOconfAlert: wrong format: " + row);
    
             (Sensor, Value, MessageTemplate, type) = ParseExpression(
-                Name, list[2], "IOconfAlert: wrong format: " + row + ". Format: Alert;Name;SensorName comparison value;[rateMinutes];[command].");
+                Name, list[2], $"IOconfAlert: wrong format: {row}. Format: {Format}.");
             Message = MessageTemplate;
             if (list.Count <= 3)
                 (RateLimitMinutes, Command) = (DefaultRateLimitMinutes, default);
@@ -47,6 +49,8 @@ namespace CA_DataUploaderLib.IOconf
         //sample expression: SomeValue < 202
         private static readonly Regex comparisonRegex = new(@"^\s*([\w%]+)\s*(=|!=|>|<|>=|<=)\s*([-]?\d+(?:\.\d+)?)\s*$");
         public int RateLimitMinutes { get; }
+        public EventType EventType { get; }
+
         private const int DefaultRateLimitMinutes = 30; // by default fire the same alert max once every 30 mins.
         private DateTime LastTriggered;
 

--- a/CA_DataUploaderLib/SingleNodeRunner.cs
+++ b/CA_DataUploaderLib/SingleNodeRunner.cs
@@ -8,14 +8,14 @@ namespace CA_DataUploaderLib
 {
     public class SingleNodeRunner
     {
-        public static async Task Run(CommandHandler cmdHandler, ServerUploader uploader, VectorDescription vectorDescription, CancellationToken token)
+        public static async Task Run(CommandHandler cmdHandler, ServerUploader uploader, CancellationToken token)
         {
             Queue<EventFiredArgs> receivedEventsInThisCycleQueue = new();
             List<EventFiredArgs> receivedEventsInThisCycle = new();
 
             try
             {
-                var alerts = new Alerts(vectorDescription, cmdHandler);
+                var alerts = new Alerts(cmdHandler);
                 CALog.LoggerForUserOutput = new CALog.EventsLogger(cmdHandler);
                 cmdHandler.Execute("help");
                 var subsystemsTask = Task.Run(() => cmdHandler.RunSubsystems(token), token);


### PR DESCRIPTION
It works by a naming convention. To use it the plugin must add a field with the _alert or _error suffixes.