### PR TITLE
added support for GenericOutput

### DIFF
--- a/CA_DataUploaderLib/GenericSensorBox.cs
+++ b/CA_DataUploaderLib/GenericSensorBox.cs
@@ -1,9 +1,16 @@
 using CA_DataUploaderLib.IOconf;
+using System.Linq;
 
 namespace CA_DataUploaderLib
 {
     public class GenericSensorBox : BaseSensorBox
     {
-        public GenericSensorBox(CommandHandler cmd) : base(cmd, "Generic", IOconfFile.GetGeneric()) { }
+        public GenericSensorBox(CommandHandler cmd) : base(cmd, "Generic", IOconfFile.GetGeneric()) 
+        {
+            var outputs = IOconfFile.GetGenericOutputs();
+            foreach (var output in outputs.Where(o => o.Map.IsLocalBoard && o.Map.McuBoard != null))
+                RegisterBoardWriteActions(
+                    output.Map.McuBoard!, output, output.DefaultValue, output.TargetField, (_, v) => output.GetCommand(v));
+        }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -23,6 +23,7 @@ namespace CA_DataUploaderLib.IOconf
             ("Filter", (r, l) => new IOconfFilter(r, l)),
             ("RPiTemp", (r, l) => new IOconfRPiTemp(r, l)),
             ("GenericSensor", (r, l) => new IOconfGeneric(r, l)),
+            ("GenericOutput", (r, l) => new IOconfGenericOutput(r, l)),
             ("SwitchboardSensor", (r, l) => new IOconfSwitchboardSensor(r, l)),
             ("Node", (r, l) => new IOconfNode(r, l)),
             ("Code", (r, l) => new IOconfCode(r, l)),

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -64,6 +64,7 @@ namespace CA_DataUploaderLib.IOconf
         public static CALogLevel GetOutputLevel() => GetLoopConfig().LogLevel;
         public static IEnumerable<IOconfMap> GetMap() => GetEntries<IOconfMap>();
         public static IEnumerable<IOconfGeneric> GetGeneric()  => GetEntries<IOconfGeneric>();
+        public static IEnumerable<IOconfGenericOutput> GetGenericOutputs() => GetEntries<IOconfGenericOutput>();
         public static IEnumerable<IOconfTemp> GetTemp() => GetEntries<IOconfTemp>();
         public static IOconfRPiTemp GetRPiTemp() => GetEntries<IOconfRPiTemp>().SingleOrDefault() ?? IOconfRPiTemp.Default;
         public static IEnumerable<IOconfHeater> GetHeater() => GetEntries<IOconfHeater>();

--- a/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
@@ -1,0 +1,30 @@
+using CA_DataUploaderLib.Extensions;
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace CA_DataUploaderLib.IOconf
+{
+    public class IOconfGenericOutput : IOconfOutput
+    {
+        private static readonly Regex CommandRegex = new(@"(\$\w*)$");
+        public IOconfGenericOutput(string row, int lineNum) : base(row, lineNum, "GenericSensor", false, BoardSettings.Default) 
+        {
+            Format = "GenericOutput;OutputName;BoxName;DefaultValue;command with $field";
+            var values = ToList();
+            if (values.Count < 5)
+                throw new FormatException($"Bad format in line {Row}. Expected format: {Format}");
+            if (!values[3].TryToDouble(out var defaultValue))
+                throw new FormatException($"Failed to parse default value {Row}. Expected format: {Format}");
+            DefaultValue = defaultValue;
+
+            CommandTemplate = CommandRegex.Match(values[4]);
+            if (!CommandTemplate.Success || CommandTemplate.Groups.Count != 1)
+                throw new FormatException($"Failed to find command $field in {Row}. Expected format: {Format}");
+        }
+        public double DefaultValue { get; }
+        public string TargetField => CommandTemplate.Groups[0].Value.TrimStart('$');
+        public Match CommandTemplate { get; }
+        public string GetCommand(double value) => CommandTemplate.Result(value.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
@@ -1,14 +1,16 @@
 using CA_DataUploaderLib.Extensions;
 using System;
 using System.Globalization;
+using System.IO;
 using System.Text.RegularExpressions;
 
 namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfGenericOutput : IOconfOutput
     {
-        private static readonly Regex CommandRegex = new(@"(\$\w*)$");
-        public IOconfGenericOutput(string row, int lineNum) : base(row, lineNum, "GenericSensor", false, BoardSettings.Default) 
+        private static readonly Regex CommandRegex = new(@"\$(?:{(\w*)}|(\w*))");
+        private readonly string targetFieldWithPrefix;
+        public IOconfGenericOutput(string row, int lineNum) : base(row, lineNum, "GenericOutput", false, BoardSettings.Default) 
         {
             Format = "GenericOutput;OutputName;BoxName;DefaultValue;command with $field";
             var values = ToList();
@@ -18,13 +20,21 @@ namespace CA_DataUploaderLib.IOconf
                 throw new FormatException($"Failed to parse default value {Row}. Expected format: {Format}");
             DefaultValue = defaultValue;
 
-            CommandTemplate = CommandRegex.Match(values[4]);
-            if (!CommandTemplate.Success || CommandTemplate.Groups.Count != 1)
+            CommandTemplate = values[4];
+            var match = CommandRegex.Match(CommandTemplate);
+            if (!match.Success || match.Groups.Count != 3)
+                throw new FormatException($"Failed to find command $field in {Row}. Expected format: {Format}");
+            targetFieldWithPrefix = match.Groups[0].Value;
+            if (match.Groups[1].Success)
+                TargetField = match.Groups[1].Value;
+            else if (match.Groups[2].Success)
+                TargetField = match.Groups[2].Value;
+            else
                 throw new FormatException($"Failed to find command $field in {Row}. Expected format: {Format}");
         }
         public double DefaultValue { get; }
-        public string TargetField => CommandTemplate.Groups[0].Value.TrimStart('$');
-        public Match CommandTemplate { get; }
-        public string GetCommand(double value) => CommandTemplate.Result(value.ToString(CultureInfo.InvariantCulture));
+        public string TargetField { get; }
+        public string CommandTemplate { get; }
+        public string GetCommand(double value) => CommandTemplate.Replace(targetFieldWithPrefix, value.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfNode.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfNode.cs
@@ -14,7 +14,7 @@ namespace CA_DataUploaderLib.IOconf
         private readonly IPEndPoint? _endPoint;
 
         private static readonly Lazy<IOconfNode> _singleNode = new(() => 
-            new IOconfNode(IOconfFile.GetLoopName()) { IsCurrentSystem = true, IsUploader = true }
+            new IOconfNode(TestableIOconfFile.Instance.GetLoopName()) { IsCurrentSystem = true, IsUploader = true }
         );
         private static byte _nodeInstances;
 

--- a/CA_DataUploaderLib/IOconf/IOconfOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOutput.cs
@@ -21,7 +21,7 @@ namespace CA_DataUploaderLib.IOconf
 
         protected static IOconfMap GetMap(string boxName, BoardSettings settings)
         {
-            var maps = IOconfFile.GetMap();
+            var maps = TestableIOconfFile.Instance.GetMap();
             var map = maps.SingleOrDefault(x => x.BoxName == boxName);
             if (map == null)
                 throw new Exception($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");

--- a/CA_DataUploaderLib/IOconf/TestableIOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/TestableIOconfFile.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CA_DataUploaderLib.IOconf
+{
+    public class TestableIOconfFile
+    {
+        private static TestableIOconfFile? instance;
+
+        public static TestableIOconfFile Instance 
+        { 
+            get => instance ?? new() { GetMap = IOconfFile.GetMap, GetLoopName = IOconfFile.GetLoopName }; 
+            set => instance = value; 
+        }
+        public Func<IEnumerable<IOconfMap>> GetMap { get; init; } = () => throw new NotImplementedException("missing test override for GetMap");
+        public Func<string> GetLoopName { get; init; } = () => "TestableIOconfFileloop";
+
+        public static IDisposable Override(TestableIOconfFile newInstance)
+        {
+            var revertOnDispose = new RevertToOldInstanceOnDispose(instance);
+            instance = newInstance;
+            return revertOnDispose;
+        }
+
+        private sealed class RevertToOldInstanceOnDispose : IDisposable
+        {
+            private readonly TestableIOconfFile? oldInstance;
+            public RevertToOldInstanceOnDispose(TestableIOconfFile? oldInstance) => this.oldInstance = oldInstance;
+            public void Dispose() => instance = oldInstance;
+        }
+    }
+}

--- a/UnitTests/CA_DataUploader.UnitTests.csproj
+++ b/UnitTests/CA_DataUploader.UnitTests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ProjectGuid>{C74C4DFC-74A1-40D4-A8DB-A0546ED810FD}</ProjectGuid>
+		<TestProjectType>UnitTest</TestProjectType>
+		<LangVersion>10.0</LangVersion>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\CA_DataUploaderLib\CA_DataUploaderLib.csproj" />
+	</ItemGroup>
+</Project>

--- a/UnitTests/IOConfFileLoaderTests.cs
+++ b/UnitTests/IOConfFileLoaderTests.cs
@@ -30,6 +30,35 @@ namespace UnitTests
             Assert.AreEqual(405, math.Calculate(new() { {"heater1", 400} }));
         }
 
+        [TestMethod]
+        public void CanLoadGenericOutputLine()
+        {
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[]{new IOconfMap("Map;acserial;realacbox2", 0)} });
+            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "GenericOutput;generic_ac_on;realacbox2;0;p1 $heater1_onoff 3" });
+            var rows = rowsEnum.ToArray();
+            Assert.AreEqual(1, rows.Length);
+            Assert.IsInstanceOfType(rows[0], typeof(IOconfGenericOutput));
+            var output = (IOconfGenericOutput)rows[0];
+            Assert.AreEqual("generic_ac_on", output.Name);
+            Assert.AreEqual(0, output.DefaultValue);
+            Assert.AreEqual("heater1_onoff", output.TargetField);
+            Assert.AreEqual("p1 5 3", output.GetCommand(5));
+        }
+
+        [TestMethod]
+        public void CanLoadGenericOutputLineWithBraces()
+        {
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { new IOconfMap("Map;acserial;realacbox2", 0) } });
+            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "GenericOutput;generic_ac_on;realacbox2;0;p1 on 3 ${heater1_onoff}00%" });
+            var rows = rowsEnum.ToArray();
+            Assert.AreEqual(1, rows.Length);
+            Assert.IsInstanceOfType(rows[0], typeof(IOconfGenericOutput));
+            var output = (IOconfGenericOutput)rows[0];
+            Assert.AreEqual("generic_ac_on", output.Name);
+            Assert.AreEqual(0, output.DefaultValue);
+            Assert.AreEqual("heater1_onoff", output.TargetField);
+            Assert.AreEqual("p1 on 3 100%", output.GetCommand(1));
+        }
 
         [TestMethod]
         public void CanLoadCustomConfigWithoutMixingPrefix()


### PR DESCRIPTION
This allows to tie any vector field to an output by specifyng a simple template in a config line.

This makes it possible to have subsystems that are done purely on plugins + config lines.

The generic aspect here means 'not specific to a board type'. However, without host customizations the support is limited to boards using the standard copenhagen atomics communications format (usb serial port with 115200 baud rate that returns csv lines at 10Hz + receives commands as a line of text).

To use, add a line to the IO.conf:

`GenericOutput;OutputName;BoxName;DefaultValue;command with $field`

Some examples:

- `GenericOutput;myheater;heaterbox;0;p1 $myheater_onoff 3`
- `GenericOutput;myheater;heaterbox;0;p1 on 3 ${myheater_onoff}00%`

The first 3 are values in the line are the standard type of the line, name of the sensor/actuator and box name.

The DefaultValue indicates the target that is used if no new vector data is received on the system. For example, if a node in a multinode host loses connection to the rest of the nodes.

The `command with $field` is the text line that will be sent to the box whenever there is a new value for the field. If there are no changes to the field, the system resends the command every 2 seconds, to re-assert the desired state of the connected box. The $field must be replaced with the name of the channel as shown in the plots, keeping the $ prefix.

In the first example, the board receives the command `p1 1 3`, eveyrtime the field myheater_onoff is set to 1 and whenever it changes to 0 it gets `p1 0 3`. Note these are not valid commands for the copenhagen atomics switchboard as it uses p1 on 3. Instead, the second example can be used which produces 'p1 on 3 100%' and 'p1 on 3 000%'.

