### PR TITLE
improved messages logged when (re)connecting to boards

### DIFF
--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -14,7 +14,6 @@ namespace CA_DataUploaderLib.IOconf
 
         public int DefaultBaudRate { get; set; } = 0;
         public int MillisecondsBetweenReads { get; set; } = 100;
-        public int ExpectedHeaderLines { get; set; } = 8;
         public int MaxMillisecondsWithoutNewValues { get; set; } = 2000;
         public int SecondsBetweenReopens { get; set; } = 3;
         public bool SkipBoardAutoDetection { get; set; } = false;

--- a/CA_DataUploaderLib/IOconf/IOconfMap.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfMap.cs
@@ -123,7 +123,6 @@ namespace CA_DataUploaderLib.IOconf
         internal static bool IsVirtualPortName(string portName) => portName.StartsWith("vports/");
         public static readonly BoardSettings DefaultVirtualBoardSettings = new()
         {
-            ExpectedHeaderLines = 0, //no headers expected, just value lines right away
             SkipBoardAutoDetection = true, //everything about how we detect board data is specific to our units, so this must be skipped for vports
             //reconnect does not play well with socat based ports, so we let it go a full hour without data
             //we should greatly reduce it if we find a way of running socat that plays well with the way reconnects run

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -412,24 +412,24 @@ namespace CA_DataUploaderLib
         }
 
         ///<returns>true if a non empty line was found, or false if more data is needed</returns>
-        static bool TryPeekNextNonEmptyLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> bufferAfterReads, out string? nonEmptyLine, TryReadLineDelegate tryReadLine)
+        static bool TryPeekNextNonEmptyLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> bufferAfterLine, out string? nonEmptyLine, TryReadLineDelegate tryReadLine)
         {
             nonEmptyLine = null;
-            bufferAfterReads = buffer; // take a copy to avoid unnecesarily throwing away data coming after the header
-            bool readLine = tryReadLine(ref bufferAfterReads, out var line);
+            bufferAfterLine = buffer; // take a copy to avoid unnecesarily throwing away data coming after the header
+            bool readLine = tryReadLine(ref bufferAfterLine, out var line);
 
             //skip empty lines advancing the caller's buffer so it does not read the empty line again.
             while (readLine && string.IsNullOrWhiteSpace(line))
             {
-                buffer = bufferAfterReads;
-                readLine = tryReadLine(ref bufferAfterReads, out line);
+                buffer = bufferAfterLine;
+                readLine = tryReadLine(ref bufferAfterLine, out line);
             }
 
             if (readLine && line != null)
                 return true;
 
             //we did not get a line, more data is needed, advance the buffer to ensure the caller fetches more data
-            buffer = bufferAfterReads;
+            buffer = bufferAfterLine;
             return false;
         }
 

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -415,7 +415,7 @@ namespace CA_DataUploaderLib
         static bool TryPeekNextNonEmptyLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> bufferAfterLine, out string? nonEmptyLine, TryReadLineDelegate tryReadLine)
         {
             nonEmptyLine = null;
-            bufferAfterLine = buffer; // take a copy to avoid unnecesarily throwing away data coming after the header
+            bufferAfterLine = buffer;
             bool readLine = tryReadLine(ref bufferAfterLine, out var line);
 
             //skip empty lines advancing the caller's buffer so it does not read the empty line again.
@@ -432,7 +432,6 @@ namespace CA_DataUploaderLib
             buffer = bufferAfterLine;
             return false;
         }
-
 
         private async Task<TResult> RunWaitingForAnyOngoingReconnect<TResult>(Func<TResult> action, CancellationToken token)
         {

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -196,9 +196,9 @@ namespace CA_DataUploaderLib
             return true;
 
             bool TrySkipEmptyLines(ref ReadOnlySequence<byte> buffer, [NotNullWhen(true)] out string? line)
-            {
+            {//TryPeekNextNonEmptyLine updates the ref buffer to skip any empty line it finds before the next non empty line
                 var readLine = TryPeekNextNonEmptyLine(ref buffer, out _, out _, TryReadLine);
-                line = readLine ? string.Empty : null;
+                line = string.Empty; //we don't really read the returned line, so just return string.Empty to meet the not null requirement of ReadLine
                 return readLine;
             }
         }

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -532,6 +532,7 @@ namespace CA_DataUploaderLib
                         {
                             finishedReadingHeader = true;
                             Calibration = UpdatedCalibration = calibration;
+                            buffer = buffer.Slice(0, 0);//don't advance the reader beyond the optional calibration line, so the next read does not unnecesarily fetches more data
                         }
 
                         // Tell the PipeReader how much of the buffer has been consumed.

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -161,7 +161,7 @@ namespace CA_DataUploaderLib
         /// </summary>
         /// <returns><c>false</c> if the reconnect attempt failed.</returns>
         /// <remarks>
-        /// The reconnection is only considered succesfull after the board returns the first non empty line within 5 seconds.
+        /// The reconnection is only considered succesfull after the board returns the first non empty line within <see cref="BoardSettings.MaxMillisecondsWithoutNewValues"/>.
         /// Any initial empty lines returned by the board are skipped.
         /// 
         /// Log entries about te attempt to reopen the connection are added to <see cref="LogID.B"/>, but not to the console / event log.

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -412,11 +412,10 @@ namespace CA_DataUploaderLib
         }
 
         ///<returns>true if a non empty line was found, or false if more data is needed</returns>
-        static bool TryPeekNextNonEmptyLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> bufferAfterLine, out string? nonEmptyLine, TryReadLineDelegate tryReadLine)
+        static bool TryPeekNextNonEmptyLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> bufferAfterLine, out string? line, TryReadLineDelegate tryReadLine)
         {
-            nonEmptyLine = null;
             bufferAfterLine = buffer;
-            bool readLine = tryReadLine(ref bufferAfterLine, out var line);
+            bool readLine = tryReadLine(ref bufferAfterLine, out line);
 
             //skip empty lines advancing the caller's buffer so it does not read the empty line again.
             while (readLine && string.IsNullOrWhiteSpace(line))
@@ -425,7 +424,7 @@ namespace CA_DataUploaderLib
                 readLine = tryReadLine(ref bufferAfterLine, out line);
             }
 
-            if (readLine && line != null)
+            if (readLine)
                 return true;
 
             //we did not get a line, more data is needed, advance the buffer to ensure the caller fetches more data

--- a/CA_DataUploaderLib/SerialNumberMapper.cs
+++ b/CA_DataUploaderLib/SerialNumberMapper.cs
@@ -46,7 +46,7 @@ namespace CA_DataUploaderLib
                 foreach (var detection in CustomDetections)
                     if (detection(ioconf, name) is Board board)
                     {
-                        CALog.LogInfoAndConsoleLn(LogID.A, board.ToString());
+                        LogToLocalLogAndConsole(board.ToString());
                         return board;
                     }
                 var mcu = await MCUBoard.OpenDeviceConnection(ioconf, name);
@@ -56,9 +56,7 @@ namespace CA_DataUploaderLib
                     return default;
                 }
 
-                string logline = ioconf?.GetOutputLevel() == CALogLevel.Debug ? mcu.ToDebugString(Environment.NewLine) : mcu.ToString();
-                Console.WriteLine(logline);      // Always write this in the console
-                CALog.LogData(LogID.A, logline); // + local log, but don't send it to the event log.
+                LogToLocalLogAndConsole(ioconf?.GetOutputLevel() == CALogLevel.Debug ? mcu.ToDebugString(Environment.NewLine) : mcu.ToString());
                 return mcu;
             }
             catch (UnauthorizedAccessException ex)
@@ -71,6 +69,12 @@ namespace CA_DataUploaderLib
             }
 
             return default;
+
+            void LogToLocalLogAndConsole(string line)
+            {
+                Console.WriteLine(line);
+                CALog.LogData(LogID.A, line);
+            }
         }
     }
 }


### PR DESCRIPTION
### Breaking changes

- removed BoardSettings.ExpectedHeaderLines. Use a LineParser to skip any expected non value lines if desired. Otherwise any extra lines will be logged as unexpected lines returned by a board.

### Other changes

- skips optional empty lines after a (re)connect
- improved speed of the first read after the header in cases where the data was already returned by the board
- fixed: double logging of audio to the event log
- the board reconnected message now includes an optional board reconnect response