### PR TITLE
Added RepeatMilliseconds to the GenericOutput configuration line

### DIFF
--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />
 	  <PackageReference Include="CA.LoopControlPluginBase" Version="1.0.0" />
 	  <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
+	<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0-rc.2.23479.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CA_DataUploaderLib/GenericSensorBox.cs
+++ b/CA_DataUploaderLib/GenericSensorBox.cs
@@ -10,7 +10,7 @@ namespace CA_DataUploaderLib
             var outputs = IOconfFile.GetGenericOutputs();
             foreach (var output in outputs.Where(o => o.Map.IsLocalBoard && o.Map.McuBoard != null))
                 RegisterBoardWriteActions(
-                    output.Map.McuBoard!, output, output.DefaultValue, output.TargetField, (_, v) => output.GetCommand(v));
+                    output.Map.McuBoard!, output, output.DefaultValue, output.TargetField, (_, v) => output.GetCommand(v), output.RepeatMilliseconds);
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
@@ -1,7 +1,6 @@
 using CA_DataUploaderLib.Extensions;
 using System;
 using System.Globalization;
-using System.IO;
 using System.Text.RegularExpressions;
 
 namespace CA_DataUploaderLib.IOconf
@@ -12,7 +11,7 @@ namespace CA_DataUploaderLib.IOconf
         private readonly string targetFieldWithPrefix;
         public IOconfGenericOutput(string row, int lineNum) : base(row, lineNum, "GenericOutput", false, BoardSettings.Default) 
         {
-            Format = "GenericOutput;OutputName;BoxName;DefaultValue;command with $field";
+            Format = "GenericOutput;OutputName;BoxName;DefaultValue;command with $field;[RepeatMilliseconds]";
             var values = ToList();
             if (values.Count < 5)
                 throw new FormatException($"Bad format in line {Row}. Expected format: {Format}");
@@ -31,10 +30,16 @@ namespace CA_DataUploaderLib.IOconf
                 TargetField = match.Groups[2].Value;
             else
                 throw new FormatException($"Failed to find command $field in {Row}. Expected format: {Format}");
+
+            RepeatMilliseconds = values.Count < 6 
+                ? 2000 
+                : int.TryParse(values[5], out var repeatMs) ? repeatMs : throw new FormatException($"Failed to parse repeat milliseconds {Row}. Expected format: {Format}");
         }
         public double DefaultValue { get; }
         public string TargetField { get; }
         public string CommandTemplate { get; }
+        public int RepeatMilliseconds { get; }
+
         public string GetCommand(double value) => CommandTemplate.Replace(targetFieldWithPrefix, value.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/UnitTests/CA_DataUploader.UnitTests.csproj
+++ b/UnitTests/CA_DataUploader.UnitTests.csproj
@@ -12,6 +12,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23510.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -12,6 +12,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23510.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
* Added RepeatMilliseconds to the GenericOutput configuration line
* fixed vector based timeout in LastAction and added related unit test while also making those unit tests faster by using the TimeProvider for time passing in tests

The line format is now: `GenericOutput;OutputName;BoxName;DefaultValue;command with $field;[RepeatMilliseconds]`

So now these 2 are possible, where the second repeats the command every 2 minutes:
* `GenericOutput;myheater;heaterbox;0;p1 on 3 ${myheater_onoff}00%`
* `GenericOutput;myheater;heaterbox;0;p1 on 3 ${myheater_onoff}00%;120000`