### PR TITLE
BaseSensorBox.ReadSensors: escape hidden characters in case of error when parsing the line

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -482,7 +482,7 @@ namespace CA_DataUploaderLib
                     }
                     else if (!board.ConfigSettings.Parser.IsExpectedNonValuesLine(line))// mostly responses to commands or headers on reconnects.
                     {
-                        LowFrequencyLogInfo((args, skipMessage) => LogInfo(args.board, $"Unexpected board response '{args.line.Replace("\r", "\\r")}'{skipMessage}"), (board, line));// we avoid \r as it makes the output hard to read
+                        LowFrequencyLogInfo((args, skipMessage) => LogInfo(args.board, $"Unexpected board response '{args.line.ToLiteral()}'{skipMessage}"), (board, line));
                         if (timeSinceLastValidRead.ElapsedMilliseconds > msBetweenReads)
                             _boardsState.SetState(boxName, ConnectionState.ReturningNonValues);
                     }
@@ -493,7 +493,7 @@ namespace CA_DataUploaderLib
                 }
                 catch (Exception ex)
                 { //usually a parsing errors on non value data, we log it and consider it as such i.e. we set ReturningNonValues if we have not had a valid read in msBetweenReads
-                    LowFrequencyLogError((args, skipMessage) => LogError(args.board, $"Failed handling board response {args.line.Replace("\r", "\\r")}{skipMessage}", args.ex), (board, line, ex)); // we avoid \r as it makes the output hard to read
+                    LowFrequencyLogError((args, skipMessage) => LogError(args.board, $"Failed handling board response '{args.line.ToLiteral()}'{skipMessage}", args.ex), (board, line, ex));
                     if (timeSinceLastValidRead.ElapsedMilliseconds > msBetweenReads)
                         _boardsState.SetState(boxName, ConnectionState.ReturningNonValues);
                 }

--- a/CA_DataUploaderLib/Extensions/StringExtensions.cs
+++ b/CA_DataUploaderLib/Extensions/StringExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 
 namespace CA_DataUploaderLib.Extensions
 {
@@ -33,5 +34,22 @@ namespace CA_DataUploaderLib.Extensions
         public static bool TryToDouble(this ReadOnlySpan<char> s, out double val) => double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out val);
         public static List<string> SplitNewLine(this string s, StringSplitOptions options = StringSplitOptions.RemoveEmptyEntries) => s.Split(new[] { Environment.NewLine }, options).ToList();
         private static bool TryGetIndex(string s, string match, out int pos) => (pos = s.IndexOf(match)) >= 0;
+
+        /// <summary>
+        /// Escapes fixed set of hidden characters in a string to be able to see them when printing to log/console.
+        /// </summary>
+        public static string ToLiteral(this string s)
+        {
+            return new StringBuilder(s)
+                .Replace("\0", @"\0") // Null character
+                .Replace("\a", @"\a") // Alert
+                .Replace("\b", @"\b") // Backspace
+                .Replace("\f", @"\f") // Form feed
+                .Replace("\n", @"\n") // New line
+                .Replace("\r", @"\r") // Carriage return
+                .Replace("\t", @"\t") // Horizontal tab
+                .Replace("\v", @"\v") // Vertical tab
+                .ToString();
+        }
     }
 }


### PR DESCRIPTION
To be able to see them when printing to log.