### PR TITLE
Implemented name validation on all IOconfRows

### DIFF
--- a/CA_DataUploaderLib/Helpers/ExtendedVectorDescription.cs
+++ b/CA_DataUploaderLib/Helpers/ExtendedVectorDescription.cs
@@ -30,14 +30,17 @@ namespace CA_DataUploaderLib.Helpers
             allItems.AddRange(_values.Select(m => new VectorDescriptionItem("double", m.Output.Name, DataTypeEnum.Input)));
             RemoveHiddenSources(allItems, i => i.Descriptor);
             InputsAndFiltersCount = allItems.Count;
+            _outputCount = outputs.Count;
+
             _mathVectorExpansion = new MathVectorExpansion();
             allItems.AddRange(_mathVectorExpansion.GetVectorDescriptionEntries());
             allItems.AddRange(outputs);
-            _outputCount = outputs.Count;
-            _mathVectorExpansion.Initialize(allItems.Select(i => i.Descriptor));
-            var duplicates = allItems.GroupBy(x => x.Descriptor).Where(x => x.Count() > 1).Select(x => x.Key);
+            
+            var duplicates = allItems.GroupBy(x => x.Descriptor, StringComparer.InvariantCultureIgnoreCase).Where(x => x.Count() > 1).Select(x => x.Key);
             if (duplicates.Any())
-                throw new Exception("Title of datapoint in vector was listed twice: " + string.Join(", ", duplicates));
+                throw new Exception("Different fields cannot use the same name (even if the casing is different). Please rename: " + string.Join(", ", duplicates));
+            
+            _mathVectorExpansion.Initialize(allItems.Select(i => i.Descriptor));
             VectorDescription = new VectorDescription(allItems, RpiVersion.GetHardware(), RpiVersion.GetSoftware());
         }
 

--- a/CA_DataUploaderLib/IOconf/IOconfAccount.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAccount.cs
@@ -12,5 +12,7 @@
 
         public readonly string Email;
         public readonly string Password;
+
+        protected override void ValidateName(string name) { } // no validation
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfDriver.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfDriver.cs
@@ -4,5 +4,7 @@ namespace CA_DataUploaderLib.IOconf
     public class IOconfDriver : IOconfRow
     {
         public IOconfDriver(string row, int lineNum, string type) : base(row, lineNum, type) { }
+
+        protected override void ValidateName(string name) { } // no validation
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -32,10 +32,10 @@ namespace CA_DataUploaderLib.IOconf
 
         private static void CheckRules()
         {
-            // no two rows can have the same type,name combination. 
-            var groups = Table.GroupBy(x => x.UniqueKey());
-            foreach (var g in groups.Where(x => x.Count() > 1))
-                CALog.LogErrorAndConsoleLn(LogID.A, $"ERROR in {Directory.GetCurrentDirectory()}\\IO.conf:{Environment.NewLine} Name: {g.First().ToList()[1]} occurred {g.Count()} times in this group: {g.First().ToList()[0]}");
+            // All rows have to be uniquely named/identified
+            var dupes = Table.GroupBy(x => x.UniqueKey());
+            foreach (var d in dupes.Where(x => x.Count() > 1))
+                CALog.LogErrorAndConsoleLn(LogID.A, $"ERROR in {Directory.GetCurrentDirectory()}\\IO.conf:{Environment.NewLine} Different entries cannot use the same name:{Environment.NewLine + "\t" + string.Join(Environment.NewLine + "\t", d)}");
 
             // no heater can be in several oven areas
             var heaters = GetOven().Where(x => x.OvenArea > 0).GroupBy(x => x.HeatingElement);

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -32,8 +32,8 @@ namespace CA_DataUploaderLib.IOconf
 
         private static void CheckRules()
         {
-            // All rows have to be uniquely named/identified
-            var dupes = Table.GroupBy(x => x.UniqueKey());
+            // All rows have to be uniquely named/identified (exclude Account and LoopName-lines)
+            var dupes = Table.Where(e => e is not IOconfAccount && e is not IOconfLoopName).GroupBy(x => x.UniqueKey());
             foreach (var d in dupes.Where(x => x.Count() > 1))
                 CALog.LogErrorAndConsoleLn(LogID.A, $"ERROR in {Directory.GetCurrentDirectory()}\\IO.conf:{Environment.NewLine} Different entries cannot use the same name:{Environment.NewLine + "\t" + string.Join(Environment.NewLine + "\t", d)}");
 

--- a/CA_DataUploaderLib/IOconf/IOconfFilter.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFilter.cs
@@ -36,5 +36,7 @@ namespace CA_DataUploaderLib.IOconf
             // source validation happens later, as there is not a 1-1 relation of IOConfFile entries and values getting into the Vector i.e. some oxygen sensors have 3 values. 
             SourceNames = sources;
         }
+
+        public override string UniqueKey() => NameInVector.ToLower();
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfLoopName.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfLoopName.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace CA_DataUploaderLib.IOconf
 {
@@ -18,5 +19,11 @@ namespace CA_DataUploaderLib.IOconf
 
         public readonly CALogLevel LogLevel;
         public readonly string Server;
+
+        protected override void ValidateName(string name)
+        {
+            if (!new Regex(@"^[a-zA-Z_-]+[a-zA-Z0-9_-]*$").IsMatch(name))
+                throw new Exception($"Invalid loop name: {name}. Name can only contain letters, numbers (except as the first character), hyphen and underscore.");
+        }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -119,5 +119,7 @@ namespace CA_DataUploaderLib.IOconf
         };
 
         public override string ToString() => $"{BoxName} - {USBPort ?? SerialNumber}";
+
+        protected override void ValidateName(string name) { } // no validation
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -1,12 +1,15 @@
 ﻿#nullable enable
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfMap : IOconfRow
     {
+        private Regex ValidateMapNameRegex = new(".*"); // Accepts anything - is replaced in the constructor before Name is updated.
+
         public IOconfMap(string row, int lineNum) : base(row, lineNum, "Map")
         {
             Format = "Map;SerialNo/COM1/USB1-1.1;BoxName;[NodeName];[baud rate];[customwrites]";
@@ -24,6 +27,7 @@ namespace CA_DataUploaderLib.IOconf
             else
                 SerialNumber = list[1];
 
+            ValidateMapNameRegex = ValidateNameRegex;
             Name = BoxName = list[2];
             _boardSettings = isVirtualPort ? DefaultVirtualBoardSettings : BoardSettings.Default;
 
@@ -120,6 +124,10 @@ namespace CA_DataUploaderLib.IOconf
 
         public override string ToString() => $"{BoxName} - {USBPort ?? SerialNumber}";
 
-        protected override void ValidateName(string name) { } // no validation
+        protected override void ValidateName(string name) 
+        {
+            if (!ValidateMapNameRegex.IsMatch(name))
+                throw new Exception($"Invalid map name: {name}. Name can only contain letters, numbers (except as the first character) and underscore.");
+        }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfNode.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfNode.cs
@@ -48,5 +48,7 @@ namespace CA_DataUploaderLib.IOconf
         public bool IsUploader { get; private init; }
         public static bool IsCurrentSystemAnUploader(IReadOnlyCollection<IOconfNode> allNodes) => 
             allNodes.SingleOrDefault(n => n.IsCurrentSystem)?.IsUploader ?? allNodes.Count == 0;
+
+        protected override void ValidateName(string name) { } // no validation
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfOven.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOven.cs
@@ -52,6 +52,12 @@ namespace CA_DataUploaderLib.IOconf
             BoardStateSensorNames = IOconfFile.GetBoardStateNames(TemperatureSensorName).ToList().AsReadOnly();
         }
 
+        public override string UniqueKey()
+        {
+            var list = ToList();
+            return list[0] + list[2] + list[3];  // you could argue that this should somehow include 1 too. 
+        }
+
         private IOconfHeater? heatingElement;
         private ReadOnlyCollection<string>? boardStateSensorNames;
 

--- a/CA_DataUploaderLib/IOconf/IOconfRow.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRow.cs
@@ -43,6 +43,8 @@ namespace CA_DataUploaderLib.IOconf
             var list = ToList();
             if (GetType() == typeof(IOconfOven))
                 return list[0] + list[2] + list[3];  // you could argue that this should somehow include 1 too. 
+            if (GetType() == typeof(IOconfFilter))
+                return ((IOconfFilter)this).NameInVector.ToLower();
 
             return IsUnknown
                 ? list[0] + Name.ToLower()

--- a/CA_DataUploaderLib/IOconf/IOconfRow.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRow.cs
@@ -38,17 +38,10 @@ namespace CA_DataUploaderLib.IOconf
 
         public List<string> ToList() => RowWithoutComment().Trim().TrimEnd(';').Split(";".ToCharArray()).Select(x => x.Trim()).ToList();
 
-        // TODO: change to virtual method
-        public string UniqueKey()
+        public virtual string UniqueKey()
         {
-            var list = ToList();
-            if (GetType() == typeof(IOconfOven))
-                return list[0] + list[2] + list[3];  // you could argue that this should somehow include 1 too. 
-            if (GetType() == typeof(IOconfFilter))
-                return ((IOconfFilter)this).NameInVector.ToLower();
-
             return IsUnknown
-                ? list[0] + Name.ToLower()
+                ? Type + Name.ToLower()
                 : Name.ToLower();
         }
 

--- a/CA_DataUploaderLib/IOconf/IOconfRow.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRow.cs
@@ -2,11 +2,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace CA_DataUploaderLib.IOconf
 {
     public class IOconfRow
     {
+        private string _name = string.Empty;
+
         public IOconfRow(string row, int lineNum, string type, bool isUnknown = false)
         {
             Row = row;
@@ -21,7 +24,15 @@ namespace CA_DataUploaderLib.IOconf
         public string Row { get; }
         public string Type { get; }
         public int LineNumber { get; }
-        public string Name { get; init; }
+        public string Name 
+        { 
+            get => _name; 
+            init
+            {
+                ValidateName(value);
+                _name = value;
+            }
+        }
         protected string Format { get; init; } = string.Empty;
         public bool IsUnknown { get; }
 
@@ -30,10 +41,12 @@ namespace CA_DataUploaderLib.IOconf
         public string UniqueKey()
         {
             var list = ToList();
-            if(GetType() == typeof(IOconfOven))
+            if (GetType() == typeof(IOconfOven))
                 return list[0] + list[2] + list[3];  // you could argue that this should somehow include 1 too. 
 
-            return list[0] + Name;
+            return IsUnknown
+                ? list[0] + Name.ToLower()
+                : Name.ToLower();
         }
 
         protected string RowWithoutComment()
@@ -55,5 +68,13 @@ namespace CA_DataUploaderLib.IOconf
         /// Can be used for verification/initialization of things which would be premature to do during construction.
         /// </summary>
         public virtual void ValidateDependencies() {}
+
+        protected virtual void ValidateName(string name)
+        {
+            if (!ValidateNameRegex.IsMatch(name))
+                throw new Exception($"Invalid name: {name}. Name can only contain letters, numbers (except as the first character) and underscore.");
+        }
+
+        private static readonly Regex ValidateNameRegex = new(@"^[a-zA-Z_]+[a-zA-Z0-9_]*$");
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfRow.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRow.cs
@@ -38,6 +38,7 @@ namespace CA_DataUploaderLib.IOconf
 
         public List<string> ToList() => RowWithoutComment().Trim().TrimEnd(';').Split(";".ToCharArray()).Select(x => x.Trim()).ToList();
 
+        // TODO: change to virtual method
         public string UniqueKey()
         {
             var list = ToList();
@@ -77,6 +78,6 @@ namespace CA_DataUploaderLib.IOconf
                 throw new Exception($"Invalid name: {name}. Name can only contain letters, numbers (except as the first character) and underscore.");
         }
 
-        private static readonly Regex ValidateNameRegex = new(@"^[a-zA-Z_]+[a-zA-Z0-9_]*$");
+        protected static readonly Regex ValidateNameRegex = new(@"^[a-zA-Z_]+[a-zA-Z0-9_]*$");
     }
 }

--- a/UnitTests/IOconfLoopNameTests.cs
+++ b/UnitTests/IOconfLoopNameTests.cs
@@ -1,0 +1,56 @@
+﻿using CA_DataUploaderLib.IOconf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class IOconfLoopNameTests
+    {
+        [DataRow("0_cannot_start_with_number")]
+        [DataRow("æøå")]
+        [DataRow("hat^")]
+        [DataRow("pipe|")]
+        [DataRow("back_\\slash")]
+        [DataRow("forward_/slash")]
+        [DataRow("ampersand&")]
+        [DataRow("question?")]
+        [DataRow("colon:")]
+        [DataRow("exclamation!")]
+        [DataRow("half½")]
+        [DataRow("paragraph§")]
+        [DataRow("turtle¤")]
+        [DataRow("hash#tag")]
+        [DataRow("percent_%rel")]
+        [DataRow("angle<bracket>")]
+        [DataRow("curly{bracket}")]
+        [DataRow("square[bracket]")]
+        [DataRow("name with space")]
+        [DataRow("name_with(parenthesis)")]
+        [DataRow("name~with~tilde")]
+        [DataRow("name*with*star")]
+        [DataRow("name,with,comma")]
+        [DataRow("name.with.dot")]
+        [DataRow("name=with=equals")]
+        [DataRow("name+with+plus")]
+        [DataTestMethod]
+        public void InvalidName(string name) 
+        {
+            var ex = Assert.ThrowsException<Exception>(() => new IOconfLoopName($"LoopName; {name}; Normal; https://stagingtsserver.copenhagenatomics.come", 0));
+            Assert.IsTrue(ex.Message.StartsWith($"Invalid loop name: {name}"), ex.Message);
+        }
+
+        [DataRow("name_with_number_42")]
+        [DataRow("UPPERCASE")]
+        [DataRow("lowercase")]
+        [DataRow("-name-starting-with-dash")]
+        [DataRow("name-with-dash")]
+        [DataRow("_name_starting_with_underscore")]
+        [DataRow("name_with_underscore")]
+        [DataTestMethod]
+        public void ValidName(string name)
+        {
+            _ = new IOconfLoopName($"LoopName; {name}; Normal; https://stagingtsserver.copenhagenatomics.come", 0);
+        }
+    }
+}

--- a/UnitTests/IOconfRowTests.cs
+++ b/UnitTests/IOconfRowTests.cs
@@ -1,0 +1,89 @@
+﻿using CA_DataUploaderLib.IOconf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class IOconfRowTests
+    {
+        [DataRow("0_cannot_start_with_number")]
+        [DataRow("æøå")]
+        [DataRow("hat^")]
+        [DataRow("pipe|")]
+        [DataRow("back_\\slash")]
+        [DataRow("forward_/slash")]
+        [DataRow("ampersand&")]
+        [DataRow("question?")]
+        [DataRow("colon:")]
+        [DataRow("exclamation!")]
+        [DataRow("half½")]
+        [DataRow("paragraph§")]
+        [DataRow("turtle¤")]
+        [DataRow("hash#tag")]
+        [DataRow("percent_%rel")]
+        [DataRow("angle<bracket>")]
+        [DataRow("curly{bracket}")]
+        [DataRow("square[bracket]")]
+        [DataRow("name with space")]
+        [DataRow("name_with(parenthesis)")]
+        [DataRow("name~with~tilde")]
+        [DataRow("name*with*star")]
+        [DataRow("name,with,comma")]
+        [DataRow("name.with.dot")]
+        [DataRow("name=with=equals")]
+        [DataRow("name+with+plus")]
+        [DataRow("name-with-dash")]
+        [DataTestMethod]
+        public void InvalidName_Constructor(string name) 
+        {
+            var ex = Assert.ThrowsException<Exception>(() => new IOconfRow($"TestType; {name}", 0, "TestType"));
+            Assert.IsTrue(ex.Message.StartsWith($"Invalid name: {name}"), ex.Message);
+        }
+
+        [DataRow("0_cannot_start_with_number")]
+        [DataRow("æøå")]
+        [DataRow("hat^")]
+        [DataRow("pipe|")]
+        [DataRow("back_\\slash")]
+        [DataRow("forward_/slash")]
+        [DataRow("ampersand&")]
+        [DataRow("question?")]
+        [DataRow("colon:")]
+        [DataRow("exclamation!")]
+        [DataRow("half½")]
+        [DataRow("paragraph§")]
+        [DataRow("turtle¤")]
+        [DataRow("hash#tag")]
+        [DataRow("percent_%rel")]
+        [DataRow("angle<bracket>")]
+        [DataRow("curly{bracket}")]
+        [DataRow("square[bracket]")]
+        [DataRow("name with space")]
+        [DataRow("name_with(parenthesis)")]
+        [DataRow("name~with~tilde")]
+        [DataRow("name*with*star")]
+        [DataRow("name,with,comma")]
+        [DataRow("name.with.dot")]
+        [DataRow("name=with=equals")]
+        [DataRow("name+with+plus")]
+        [DataRow("name-with-dash")]
+        [DataTestMethod]
+        public void InvalidName_NameSetter(string name)
+        {
+            var ex = Assert.ThrowsException<Exception>(() => new IOconfRow($"TestType; allowedName", 0, "TestType") { Name = name });
+            Assert.IsTrue(ex.Message.StartsWith($"Invalid name: {name}"), ex.Message);
+        }
+
+        [DataRow("name_with_number_42")]
+        [DataRow("UPPERCASE")]
+        [DataRow("lowercase")]
+        [DataRow("_name_starting_with_underscore")]
+        [DataRow("name_with_underscore")]
+        [DataTestMethod]
+        public void ValidName(string name)
+        {
+            _ = new IOconfRow($"TestType; {name}", 0, "TestType");
+        }
+    }
+}


### PR DESCRIPTION
Exceptions: Account, Nodes, Map-lines, IOconfControlWebUI, Oven+OvenProportionalControlUpdates (IOconfDriver). 
LoopName has a special validation (allowing hyphen). 
Also making sure that no rows use the same name (ignoring case).#257

Examples of error messages:

![image](https://github.com/copenhagenatomics/CA_DataUploader/assets/132266664/1d45ecc7-9fe1-4796-a747-23d14f063cc5)

![image](https://github.com/copenhagenatomics/CA_DataUploader/assets/132266664/ed8cd58f-b204-4917-81af-1435f2b2f220)
