### PR TITLE
added OvenProportionalControlUpdates

### DIFF
--- a/CA_DataUploaderLib/HeatingController.cs
+++ b/CA_DataUploaderLib/HeatingController.cs
@@ -19,9 +19,10 @@ namespace CA_DataUploaderLib
 
             var ovens = IOconfFile.GetOven().ToList();
             var allAreas = IOconfFile.GetOven().Select(x => x.OvenArea).Distinct();
+            var ovenProportionalControlUpdatesConf = IOconfFile.GetEntries<IOconfOvenProportionalControlUpdates>().SingleOrDefault();
 
             //notice that the decisions states and outputs are handled by the registered decisions, while the switchboard inputs and actuations are handled by the switchboard controller
-            cmd.AddDecisions(allAreas.Select(a => new OvenAreaDecision(new($"ovenarea{a}", a))).ToList());
+            cmd.AddDecisions(allAreas.Select(a => new OvenAreaDecision(new($"ovenarea{a}", a, ovenProportionalControlUpdatesConf))).ToList());
             cmd.AddDecisions(heatersConfigs.Select(h => new HeaterDecision(h, ovens.SingleOrDefault(x => x.HeatingElement.Name == h.Name))).ToList());
             SwitchBoardController.Initialize(cmd);
         }
@@ -117,6 +118,13 @@ namespace CA_DataUploaderLib
                 public double on { get => _latestVector[_indexes.on]; set => _latestVector[_indexes.on] = value; }
                 public double nextcontrolperiod { get => _latestVector[_indexes.nextcontrolperiod]; set => _latestVector[_indexes.nextcontrolperiod] = value; }
                 public double controlperiodtimeoff { get => _latestVector[_indexes.controlperiodtimeoff]; set => _latestVector[_indexes.controlperiodtimeoff] = value; }
+                public double pgain { get => _latestVector[_indexes.pgain]; set => _latestVector[_indexes.pgain] = value; }
+                public bool pgain_defined => _indexes.pgain != -1;
+                public double controlperiodseconds { get => _latestVector[_indexes.controlperiodseconds]; set => _latestVector[_indexes.controlperiodseconds] = value; }
+                public bool controlperiodseconds_defined => _indexes.controlperiodseconds != -1;
+                public double maxoutput { get => _latestVector[_indexes.maxoutput]; set => _latestVector[_indexes.maxoutput] = value; }
+                public bool maxoutput_defined => _indexes.maxoutput != -1;
+
                 public bool TemperatureBoardsConnected
                 {
                     get
@@ -177,11 +185,8 @@ namespace CA_DataUploaderLib
                                 on = 1;
                                 break;
                             case States.InControlPeriod:
-                                var secondsOn = Math.Min(
-                                    (Math.Min(target, _config.MaxTemperature) - ovensensor) * _config.ProportionalGain,
-                                    _config.MaxOutputPercentage * _config.ControlPeriod.TotalSeconds
-                                    );
-                                nextcontrolperiod = _latestVector.TimeAfter((int)_config.ControlPeriod.TotalMilliseconds);
+                                var secondsOn = GetProportionalControlSecondsOn();
+                                nextcontrolperiod = _latestVector.TimeAfter((int)((controlperiodseconds_defined && controlperiodseconds != 0 ? controlperiodseconds : _config.ControlPeriod.TotalSeconds) * 1000));
                                 controlperiodtimeoff = _latestVector.TimeAfter(secondsOn < 0.1d ? 0 : (int)(secondsOn * 1000));
                                 on = _latestVector.Reached(controlperiodtimeoff) ? 0 : 1;
                                 break;
@@ -203,11 +208,8 @@ namespace CA_DataUploaderLib
                                 on = _latestVector.Reached(controlperiodtimeoff) ? 0 : 1;
                                 break;
                             case (States.InControlPeriod, Events.oven):
-                                var secondsOn = Math.Min(
-                                    (Math.Min(target, _config.MaxTemperature) - ovensensor) * _config.ProportionalGain,
-                                    _config.MaxOutputPercentage * _config.ControlPeriod.TotalSeconds
-                                    );
-                                controlperiodtimeoff = nextcontrolperiod.ToVectorDate().AddMilliseconds(-_config.ControlPeriod.TotalMilliseconds)
+                                var secondsOn = GetProportionalControlSecondsOn();
+                                controlperiodtimeoff = nextcontrolperiod.ToVectorDate().AddMilliseconds(-(int)((controlperiodseconds_defined && controlperiodseconds != 0 ? controlperiodseconds : _config.ControlPeriod.TotalSeconds)*1000))
                                     .AddMilliseconds(secondsOn < 0.1d ? 0 : (int)(secondsOn * 1000)).ToVectorDouble();
                                 on = _latestVector.Reached(controlperiodtimeoff) ? 0 : 1;
                                 break;
@@ -219,6 +221,11 @@ namespace CA_DataUploaderLib
                     if (oldState != State)
                         MakeDecision(Events.none); //ensure completion transitions run
                 }
+
+                double GetProportionalControlSecondsOn() =>
+                    Math.Min( //note we only use the vector based proportional control arguments if the fields are defined and set (they are enabled in configuration and have a non 0 value) and otherwise use the values in the Oven line
+                        (Math.Min(target, _config.MaxTemperature) - ovensensor) * (pgain_defined && pgain != 0 ? pgain : _config.ProportionalGain),
+                        (maxoutput_defined && maxoutput != 0 ? maxoutput : _config.MaxOutputPercentage) * (controlperiodseconds_defined && controlperiodseconds != 0 ? controlperiodseconds : _config.ControlPeriod.TotalSeconds));
             }
 
             public class Indexes
@@ -230,6 +237,9 @@ namespace CA_DataUploaderLib
                 public int controlperiodtimeoff { get; } = -1;
                 public int ovensensor { get; internal set; } = -1;
                 public int[] TemperatureBoardsStates;
+                public int pgain { get; internal set; } = -1;
+                public int controlperiodseconds { get; internal set; } = -1;
+                public int maxoutput { get; internal set; } = -1;
 
                 public Indexes(CA.LoopControlPluginBase.VectorDescription desc, Config _config)
                 {
@@ -254,6 +264,13 @@ namespace CA_DataUploaderLib
                         for (int j = 0; j < TemperatureBoardsStates.Length; j++)
                             if (field == _config.TemperatureBoardStateSensorNames[j])
                                 TemperatureBoardsStates[j] = i;
+                        if (field == $"ovenarea{_config.Area}_pgain")
+                            pgain = i;
+                        if (field == $"ovenarea{_config.Area}_controlperiodseconds")
+                            controlperiodseconds = i;
+                        if (field == $"ovenarea{_config.Area}_maxoutput")
+                            maxoutput = i;
+
                     }
 
                     if (state == -1) throw new ArgumentException($"Field used by '{_config.Name}' is not in the vector description: {_config.Name}_state", nameof(desc));
@@ -271,31 +288,42 @@ namespace CA_DataUploaderLib
 
         public class OvenAreaDecision : LoopControlDecision
         {
-            public enum States { initial, Off, Running }
-            public enum Events { none, vector, oven, ovenarea, emergencyshutdown };
+            public enum States { initial, Off, Running, ReceivedOvenCommand }
+            public enum Events { none, vector, oven, ovenarea, emergencyshutdown, pgain, controlperiodseconds, maxoutputs };
             private readonly (string prefix, Events e, bool targetRequired)[] _eventsMap;
             private readonly Config _config;
 
             private Indexes? _indexes;
             public override string Name => _config.Name;
-            public override PluginField[] PluginFields => new PluginField[] { $"{Name}_state", $"{Name}_target" };
+            public override PluginField[] PluginFields { get; }
             public override string[] HandledEvents { get; }
             public OvenAreaDecision(Config config)
             {
                 _config = config;
-                _eventsMap = new (string prefix, Events e, bool targetRequired)[] {
+                var canUpdatePArgs = config.OvenProportionalControlUpdatesConf != null;
+                PluginFields = canUpdatePArgs ?
+                    new PluginField[] { $"{Name}_state", $"{Name}_target", $"{Name}_pgain", $"{Name}_controlperiodseconds", $"{Name}_maxoutput" } :
+                    new PluginField[] { $"{Name}_state", $"{Name}_target" };
+                var eventsMap = new List<(string prefix, Events e, bool targetRequired)>() {
                     (prefix: "oven", Events.oven, true),
                     (prefix: $"ovenarea {config.Area}", Events.ovenarea, true),
                     (prefix: $"ovenarea all", Events.ovenarea, true),
                     (prefix: "emergencyshutdown", Events.emergencyshutdown, false)};
-                HandledEvents = new[] { "oven", $"ovenarea {config.Area}", "ovenarea all", "emergencyshutdown" };
+                if (canUpdatePArgs)
+                {
+                    eventsMap.Insert(0, (prefix: $"ovenarea {config.Area} pgain", Events.pgain, true));
+                    eventsMap.Insert(0, (prefix: $"ovenarea {config.Area} controlperiodseconds", Events.controlperiodseconds, true));
+                    eventsMap.Insert(0, (prefix: $"ovenarea {config.Area} maxoutput", Events.maxoutputs, true));
+                }
+                _eventsMap = eventsMap.ToArray();
+                HandledEvents = eventsMap.Select(e => e.prefix).ToArray();
             }
 
             public override void Initialize(CA.LoopControlPluginBase.VectorDescription desc) => _indexes = new(desc, _config);
             public override void MakeDecision(CA.LoopControlPluginBase.DataVector vector, List<string> events)
             {
                 if (_indexes == null) throw new InvalidOperationException("Unexpected call to MakeDecision before Initialize was called first");
-                var model = new Model(vector, _indexes);
+                var model = new Model(vector, _indexes, _config);
 
                 foreach (var e in events)
                 foreach (var (prefix, typedEvent, targetRequired) in _eventsMap)
@@ -313,29 +341,36 @@ namespace CA_DataUploaderLib
 
             public class Config
             {
-                public Config(string name, int area)
+                public Config(string name, int area, IOconfOvenProportionalControlUpdates? ovenProportionalControlUpdatesConf = null)
                 {
                     Name = name;
                     Area = area;
+                    OvenProportionalControlUpdatesConf = ovenProportionalControlUpdatesConf;
                 }
 
                 public int Area { get; init; }
                 public string Name { get; }
+                public IOconfOvenProportionalControlUpdates? OvenProportionalControlUpdatesConf { get; }
             }
 
 #pragma warning disable IDE1006 // Naming Styles - decisions are coded using a similar approach to decisions plugins, which avoid casing rules in properties to more have naming more similar to the original fields
             public ref struct Model
             {
                 private readonly Indexes _indexes;
+                private readonly Config _config;
                 private readonly CA.LoopControlPluginBase.DataVector _latestVector;
 
-                public Model(CA.LoopControlPluginBase.DataVector latestVector, Indexes indexes)
+                public Model(CA.LoopControlPluginBase.DataVector latestVector, Indexes indexes, Config config)
                 {
                     _latestVector = latestVector;
                     _indexes = indexes;
+                    _config = config;
                 }
                 public States State { get => (States)_latestVector[_indexes.state]; set => _latestVector[_indexes.state] = (int)value; }
                 public double target { get => _latestVector[_indexes.target]; set => _latestVector[_indexes.target] = value; }
+                public double pgain { get => _latestVector[_indexes.pgain]; set => _latestVector[_indexes.pgain] = value; }
+                public double controlperiodseconds { get => _latestVector[_indexes.controlperiodseconds]; set => _latestVector[_indexes.controlperiodseconds] = value; }
+                public double maxoutput { get => _latestVector[_indexes.maxoutput]; set => _latestVector[_indexes.maxoutput] = value; }
 
                 internal void MakeDecision(Events e, double data = 0)
                 {
@@ -343,6 +378,9 @@ namespace CA_DataUploaderLib
                     State = (oldState, e) switch
                     {
                         (States.initial, _) => States.Off,
+                        (States.Off, Events.oven or Events.ovenarea) => States.ReceivedOvenCommand,
+                        (States.ReceivedOvenCommand, _) when target > 0 => States.Running,
+                        (States.ReceivedOvenCommand, _) => States.Off,
                         (States.Off, Events.vector) when target > 0 => States.Running,
                         (States.Running, Events.emergencyshutdown) => States.Off,
                         (States.Running, Events.vector) when target == 0 => States.Off,
@@ -355,6 +393,9 @@ namespace CA_DataUploaderLib
                             case States.Off:
                                 target = 0;
                                 break;
+                            case States.ReceivedOvenCommand:
+                                target = data;
+                                break;
                             default: //any state without entry actions goes here
                                 break;
                         }
@@ -365,6 +406,23 @@ namespace CA_DataUploaderLib
                         {
                             case (States.Off or States.Running, Events.oven or Events.ovenarea):
                                 target = data;
+                                break;
+                            case (States.Off or States.Running, Events.pgain):
+                                pgain = Math.Min(data, _config.OvenProportionalControlUpdatesConf!.MaxProportionalGain);
+                                break;
+                            case (States.Off or States.Running, Events.controlperiodseconds):
+                                controlperiodseconds = Math.Min(data, _config.OvenProportionalControlUpdatesConf!.MaxControlPeriod.TotalSeconds);
+                                break;
+                            case (States.Off or States.Running, Events.maxoutputs):
+                                maxoutput = Math.Min(data / 100, _config.OvenProportionalControlUpdatesConf!.MaxOutputPercentage);
+                                break;
+                            case (States.Off or States.Running, Events.vector):
+                                if (_config.OvenProportionalControlUpdatesConf != null)
+                                {
+                                    pgain = Math.Min(pgain, _config.OvenProportionalControlUpdatesConf.MaxProportionalGain);
+                                    controlperiodseconds = Math.Min(controlperiodseconds, _config.OvenProportionalControlUpdatesConf.MaxControlPeriod.TotalSeconds);
+                                    maxoutput = Math.Min(maxoutput, _config.OvenProportionalControlUpdatesConf.MaxOutputPercentage);
+                                }
                                 break;
                             default: //any state without event actions goes here
                                 break;
@@ -380,6 +438,9 @@ namespace CA_DataUploaderLib
             {
                 public int state { get; } = -1;
                 public int target { get; internal set; } = -1;
+                public int pgain { get; internal set; } = -1;
+                public int controlperiodseconds { get; internal set; } = -1;
+                public int maxoutput { get; internal set; } = -1;
 
                 public Indexes(CA.LoopControlPluginBase.VectorDescription desc, Config _config)
                 {
@@ -390,10 +451,19 @@ namespace CA_DataUploaderLib
                             state = i;
                         if (field == $"{_config.Name}_target")
                             target = i;
+                        if (field == $"{_config.Name}_pgain")
+                            pgain = i;
+                        if (field == $"{_config.Name}_controlperiodseconds")
+                            controlperiodseconds = i;
+                        if (field == $"{_config.Name}_maxoutput")
+                            maxoutput = i;
                     }
 
                     if (state == -1) throw new ArgumentException($"Field used by '{_config.Name}' is not in the vector description: {_config.Name}_state", nameof(desc));
                     if (target == -1) throw new ArgumentException($"Field used by '{_config.Name}' is not in the vector description: {_config.Name}_target", nameof(desc));
+                    if (pgain == -1 && _config.OvenProportionalControlUpdatesConf != null) throw new ArgumentException($"Field used by '{_config.Name}' is not in the vector description: {_config.Name}_pgain", nameof(desc));
+                    if (controlperiodseconds == -1 && _config.OvenProportionalControlUpdatesConf != null) throw new ArgumentException($"Field used by '{_config.Name}' is not in the vector description: {_config.Name}_controlperiodseconds", nameof(desc));
+                    if (maxoutput == -1 && _config.OvenProportionalControlUpdatesConf != null) throw new ArgumentException($"Field used by '{_config.Name}' is not in the vector description: {_config.Name}_maxoutput", nameof(desc));
                 }
             }
 #pragma warning restore IDE1006 // Naming Styles

--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -20,6 +20,7 @@ namespace CA_DataUploaderLib.IOconf
             (IOconfTemp.TypeJName, IOconfTemp.NewTypeJ),
             ("Heater", (r, l) => new IOconfHeater(r, l)),
             ("Oven", (r, l) => new IOconfOven(r, l)),
+            (IOconfOvenProportionalControlUpdates.TypeName, (r, l) => new IOconfOvenProportionalControlUpdates(r, l)),
             ("Filter", (r, l) => new IOconfFilter(r, l)),
             ("RPiTemp", (r, l) => new IOconfRPiTemp(r, l)),
             ("GenericSensor", (r, l) => new IOconfGeneric(r, l)),

--- a/CA_DataUploaderLib/IOconf/IOconfOven.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOven.cs
@@ -17,7 +17,8 @@ namespace CA_DataUploaderLib.IOconf
                 throw new Exception($"IOconfOven: wrong OvenArea number: {row} {Format}");
             if (OvenArea < 1)
                 throw new Exception("Oven area must be a number bigger or equal to 1");
-            
+
+            HeaterName = list[2];
             TemperatureSensorName = list[3];
 
             if (list.Count < 5) return;
@@ -41,7 +42,7 @@ namespace CA_DataUploaderLib.IOconf
         public override void ValidateDependencies()
         {
             var list = ToList();
-            HeatingElement = IOconfFile.GetHeater().Single(x => x.Name == list[2]);
+            HeatingElement = IOconfFile.GetHeater().Single(x => x.Name == HeaterName);
             var isTemp = IOconfFile.GetTemp().Any(t => t.Name == TemperatureSensorName);
             var isMath = IOconfFile.GetMath().Any(m => m.Name == TemperatureSensorName);
             var isFilter = IOconfFile.GetFilters().Any(f => f.NameInVector == TemperatureSensorName);
@@ -61,6 +62,7 @@ namespace CA_DataUploaderLib.IOconf
             private set => heatingElement = value; 
         }
         public string TemperatureSensorName { get; }
+        public string HeaterName { get; }
         public ReadOnlyCollection<string> BoardStateSensorNames 
         { 
             get => boardStateSensorNames ?? throw new Exception($"Call {nameof(ValidateDependencies)} before accessing {nameof(BoardStateSensorNames)}.");

--- a/CA_DataUploaderLib/IOconf/IOconfOvenProportionalControlUpdates.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOvenProportionalControlUpdates.cs
@@ -30,6 +30,7 @@ namespace CA_DataUploaderLib.IOconf
         /// <remarks><see cref="IOconfOven.ProportionalGain"/></remarks>
         public double MaxProportionalGain { get; }
         public TimeSpan MaxControlPeriod { get; }
+        /// <summary>the percentage in the 0 to 1 range (the line in IO.conf instead is entered in the 0-100 range, as we do for <see cref="IOconfOven.MaxOutputPercentage"/>)</summary>
         public double MaxOutputPercentage { get; }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfOvenProportionalControlUpdates.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOvenProportionalControlUpdates.cs
@@ -1,0 +1,35 @@
+﻿#nullable enable
+using System;
+using CA_DataUploaderLib.Extensions;
+
+namespace CA_DataUploaderLib.IOconf
+{
+    public class IOconfOvenProportionalControlUpdates : IOconfDriver
+    {
+        public IOconfOvenProportionalControlUpdates(string row, int lineNum) : base(row, lineNum, TypeName)
+        {
+            Format = $"{TypeName};[MaxProportionalGain];[MaxControlPeriod];[MaxOutputPercentage]";
+
+            var list = ToList();
+            if (!list[1].TryToDouble(out var maxpGain)) 
+                throw new FormatException($"failed to parse MaxProportionalGain: {row}. Expected format: {Format}");
+
+            if (!TimeSpan.TryParse(list[2], out var maxPeriod))
+                throw new FormatException($"Failed to parse MaxControlPeriod: {row}. Expected format: {Format}");
+
+            if (!int.TryParse(list[3], out var maxOutput))
+                throw new FormatException($"Failed to parse MaxOutputPercentage: {row}. Expected format: {Format}");
+            if (maxOutput < 0 || maxOutput > 100)
+                throw new FormatException($"Max output percentage must be a whole number between 0 and 100: {row}. Expected format: {Format}");
+
+            (MaxProportionalGain, MaxControlPeriod, MaxOutputPercentage) = (maxpGain, maxPeriod, maxOutput / 100d);
+        }
+
+        public const string TypeName = "OvenProportionalControlUpdates";
+
+        /// <remarks><see cref="IOconfOven.ProportionalGain"/></remarks>
+        public double MaxProportionalGain { get; }
+        public TimeSpan MaxControlPeriod { get; }
+        public double MaxOutputPercentage { get; }
+    }
+}

--- a/UnitTests/HeaterDecisionTests.cs
+++ b/UnitTests/HeaterDecisionTests.cs
@@ -322,7 +322,7 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void PControlUsesUsesMaxConfigurationForCommandValuesAboveAllowedRange()
+        public void PControlUsesMaxConfigurationForCommandValuesAboveAllowedRange()
         {
             var ovenProportionalControlUpdatesConf = new IOconfOvenProportionalControlUpdates("OvenProportionalControlUpdates;2;00:00:30;100", 0);
             NewOvenAreaDecisionConfig(new("ovenarea0", 0, ovenProportionalControlUpdatesConf));
@@ -406,7 +406,7 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void PControlUsesUsesMaxConfigurationForVectorValuesAboveAllowedRange()
+        public void PControlUsesMaxConfigurationForVectorValuesAboveAllowedRange()
         {
             var ovenProportionalControlUpdatesConf = new IOconfOvenProportionalControlUpdates("OvenProportionalControlUpdates;2;00:00:30;100", 0);
             NewOvenAreaDecisionConfig(new("ovenarea0", 0, ovenProportionalControlUpdatesConf));

--- a/UnitTests/IOconfOvenTests.cs
+++ b/UnitTests/IOconfOvenTests.cs
@@ -1,0 +1,42 @@
+﻿using CA_DataUploaderLib.IOconf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class IOconfOvenTests
+    {
+        [DataRow("Oven;2;topheater1;typek1;0.2;00:00:10;20", "topheater1", "typek1", 0.2d, 10d, 0.2d)]
+        [DataTestMethod]
+        public void ParsesOvenLine(string row, string heaterName, string sensorName, double pgain, double controlPeriodSeconds, double maxOutput) 
+        {
+            var oven = new IOconfOven(row, 0);
+            Assert.AreEqual(heaterName, oven.HeaterName);
+            Assert.AreEqual(sensorName, oven.TemperatureSensorName);
+            Assert.AreEqual(pgain, oven.ProportionalGain);
+            Assert.AreEqual(TimeSpan.FromSeconds(controlPeriodSeconds), oven.ControlPeriod);
+            Assert.AreEqual(maxOutput, oven.MaxOutputPercentage);
+        }
+
+        [DataRow("OvenProportionalControlUpdates;3.5;00:01:10;30", 3.5d, 70d, 0.3d)]
+        [DataRow("OvenProportionalControlUpdates;3;00:00:05;5", 3d, 5d, 0.05d)]
+        [DataTestMethod]
+        public void ParsesOvenProportionalControlUpdatesLine(string row, double pgain, double controlPeriodSeconds, double maxOutput)
+        {
+            var oven = new IOconfOvenProportionalControlUpdates(row, 0);
+            Assert.AreEqual(pgain, oven.MaxProportionalGain);
+            Assert.AreEqual(TimeSpan.FromSeconds(controlPeriodSeconds), oven.MaxControlPeriod);
+            Assert.AreEqual(maxOutput, oven.MaxOutputPercentage);
+        }
+
+        [DataRow("OvenProportionalControlUpdates;3.5a;00:01:10;30")]
+        [DataRow("OvenProportionalControlUpdates;3;00:00:05;5d")]
+        [DataRow("OvenProportionalControlUpdates;3;00:00:05;-5")]
+        [DataTestMethod]
+        public void ThrowsFormatExceptionOnBrokenOvenProportionalControlUpdatesLine(string row)
+        {
+            Assert.ThrowsException<FormatException>(() => new IOconfOvenProportionalControlUpdates(row, 0));
+        }
+    }
+}


### PR DESCRIPTION
This allows live updates to the proportional control arguments of the heating control. Note that the updated values are lost when restarting the system.

The configuration line requires specifying the maximum value for the different proportional control arguments. The meaning and format of the arguments is the same as in the Oven configuration lines.

The feature is only supported at the oven area level, so all the heaters in the area get the same values. When the arguments have not been changed, the system uses the configuration values specified in the Oven configuration lines for each heater.

* **IO.conf lines:** 
    * `OvenProportionalControlUpdates;[MaxProportionalGain];[MaxControlPeriod];[MaxOutputPercentage]` e.g. `OvenProportionalControlUpdates;10;00:01:00;100`
* **user commands:** 
    * set proportional gain for oven area 2: `ovenarea 2 pgain 0.5`
    * set control period for oven area 1: `ovenarea 1 controlperiodseconds 100 `
    * set max output for oven area 3: `ovenarea 3 maxoutput 70`
* **plugin fields:** `ovenarea{number}_pgain`, `ovenarea{number}_controlperiodseconds`, `ovenarea{number}_maxoutput`. The fields are state fields that retain their value once set. The change is only reflected in the next control period.