### PR TITLE
CommandHandler: Removed node name from uptime and version events

### DIFF
--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -418,14 +418,13 @@ namespace CA_DataUploaderLib
         }
 
         public void Uptime(List<string> _) => 
-            CALog.LogInfoAndConsoleLn(LogID.A, $"{GetCurrentNode().Name} - {DateTime.UtcNow.Subtract(_start)}");
+            CALog.LogInfoAndConsoleLn(LogID.A, $"{DateTime.UtcNow.Subtract(_start)}");
 
         public void GetVersion(List<string> _)
         {
             var connInfo = _ioconf.GetConnectionInfo();
             CALog.LogInfoAndConsoleLn(LogID.A, 
-$@"{GetCurrentNode().Name}
-{RpiVersion.GetSoftware()}
+$@"{RpiVersion.GetSoftware()}
 {RpiVersion.GetHardware()}
 {connInfo.LoopName} - {connInfo.Email}
 {(_mapper != null ? string.Join(Environment.NewLine, Mapper.McuBoards.Select(x => x.ToString())) : "")}");

--- a/CA_DataUploaderLib/ServerUploader.cs
+++ b/CA_DataUploaderLib/ServerUploader.cs
@@ -109,7 +109,7 @@ namespace CA_DataUploaderLib
             //note slightly changing the event time below is a workaround to ensure they come in order in the event log
             int @eventIndex = 0;
             foreach (var e in vector.Events)
-                SendEvent(this, new EventFiredArgs($"{((e.EventType == (byte) EventType.Log || e.EventType == (byte)EventType.LogError) && e.NodeId != byte.MaxValue ? $"[{_nodeIdToName?[e.NodeId]}] " : "")}{e.Data}", e.EventType, e.TimeSpan.AddTicks(eventIndex++)));
+                SendEvent(this, new EventFiredArgs($"{((e.EventType == (byte) EventType.Log || e.EventType == (byte)EventType.LogError) ? NodeIdToName(e.NodeId) : "")}{e.Data}", e.EventType, e.TimeSpan.AddTicks(eventIndex++)));
 
             //now queue vectors
             _vectorsChannel.Writer.TryWrite(FilterOnlyUploadFieldsAndCheckInvalidValues(vector, out var invalidValueMessage));
@@ -117,6 +117,8 @@ namespace CA_DataUploaderLib
             //Possibly send event due to invalid values detected in the vector
             if (!string.IsNullOrWhiteSpace(invalidValueMessage))
                 SendInvalidValueEvent(new EventFiredArgs("Invalid values detected: " + invalidValueMessage[2..], EventType.LogError, DateTime.UtcNow));
+
+            string NodeIdToName(byte nodeId) => nodeId != byte.MaxValue ? $"[{_nodeIdToName?[nodeId]}] " : "";
 
             DataVector FilterOnlyUploadFieldsAndCheckInvalidValues(DataVector fullVector, out string invalidValueMessage)
             {


### PR DESCRIPTION
+ EventsHandler now prepends node name to Log+LogError messages.