### PR TITLE
#576 BaseSensorBox: added immediate reconnect command

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -646,7 +646,7 @@ namespace CA_DataUploaderLib
         private void LogData(MCUBoard board, string message) => CALog.LogData(LogID.B, $"{message} - {Title} - {board.ToShortDescription()}");
         private void LogInfo(MCUBoard board, string message) => CALog.LogInfoAndConsoleLn(LogID.B, $"{message} - {Title} - {board.ToShortDescription()}");
 
-        protected class AllBoardsState : IEnumerable<(string sensorName, ConnectionState State)>
+        public class AllBoardsState : IEnumerable<(string sensorName, ConnectionState State)>
         {
             private readonly ConnectionState[] _states;
             private readonly string[] _sensorNames;

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -562,22 +562,19 @@ namespace CA_DataUploaderLib
         {
             _boardsState.SetAttemptingReconnectState(boxName);
             LogInfo(board, "attempting to reconnect");
-            Console.WriteLine("attempting to reconnect");
-            var lostSensorAttempts = 3;// 100;
+            var lostSensorAttempts = 100;
             var delayBetweenAttempts = TimeSpan.FromSeconds(board.ConfigSettings.SecondsBetweenReopens);
             while (!(await board.SafeReopen(token)))
             {
                 _boardsState.SetDisconnectedState(boxName);
                 if (ExactSensorAttemptsCheck(ref lostSensorAttempts))
                 { // we run this once when there has been 100 attempts
-                    Console.WriteLine("reconnect limit exceeded, reducing reconnect frequency to 15 minutes");
                     LogError(board, "reconnect limit exceeded, reducing reconnect frequency to 15 minutes");
                     delayBetweenAttempts = TimeSpan.FromMinutes(15); // 4 times x hour = 96 times x day
                 }
 
                 await Task.WhenAny(_reconnectTasks[boxName].Task, Task.Delay(delayBetweenAttempts, token));
                 token.ThrowIfCancellationRequested();
-                Console.WriteLine("after delay");
             }
 
             _boardsState.SetConnectedState(boxName);
@@ -649,7 +646,7 @@ namespace CA_DataUploaderLib
         private void LogData(MCUBoard board, string message) => CALog.LogData(LogID.B, $"{message} - {Title} - {board.ToShortDescription()}");
         private void LogInfo(MCUBoard board, string message) => CALog.LogInfoAndConsoleLn(LogID.B, $"{message} - {Title} - {board.ToShortDescription()}");
 
-        public class AllBoardsState : IEnumerable<(string sensorName, ConnectionState State)>
+        protected class AllBoardsState : IEnumerable<(string sensorName, ConnectionState State)>
         {
             private readonly ConnectionState[] _states;
             private readonly string[] _sensorNames;

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -123,7 +123,7 @@ namespace CA_DataUploaderLib
                     {
                         var currentTCS = reconnectTasks[map.BoxName];
                         reconnectTasks[map.BoxName] = new TaskCompletionSource();
-                        currentTCS.SetResult(); //Completes the task signaling to ReconnectBoard to try again (if currently waiting)
+                        currentTCS.TrySetResult(); //Completes the task signaling to ReconnectBoard to try again (if currently waiting)
                     });
             }
         }

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -203,7 +203,7 @@ namespace CA_DataUploaderLib
                 if (vector == null)
                 {
                     await board.SafeWriteLine(getCommand(port.PortNumber, defaultTarget), token);
-                    lastAction.TimedOutWaittingForDecision(defaultTarget);
+                    lastAction.TimedOutWaitingForDecision(defaultTarget);
                     return;
                 }
 

--- a/CA_DataUploaderLib/LastAction.cs
+++ b/CA_DataUploaderLib/LastAction.cs
@@ -25,7 +25,7 @@ namespace CA_DataUploaderLib
             TimeRunning.Restart();
         }
 
-        public void TimedOutWaittingForDecision(double target)
+        public void TimedOutWaitingForDecision(double target)
         {
             //DateTime.MavValue forces execution on the next vector / also note we don't restart time running for the same reason.
             Target = target;


### PR DESCRIPTION
Command: “reconnect *boxname*”. 
TaskCompletionSources are used to signal (to the ReconnectBoard-method) that reconnect should be attempted for a board with a specific name.

So far only tested running LoopControl on a PC. Will also need to test on a multipi system.