### PR TITLE
Implementing IOconf-lines for current sensors (to be able to send calibration values to a Current board). #738

### DIFF
--- a/CA_DataUploaderLib/CurrentBox.cs
+++ b/CA_DataUploaderLib/CurrentBox.cs
@@ -1,0 +1,16 @@
+﻿using CA_DataUploaderLib.IOconf;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CA_DataUploaderLib
+{
+    public class CurrentBox : BaseSensorBox
+    {
+        public CurrentBox(CommandHandler cmd) : base(cmd, "Current", GetSensorConfigs()) { }
+
+        private static IEnumerable<IOconfInput> GetSensorConfigs()
+        {
+            return IOconfFile.GetEntries<IOconfCurrent>().Cast<IOconfInput>().Concat(IOconfFile.GetEntries<IOconfCurrentFault>());
+        }
+    }
+}

--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -28,6 +28,8 @@ namespace CA_DataUploaderLib.IOconf
             ("SwitchboardSensor", (r, l) => new IOconfSwitchboardSensor(r, l)),
             ("Node", (r, l) => new IOconfNode(r, l)),
             ("Code", (r, l) => new IOconfCode(r, l)),
+            (IOconfCurrent.TypeName, (r, l) => new IOconfCurrent(r, l)),
+            (IOconfCurrentFault.TypeName, (r, l) => new IOconfCurrentFault(r, l)),
         };
 
         public static bool FileExists()

--- a/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
@@ -46,8 +46,6 @@ namespace CA_DataUploaderLib.IOconf
                 if (supportsCalibration)
                 {
                     var nfi = new NumberFormatInfo() { NumberDecimalDigits = 2 };
-                    // TODO: Map.Board.Calibration is different from Map.BoardSettings.Calibration!
-                    // Should we update Map.BoardSettings.Calibration based on Map.Board.Calibration?
                     UpdatePortCalibration(Map.BoardSettings, currentTransformerRatio.ToString("F", nfi), PortNumber);
                 }
                 else

--- a/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
@@ -8,7 +8,7 @@ namespace CA_DataUploaderLib.IOconf
     {
         public const string TypeName = "Current";
 
-        static readonly string DefaultCalibration = $"CAL {string.Join(" ", Enumerable.Range(1, 3).Select(i => $"{i},60.00,0"))}";
+        static readonly string DefaultCalibration = $"CAL {string.Join(" ", Enumerable.Range(1, 3).Select(i => $"{i},60.000000,0"))}";
 
         public IOconfCurrent(string row, int lineNum) :
             base(row, lineNum, TypeName, false, new BoardSettings()
@@ -45,7 +45,7 @@ namespace CA_DataUploaderLib.IOconf
                 var supportsCalibration = calibrationFromBoard is not null && calibrationFromBoard.StartsWith("CAL");
                 if (supportsCalibration)
                 {
-                    var nfi = new NumberFormatInfo() { NumberDecimalDigits = 2 };
+                    var nfi = new NumberFormatInfo() { NumberDecimalDigits = 6 };
                     UpdatePortCalibration(Map.BoardSettings, currentTransformerRatio.ToString("F", nfi), PortNumber);
                 }
                 else

--- a/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
@@ -26,7 +26,7 @@ namespace CA_DataUploaderLib.IOconf
             if (list.Count < 5)
                 throw new FormatException($"{nameof(IOconfCurrent)}: wrong format: {row}. Expected format: {Format}");
 
-            if (!double.TryParse(list[4], NumberStyles.Float, CultureInfo.InvariantCulture, out double loadSideRating) || !double.IsPositive(loadSideRating))
+            if (!double.TryParse(list[4], NumberStyles.Float, CultureInfo.InvariantCulture, out double loadSideRating) || double.IsNegative(loadSideRating))
                 throw new FormatException($"Unsupported load side rating at line '{Row}'. Only positive numbers are allowed. Expected format: {Format}.");
 
             var meterSideRating = 5.0; // A default meter side rating of 5.0A which can optionally be changed

--- a/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+
+namespace CA_DataUploaderLib.IOconf
+{
+    public class IOconfCurrent : IOconfInput
+    {
+        public const string TypeName = "Current";
+
+        static readonly string DefaultCalibration = $"CAL {string.Join(" ", Enumerable.Range(1, 3).Select(i => $"{i},60.00,0"))}";
+
+        public IOconfCurrent(string row, int lineNum) :
+            base(row, lineNum, TypeName, false, new BoardSettings()
+            {
+                SkipCalibrationWhenHeaderIsMissing = true //Don't try to calibrate boards that don't support calibration
+            })
+        {
+            Format = $"{TypeName};Name;BoxName;PortNumber;LoadSideRating;[MeterSideRating]";
+
+            var list = ToList();
+            if (Skip)
+                return;
+            if (!HasPort || PortNumber < 1 || PortNumber > 3)
+                throw new FormatException($"{TypeName}: invalid port number (allowed: [1-3]): {row}");
+            if (list.Count < 5)
+                throw new FormatException($"{nameof(IOconfCurrent)}: wrong format: {row}. Expected format: {Format}");
+
+            if (!double.TryParse(list[4], NumberStyles.Float, CultureInfo.InvariantCulture, out double loadSideRating) || !double.IsPositive(loadSideRating))
+                throw new FormatException($"Unsupported load side rating at line '{Row}'. Only positive numbers are allowed. Expected format: {Format}.");
+
+            var meterSideRating = 5.0; // A default meter side rating of 5.0A which can optionally be changed
+            if (list.Count >= 6 && (!double.TryParse(list[5], NumberStyles.Float, CultureInfo.InvariantCulture, out meterSideRating) || meterSideRating <= 0.0 || meterSideRating > 5.0))
+                throw new FormatException($"Unsupported meter side rating at line '{Row}'. Only numbers between 0 and 5 are allowed. Expected format: {Format}.");
+
+            var currentTransformerRatio = loadSideRating / meterSideRating;
+
+            Map.OnBoardDetected += OnBoardDetected;
+
+            // We need to read the current calibration from the board to know if it is supported
+            void OnBoardDetected(object? sender, EventArgs e)
+            {
+                var board = Map.Board ?? throw new InvalidOperationException($"Unexpected Map.OnBoardDetected with a null board for {Map.Name}");
+                var calibrationFromBoard = board.Calibration;
+                var supportsCalibration = calibrationFromBoard is not null && calibrationFromBoard.StartsWith("CAL");
+                if (supportsCalibration)
+                {
+                    var nfi = new NumberFormatInfo() { NumberDecimalDigits = 2 };
+                    // TODO: Map.Board.Calibration is different from Map.BoardSettings.Calibration!
+                    // Should we update Map.BoardSettings.Calibration based on Map.Board.Calibration?
+                    UpdatePortCalibration(Map.BoardSettings, currentTransformerRatio.ToString("F", nfi), PortNumber);
+                }
+                else
+                {
+                    CALog.LogErrorAndConsoleLn(LogID.A, $"Warning: old current board {Map.Name} cannot use new format for sensor {Name}.");
+                }
+            }
+        }
+
+        private static void UpdatePortCalibration(BoardSettings settings, string scalar, int portNumber)
+        { //see DefaultCalibration for the format, spaces separate each port configuration section (first one is just "CAL ")
+            var currentPortsCal = (settings.Calibration ?? DefaultCalibration).Split(" ");
+            currentPortsCal[portNumber] = $"{portNumber},{scalar},0";
+            settings.Calibration = string.Join(' ', currentPortsCal);
+        }
+    }
+
+    public class IOconfCurrentFault : IOconfInput
+    {
+        public const string TypeName = "CurrentFault";
+
+        public IOconfCurrentFault(string row, int lineNum) :
+            base(row, lineNum, TypeName, false, BoardSettings.Default)
+        {
+            Format = $"{TypeName};Name;BoxName";
+            PortNumber = 4;
+        }
+    }
+}

--- a/UnitTests/IOConfFileLoaderTests.cs
+++ b/UnitTests/IOConfFileLoaderTests.cs
@@ -70,6 +70,19 @@ namespace UnitTests
             Assert.IsInstanceOfType(rows[0], typeof(IOConfMathing));
         }
 
+        [TestMethod]
+        public void CanLoadCurrentLine()
+        {
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { new IOconfMap("Map;ctserial;ct01", 0) } }); 
+            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "Current;current_ct01;ct01;2;300" });
+            var rows = rowsEnum.ToArray();
+            Assert.AreEqual(1, rows.Length);
+            Assert.IsInstanceOfType(rows[0], typeof(IOconfCurrent));
+            var current = (IOconfCurrent)rows[0];
+            Assert.AreEqual("current_ct01", current.Name);
+            Assert.AreEqual(2, current.PortNumber);
+        }
+
         private class IOConfMathing : IOconfRow
         {
             public IOConfMathing(string row, int lineIndex) : base(row, lineIndex, "Mathing") {}

--- a/UnitTests/IOconfCurrentTests.cs
+++ b/UnitTests/IOconfCurrentTests.cs
@@ -1,0 +1,168 @@
+﻿using CA_DataUploaderLib;
+using CA_DataUploaderLib.IOconf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Globalization;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class IOconfCurrentTests
+    {
+        private readonly string boxName = "currentBoard12345";
+        private readonly string portName = RpiVersion.IsWindows() ? "COM3" : "USB1-2-3";
+        private readonly string portPrefix = RpiVersion.IsWindows() ? "" : "/dev/";
+
+        [TestMethod]
+        public void BoardWithoutCalibrationDoesNotGetUpdated()
+        {
+            // Arrange
+            IOconfMap? mapLine = null;
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { mapLine = new IOconfMap($"Map; {portName}; {boxName}", 0) } });
+            var loadSideRating = 300;
+            string? boardCalibration = null;
+
+            // Act
+            var ioConf = new IOconfCurrent($"Current; myCurrent; {boxName}; 2; {loadSideRating.ToString(CultureInfo.InvariantCulture)}", 0);
+            mapLine!.Setboard(new TestBoard(portPrefix + portName, mapLine, boardCalibration));
+
+            // Assert
+            Assert.IsNull(mapLine!.BoardSettings.Calibration);
+        }
+
+
+        [TestMethod]
+        public void BoardNotSupportingCalibrationDoesNotGetUpdated()
+        {
+            // Arrange
+            IOconfMap? mapLine = null;
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { mapLine = new IOconfMap($"Map; {portName}; {boxName}", 0) } });
+            var loadSideRating = 300;
+            string? boardCalibration = "Old";
+
+            // Act
+            var ioConf = new IOconfCurrent($"Current; myCurrent; {boxName}; 2; {loadSideRating.ToString(CultureInfo.InvariantCulture)}", 0);
+            mapLine!.Setboard(new TestBoard(portPrefix + portName, mapLine, boardCalibration));
+
+            // Assert
+            Assert.IsNull(mapLine!.BoardSettings.Calibration);
+        }
+
+        [TestMethod]
+        public void BoardCalibrationGetsUpdated()
+        {
+            // Arrange
+            IOconfMap? mapLine = null;
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { mapLine = new IOconfMap($"Map; {portName}; {boxName}", 0) } });
+            var loadSideRating = 150;
+            string? boardCalibration = "CAL 1,60.00,0 2,60.00,0 3,60.00,0";
+
+            // Act
+            var ioConf = new IOconfCurrent($"Current; myCurrent; {boxName}; 2; {loadSideRating.ToString(CultureInfo.InvariantCulture)}", 0);
+            mapLine!.Setboard(new TestBoard(portPrefix + portName, mapLine, boardCalibration));
+
+            // Assert
+            var twoDecimalDigits = new NumberFormatInfo() { NumberDecimalDigits = 2 };
+            var expectedScalar = (loadSideRating / 5).ToString("F", twoDecimalDigits);
+            var expectedBoardCalibration = $"CAL 1,60.00,0 2,{expectedScalar},0 3,60.00,0";
+            Assert.AreEqual(expectedBoardCalibration, mapLine!.BoardSettings.Calibration);
+        }
+
+        [TestMethod]
+        public void BoardCalibrationWithCustomMeterSideRatingGetsUpdated()
+        {
+            // Arrange
+            IOconfMap? mapLine = null;
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { mapLine = new IOconfMap($"Map; {portName}; {boxName}", 0) } });
+            var loadSideRating = 150;
+            var meterSideRating = 2;
+            string? boardCalibration = "CAL 1,60.00,0 2,60.00,0 3,60.00,0";
+
+            // Act
+            var ioConf = new IOconfCurrent($"Current; myCurrent; {boxName}; 2; {loadSideRating.ToString(CultureInfo.InvariantCulture)}; {meterSideRating.ToString(CultureInfo.InvariantCulture)}", 0);
+            mapLine!.Setboard(new TestBoard(portPrefix + portName, mapLine, boardCalibration));
+
+            // Assert
+            var twoDecimalDigits = new NumberFormatInfo() { NumberDecimalDigits = 2 };
+            var expectedScalar = (loadSideRating / meterSideRating).ToString("F", twoDecimalDigits);
+            var expectedBoardCalibration = $"CAL 1,60.00,0 2,{expectedScalar},0 3,60.00,0";
+            Assert.AreEqual(expectedBoardCalibration, mapLine!.BoardSettings.Calibration);
+        }
+
+        [TestMethod]
+        public void LoadSideRatingHasToBeSpecified()
+        {
+            // Arrange
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { new IOconfMap($"Map; {portName}; {boxName}", 0) } });
+
+            // Act + Assert
+            var ex = Assert.ThrowsException<FormatException>(() => new IOconfCurrent($"Current; myCurrent; {boxName}; 2;  // <- no value here", 0));
+            Assert.IsTrue(ex.Message.Contains("wrong format"), "missing expected part of the exception message");
+        }
+
+        [DataRow("-1",    false)]
+        [DataRow("0",     true)]
+        [DataRow("0.0",   true)]
+        [DataRow("0,1",   false)]
+        [DataRow("0.1",   true)]
+        [DataRow("300",   true)]
+        [DataRow("300.0", true)]
+        [DataRow("300A",  false)]
+        [DataRow("12345", true)]
+        [DataTestMethod]
+        public void LoadSideRatingHasToBeAValidNumber(string input, bool valid)
+        {
+            // Arrange
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { new IOconfMap($"Map; {portName}; {boxName}", 0) } });
+
+            // Act + Assert
+            if (valid)
+            {
+                new IOconfCurrent($"Current; myCurrent; {boxName}; 2; {input}", 0);
+            }
+            else
+            {
+                var ex = Assert.ThrowsException<FormatException>(() => new IOconfCurrent($"Current; myCurrent; {boxName}; 2; {input}", 0));
+                Assert.IsTrue(ex.Message.StartsWith("Unsupported load side rating"), "missing expected part of the exception message");
+            }
+        }
+
+        [DataRow("",     true)]
+        [DataRow("-1",   false)]
+        [DataRow("0",    false)]
+        [DataRow("0.0",  false)]
+        [DataRow("1A",   false)]
+        [DataRow("0,1",  false)]
+        [DataRow("0.1",  true)]
+        [DataRow("5.0",  true)]
+        [DataRow("5",    true)]
+        [DataRow("5.01", false)]
+        [DataRow("12345",false)]
+        [DataTestMethod]
+        public void MeterSideRatingHasToBeAValidNumberWhenSpecified(string input, bool valid)
+        {
+            // Arrange
+            using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { new IOconfMap($"Map; {portName}; {boxName}", 0) } });
+
+            // Act + Assert
+            if (valid)
+            {
+                new IOconfCurrent($"Current; myCurrent; {boxName}; 2; 300; {input}", 0);
+            }
+            else
+            {
+                var ex = Assert.ThrowsException<FormatException>(() => new IOconfCurrent($"Current; myCurrent; {boxName}; 2; 300; {input}", 0));
+                Assert.IsTrue(ex.Message.StartsWith("Unsupported meter side rating"), "missing expected part of the exception message");
+            }
+        }
+
+
+        private class TestBoard : Board
+        {
+            public TestBoard(string portname, IOconfMap? map, string? calibration = null, string? productType = null) : base(portname, map, productType)
+            {
+                Calibration = calibration;
+            }
+        }
+    }
+}

--- a/UnitTests/IOconfCurrentTests.cs
+++ b/UnitTests/IOconfCurrentTests.cs
@@ -55,16 +55,16 @@ namespace UnitTests
             IOconfMap? mapLine = null;
             using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { mapLine = new IOconfMap($"Map; {portName}; {boxName}", 0) } });
             var loadSideRating = 150;
-            string? boardCalibration = "CAL 1,60.00,0 2,60.00,0 3,60.00,0";
+            string? boardCalibration = "CAL 1,60.000000,0 2,60.000000,0 3,60.000000,0";
 
             // Act
             var ioConf = new IOconfCurrent($"Current; myCurrent; {boxName}; 2; {loadSideRating.ToString(CultureInfo.InvariantCulture)}", 0);
             mapLine!.Setboard(new TestBoard(portPrefix + portName, mapLine, boardCalibration));
 
             // Assert
-            var twoDecimalDigits = new NumberFormatInfo() { NumberDecimalDigits = 2 };
-            var expectedScalar = (loadSideRating / 5).ToString("F", twoDecimalDigits);
-            var expectedBoardCalibration = $"CAL 1,60.00,0 2,{expectedScalar},0 3,60.00,0";
+            var decimalDigits = new NumberFormatInfo() { NumberDecimalDigits = 6 };
+            var expectedScalar = (loadSideRating / 5).ToString("F", decimalDigits);
+            var expectedBoardCalibration = $"CAL 1,60.000000,0 2,{expectedScalar},0 3,60.000000,0";
             Assert.AreEqual(expectedBoardCalibration, mapLine!.BoardSettings.Calibration);
         }
 
@@ -76,16 +76,16 @@ namespace UnitTests
             using var _ = TestableIOconfFile.Override(new() { GetMap = () => new[] { mapLine = new IOconfMap($"Map; {portName}; {boxName}", 0) } });
             var loadSideRating = 150;
             var meterSideRating = 2;
-            string? boardCalibration = "CAL 1,60.00,0 2,60.00,0 3,60.00,0";
+            string? boardCalibration = "CAL 1,60.000000,0 2,60.000000,0 3,60.000000,0";
 
             // Act
             var ioConf = new IOconfCurrent($"Current; myCurrent; {boxName}; 2; {loadSideRating.ToString(CultureInfo.InvariantCulture)}; {meterSideRating.ToString(CultureInfo.InvariantCulture)}", 0);
             mapLine!.Setboard(new TestBoard(portPrefix + portName, mapLine, boardCalibration));
 
             // Assert
-            var twoDecimalDigits = new NumberFormatInfo() { NumberDecimalDigits = 2 };
-            var expectedScalar = (loadSideRating / meterSideRating).ToString("F", twoDecimalDigits);
-            var expectedBoardCalibration = $"CAL 1,60.00,0 2,{expectedScalar},0 3,60.00,0";
+            var decimalDigits = new NumberFormatInfo() { NumberDecimalDigits = 6 };
+            var expectedScalar = (loadSideRating / meterSideRating).ToString("F", decimalDigits);
+            var expectedBoardCalibration = $"CAL 1,60.000000,0 2,{expectedScalar},0 3,60.000000,0";
             Assert.AreEqual(expectedBoardCalibration, mapLine!.BoardSettings.Calibration);
         }
 


### PR DESCRIPTION
Format:

> Current; Name; BoxName; PortNumber; LoadSideRating; [MeterSideRating]
> CurrentFault; Name; BoxName

Example:

> Current; current_ct01_phaseA; ct01; 1; 300
> Current; current_ct01_phaseB; ct01; 2; 300
> Current; current_ct01_phaseC; ct01; 3; 300
> CurrentFault; current_ct01_fault; ct01