### PR TITLE
fixed: MathVectorExpansion is not thread safe

### DIFF
--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="CoreCLR-NCalc" Version="2.2.101" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.2" />
     <PackageReference Include="MinVer" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/CA_DataUploaderLib/IOconf/IOconfMath.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMath.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using NCalc;
+using NCalc.Domain;
 using System;
 using System.Collections.Generic;
 
@@ -19,8 +20,7 @@ namespace CA_DataUploaderLib.IOconf
 
             try
             {
-                var compiledExpression = Expression.Compile(RowWithoutComment()[(Name.Length + 6)..], true);
-                expression = new Expression(compiledExpression);
+                compiledExpression = Expression.Compile(RowWithoutComment()[(Name.Length + 6)..], true);
             }
             catch (Exception ex)
             {
@@ -30,7 +30,7 @@ namespace CA_DataUploaderLib.IOconf
             SourceNames = GetSources();
         }
 
-        private readonly Expression expression;
+        private readonly LogicalExpression compiledExpression;
 
         // https://www.codeproject.com/Articles/18880/State-of-the-Art-Expression-Evaluation
         // uses NCalc 2 for .NET core. 
@@ -39,6 +39,7 @@ namespace CA_DataUploaderLib.IOconf
         // https://github.com/sklose/NCalc2/blob/master/test/NCalc.Tests/Fixtures.cs
         public double Calculate(Dictionary<string, object> values)
         {
+            var expression = new Expression(compiledExpression);
             expression.Parameters = values;
             // Convert.ToDouble allows some expressions that return int, decimals or even boolean to work
             // note that some expression may even return different values depending on the branch hit i.e. when using if(...)
@@ -48,6 +49,7 @@ namespace CA_DataUploaderLib.IOconf
         private List<string> GetSources() 
         {
             HashSet<string> sources = new();
+            var expression = new Expression(compiledExpression);
             expression.EvaluateFunction += EvalFunction; 
             expression.EvaluateParameter += EvalParameter;
             try

--- a/CA_DataUploaderLib/MathVectorExpansion.cs
+++ b/CA_DataUploaderLib/MathVectorExpansion.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using CA_DataUploaderLib.IOconf;
+using Microsoft.Extensions.ObjectPool;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,9 +10,9 @@ namespace CA_DataUploaderLib
     public class MathVectorExpansion
     {
         private readonly List<IOconfMath> _mathStatements;
-        private readonly Dictionary<string, object> _reusableFiedsDictionary = new();
         private readonly Dictionary<int, string> _fieldsByIndex = new();
         private readonly List<(IOconfMath math, int mathFieldIndex)> _mathWithFieldIndexes = new();
+        private readonly ObjectPool<Dictionary<string, object>> reusableDictionaryPool = new DefaultObjectPool<Dictionary<string, object>>(new DefaultPooledObjectPolicy<Dictionary<string, object>>());
 
         public MathVectorExpansion(Func<IEnumerable<IOconfMath>> getMath) => _mathStatements = getMath().ToList();
         public int Count => _mathStatements.Count;
@@ -22,7 +23,6 @@ namespace CA_DataUploaderLib
             var fields = vectorFields.ToList();
             int fieldIndex = 0;
             fields.ForEach(f => _fieldsByIndex.Add(fieldIndex++, f));
-            fields.ForEach(f => _reusableFiedsDictionary.Add(f, 0d));
             foreach (var math in _mathStatements)
             {
                 var index = fields.IndexOf(math.Name);
@@ -39,18 +39,27 @@ namespace CA_DataUploaderLib
         /// <param name="vector">the full vector with the same fields as specified in <see cref="Initialize"/> (with only the inputs updated in this cycle)</param>
         public void Apply(Span<double> vector)
         {
-            if (_fieldsByIndex == null || _reusableFiedsDictionary == null) throw new InvalidOperationException("Initialize has not been called before calling Apply");
+            if (_fieldsByIndex == null) throw new InvalidOperationException("Initialize has not been called before calling Apply");
             if (vector.Length != _fieldsByIndex.Count)
                 throw new ArgumentException($"the specified vector length does not match the fields received during initialize - {vector.Length} vs {_fieldsByIndex.Count}", nameof(vector));
 
-            //note that not only we have all the innecesary copying of data here, but even though the dictionary its reused we have boxing of the values (IOConfMath.Calculate requires a Dictionary<string, object>.
+            //note that not only we have all the innecesary copying of data here, but even though the dictionary its reused we have boxing of the values (IOConfMath.Calculate requires a Dictionary<string, object>).
             //one option to improve both is to have a different math expression engine that allows preprocessing the expression in a way that allows to specify the parameters by index
             //and allows to specify them in a single desired type. Also note the engine also causes boxing of the result as it returns an object we convert to a double.
-            for (int i = 0; i < _fieldsByIndex.Count; i++)
-                _reusableFiedsDictionary[_fieldsByIndex[i]] = vector[i];
+            //one extra issue is that the dictionary is passed through a property instead of an argument, which also forces a creation of an Expresion inside the the calculate method.
+            var reusableFiedsDictionary = reusableDictionaryPool.Get();
+            try
+            {
+                for (int i = 0; i < _fieldsByIndex.Count; i++)
+                    reusableFiedsDictionary[_fieldsByIndex[i]] = vector[i];
 
-            foreach (var (math, index) in _mathWithFieldIndexes)
-                _reusableFiedsDictionary[_fieldsByIndex[index]] = vector[index] = math.Calculate(_reusableFiedsDictionary);
+                foreach (var (math, index) in _mathWithFieldIndexes)
+                    reusableFiedsDictionary[_fieldsByIndex[index]] = vector[index] = math.Calculate(reusableFiedsDictionary);
+            }
+            finally
+            {
+                reusableDictionaryPool.Return(reusableFiedsDictionary);
+            }
         }
     }
 }

--- a/UnitTests/ParallelHelper.cs
+++ b/UnitTests/ParallelHelper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UnitTests
+{
+    internal class ParallelHelper
+    {
+        public static Task ForRacingThreads(int start, int count, Func<int, Func<Task>> getAction) => 
+            RunRacingThreads(Enumerable.Range(start, count).Select(i => getAction(i)).ToList());
+        public static Task ForRacingThreads(int start, int count, Func<int, Action> getAction) =>
+            RunRacingThreads(Enumerable.Range(start, count).Select<int, Func<Task>>(i =>
+            {
+                var action = getAction(i);
+                return () => { action(); return Task.CompletedTask; };
+            }).ToList());
+        public static async Task RunRacingThreads(IReadOnlyCollection<Func<Task>> actions)
+        {
+            //We use a CountdownEvent to ensure all threads are created and ready to race before running the actions.
+            //We use SetMinThreads to ensure we have enough pool threads, as otherwise it takes way too long to start or even blocks
+            ThreadPool.SetMinThreads(actions.Count, actions.Count);
+            var readyEvent = new CountdownEvent(actions.Count);
+            await Task.WhenAll(actions
+                .Select(action => Task.Run(() =>
+                {
+                    readyEvent.Signal(); //we are ready to run
+                    readyEvent.Wait();  //wait for all others to be ready to run
+                    return action();
+                }))
+                ).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
The problem with MathVectorExpansion not being thread safe, is that it made calls to CommandHandler.MakeDecision* methods not thread safe.

There were some thread offs going this way to solve the MakeDecision* thread safety:
- pro: consumers no longer need to be concerned about the thread safety of this method
- cons: extra overhead by using an ObjectPool to reuse dictionaries in MathVectorExpansion and an allocation of an NCalc Expression in IOConfMath.Calculate (this is a small object though, as the compiled expression is reused).