### PR TITLE
improved board calibration support

### DIFF
--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -558,8 +558,11 @@ namespace CA_DataUploaderLib
                 {
                     calibration = default;
                     var localBuffer = buffer; // take a copy to avoid unnecesarily throwing away data coming after the header
-                    if (!tryReadLine(ref localBuffer, out var input))
-                        return false; //we did not get a line, more data is needed
+                    if (!tryReadLine(ref localBuffer, out var input) || input == null || input.Trim() == string.Empty)
+                    {//we did not get a line, more data is needed
+                        buffer = localBuffer;//advance the buffer to ensure we fetch more data
+                        return false; 
+                    }
                     if (input.Contains(CalibrationHeader, StringComparison.InvariantCultureIgnoreCase))
                     {
                         calibration = input[(input.IndexOf(CalibrationHeader, StringComparison.InvariantCultureIgnoreCase) + CalibrationHeader.Length)..].Trim();


### PR DESCRIPTION
- fixed: on rare cases device detection would not detect the calibration line (when the data we read from the board had part of the calibration line)
- fixed: some boards have an empty line between the rest of the header and the calibration line. LoopControl failed to read the calibration of these boards.