### PR TITLE
math depending on math uses current's vector value

### DIFF
--- a/CA_DataUploaderLib/MathVectorExpansion.cs
+++ b/CA_DataUploaderLib/MathVectorExpansion.cs
@@ -46,7 +46,7 @@ namespace CA_DataUploaderLib
                 _reusableFiedsDictionary[_fieldsByIndex[i]] = vector[i];
 
             foreach (var (math, index) in _mathWithFieldIndexes)
-                vector[index] = math.Calculate(_reusableFiedsDictionary);
+                _reusableFiedsDictionary[_fieldsByIndex[index]] = vector[index] = math.Calculate(_reusableFiedsDictionary);
         }
     }
 }

--- a/UnitTests/MathVectorExpansionTests.cs
+++ b/UnitTests/MathVectorExpansionTests.cs
@@ -27,6 +27,16 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void MathDependingOnMathUsesLatestValue()
+        {
+            var math = new MathVectorExpansion(() => new[] { new IOconfMath("Math;Math1;Math1 + 1", 0), new("Math;Math2;Math1", 0) });
+            math.Initialize(new[] { "Math1", "Math2" });
+            var values = new[] { 2d, 2 };
+            math.Apply(values);
+            CollectionAssert.AreEqual(new[] { 3d, 3 }, values);
+        }
+
+        [TestMethod]
         public void IgnoresUnusedValues()
         {
             var math = GetInitializedMathExpansion(new("Math;MyMath;MyName + 2", 2), new[] { "MyName", "UnusedValue", "MyMath" });


### PR DESCRIPTION
Math depending on math that appears before it in the IO.conf uses the current vector's value. Before it was using the previous vector's value.