### PR TITLE
subsystems can now report global inputs

### DIFF
--- a/CA_DataUploaderLib/Extensions/ChannelReaderExtensions.cs
+++ b/CA_DataUploaderLib/Extensions/ChannelReaderExtensions.cs
@@ -6,6 +6,7 @@ namespace CA_DataUploaderLib.Extensions
 {
     public static class ChannelReaderExtensions
     {
+        /// <returns><c>null</c> if it timed out, otherwise the read value.</returns>
         public static async Task<T?> ReadWithSoftTimeout<T>(this ChannelReader<T> reader, int timeoutMs, CancellationToken token)
         {
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token);

--- a/CA_DataUploaderLib/Helpers/ExtendedVectorDescription.cs
+++ b/CA_DataUploaderLib/Helpers/ExtendedVectorDescription.cs
@@ -21,11 +21,11 @@ namespace CA_DataUploaderLib.Helpers
         /// </summary>
         public IReadOnlyList<(IOconfNode, IReadOnlyList<VectorDescriptionItem>)> InputsPerNode { get; set; }
 
-        public ExtendedVectorDescription(List<(IOconfNode, IReadOnlyList<VectorDescriptionItem> values)> inputsPerNode, List<VectorDescriptionItem> outputs)
+        public ExtendedVectorDescription(List<(IOconfNode, IReadOnlyList<VectorDescriptionItem> values)> inputsPerNode, List<VectorDescriptionItem> globalInputs, List<VectorDescriptionItem> outputs)
         {
             _logLevel = IOconfFile.GetOutputLevel();
             InputsPerNode = inputsPerNode;
-            List<VectorDescriptionItem> allItems = inputsPerNode.SelectMany(n => n.values).ToList();
+            List<VectorDescriptionItem> allItems = inputsPerNode.SelectMany(n => n.values).Concat(globalInputs).ToList();
             _values = GetFilters(allItems);
             allItems.AddRange(_values.Select(m => new VectorDescriptionItem("double", m.Output.Name, DataTypeEnum.Input)));
             RemoveHiddenSources(allItems, i => i.Descriptor);

--- a/CA_DataUploaderLib/ISubsystemWithVectorData.cs
+++ b/CA_DataUploaderLib/ISubsystemWithVectorData.cs
@@ -12,11 +12,14 @@ namespace CA_DataUploaderLib
         SubsystemDescriptionItems GetVectorDescriptionItems();
         /// <returns>The input values coming from local boards</returns>
         IEnumerable<SensorSample> GetInputValues();
+        /// <returns>Unlike <see cref="GetInputValues"/>, these values are not specific to a given node e.g.  information about operations only done by a current cluster leader and after a leader change it is the new leader that reports these values.</returns>
+        IEnumerable<SensorSample> GetGlobalInputValues() => Enumerable.Empty<SensorSample>();
         Task Run(CancellationToken token);
     }
 
     public record SubsystemDescriptionItems(List<(IOconfNode node, List<VectorDescriptionItem> items)> Inputs)
     {
+        public IEnumerable<VectorDescriptionItem> GlobalInputs { get; init; } = new List<VectorDescriptionItem>(0);
         public IEnumerable<VectorDescriptionItem> GetNodeInputs(IOconfNode node) => Inputs.Where(n => n.node == node).SelectMany(n => n.items);
     }
 }

--- a/CA_DataUploaderLib/SingleNodeRunner.cs
+++ b/CA_DataUploaderLib/SingleNodeRunner.cs
@@ -29,7 +29,7 @@ namespace CA_DataUploaderLib
                     var events = GetReceivedEventsInThisCycle();
                     var commands = events.Where(e => e.EventType == (byte)EventType.Command);
                     var stringCommands = commands.Any() ? commands.Select(e => e.Data).ToList() : emptyCommands;
-                    cmdHandler.MakeDecision(cmdHandler.GetNodeInputs().ToList(), DateTime.UtcNow, ref vector, stringCommands);
+                    cmdHandler.MakeDecision(cmdHandler.GetNodeInputs().Concat(cmdHandler.GetGlobalInputs()).ToList(), DateTime.UtcNow, ref vector, stringCommands);
                     vector = new(vector.Data.ToArray(), vector.Timestamp, new List<EventFiredArgs>(events));//note we create copies to avoid changes in the next cycle affecting data of the previous cycle (specially via OnNewVectorReceived)
                     cmdHandler.OnNewVectorReceived(vector);
                     await Task.WhenAny(sendThrottle.WaitAsync(token));//whenany for no exceptions on cancel


### PR DESCRIPTION
On distributed deployments, the inputs are normally associated with a specific node. This change allows to have inputs that are not specific to a given node.

For example, this can enable a leader based host to report timing of operations done by the currently elected leader. The alternative without the new feature is to add every leader field to all nodes and only to report a value for the leader, which not only is confusing but wastes a lot of resources by needing so many extra/unused fields.