### PR TITLE
BaseSensorBox.ReadSensors: sending "Status" to the board in case the error bit of the status value is set.

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -27,7 +27,7 @@ namespace CA_DataUploaderLib
         private readonly Dictionary<MCUBoard, SensorSample.InputBased[]> _boardSamplesLookup = [];
         private readonly string mainSubsystem;
         private readonly Dictionary<MCUBoard, List<(Func<DataVector?, MCUBoard, CancellationToken, Task> write, Func<MCUBoard, CancellationToken, Task> exit)>> _builtInWriteActions = [];
-        private readonly Dictionary<MCUBoard, ChannelReader<string>> _boardCustomCommandsReceived = [];
+        private readonly Dictionary<MCUBoard, (ChannelReader<string> Reader, ChannelWriter<string> Writer)> _boardCustomCommands = [];
         private ChannelReader<DataVector>? _receivedVectors;
         private static readonly Dictionary<CommandHandler, Dictionary<string, string>> _usedBoxNames = []; //Dictionary of used board names tied to a specific CommandHandler-instance
         private readonly Dictionary<string, TaskCompletionSource> _reconnectTasks = [];
@@ -51,7 +51,7 @@ namespace CA_DataUploaderLib
             foreach (var board in allBoards)
             {
                 RegisterReconnectBoardCommand(board.map, cmd, _reconnectTasks);
-                RegisterCustomBoardCommand(board.map, cmd, _boardCustomCommandsReceived);
+                RegisterCustomBoardCommand(board.map, cmd, _boardCustomCommands);
                 EnforceBoardNotAlreadyInUse(board.map.BoxName, board.values.First().Input.Row, cmd);//used by another sensor type / BaseSensorBox instance
                 EnforceNoDuplicatePorts(board.map.BoxName, board.values);
             }
@@ -79,9 +79,8 @@ namespace CA_DataUploaderLib
                     throw new FormatException($"Can't map the same board to different IO.conf line types: {boxName}{Environment.NewLine}{usedRow}{Environment.NewLine}{newRow}");
                 _usedBoxNames[cmd].Add(boxName, newRow);
             }
-            static void RegisterCustomBoardCommand(IOconfMap map, CommandHandler cmd, Dictionary<MCUBoard, ChannelReader<string>> boardCustomCommandsReceived)
+            static void RegisterCustomBoardCommand(IOconfMap map, CommandHandler cmd, Dictionary<MCUBoard, (ChannelReader<string> reader, ChannelWriter<string> writer)> boardCustomCommands)
             {
-                if (!map.CustomWritesEnabled) return;
                 if (!map.IsLocalBoard)
                 {//if the board is not local we register the command validation with an empty action
                     cmd.AddMultinodeCommand("custom", a => a.Count >= 3 && a[1] == map.BoxName, _ => { });
@@ -99,8 +98,8 @@ namespace CA_DataUploaderLib
 
                 //for local boards we instead register a multinode that sends the command to a local channel the write loop uses
                 var channel = Channel.CreateUnbounded<string>();
-                var channelWriter = channel.Writer;
-                boardCustomCommandsReceived.Add(map.McuBoard, channel.Reader);
+                var channelWriter = channel.Writer; 
+                boardCustomCommands.Add(map.McuBoard, (channel.Reader, channelWriter));
                 cmd.AddMultinodeCommand(
                     "custom",
                     a => a.Count >= 3 && a[1] == map.BoxName,
@@ -303,7 +302,7 @@ namespace CA_DataUploaderLib
 
         private async Task BoardWriteLoop(MCUBoard board, int boardStateIndexInFullVector, CancellationToken token)
         {
-            var customWritesEnabled = _boardCustomCommandsReceived.TryGetValue(board, out var customCommandsChannel);
+            var customWritesEnabled = _boardCustomCommands.TryGetValue(board, out var customCommandsChannel);
             var builtInActionsEnabled = _builtInWriteActions.TryGetValue(board, out var builtInActions);
             if (!builtInActionsEnabled && !customWritesEnabled) return;
             ChannelReader<DataVector>? vectorsChannel = builtInActionsEnabled
@@ -319,13 +318,13 @@ namespace CA_DataUploaderLib
             {
                 try
                 {
-                    if (customWritesEnabled && customCommandsChannel!.TryRead(out var command))
+                    if (customWritesEnabled && customCommandsChannel!.Reader.TryRead(out var command))
                         await board.SafeWriteLine(command, token);
 
                     if (!builtInActionsEnabled)
                     {
                         EnsureResumeAfterTimeoutIsReported();
-                        await customCommandsChannel!.WaitToReadAsync(token);
+                        await customCommandsChannel!.Reader.WaitToReadAsync(token);
                         continue;
                     }
 
@@ -471,17 +470,27 @@ namespace CA_DataUploaderLib
             var msBetweenReads = (int)Math.Ceiling(board.ConfigSettings.MillisecondsBetweenReads * 1.5);
             Stopwatch timeSinceLastLogInfo = new(), timeSinceLastLogError = new();
             int logInfoSkipped = 0, logErrorSkipped = 0;
+            MultilineMessageReceiver multilineMessageReceiver = new((message) => CALog.LogInfoAndConsoleLn(LogID.B, $"{message} - {Title} - {board.ToShortDescription()}"));
             //We set the state early if we detect no data is being returned or if we received values,
             //but we only set ReturningNonValues if it has passed msBetweenReads since the last valid read
             while (true) // we only stop reading if a disconnect or timeout is detected
             {
                 var (stillConnected, line) = await TryReadLineWithStallDetection(board, boxName, msBetweenReads, token);
                 if (!stillConnected)
+                {
+                    multilineMessageReceiver.LogPossibleIncompleteMessage();
                     return false;  //board disconnect detected, let caller know 
+                }
                 if (line == default)
+                {
+                    multilineMessageReceiver.LogPossibleIncompleteMessage();
                     return true; //timed out reading from the board, TryReadLineWithStallDetection already updated the state after the first msBetweenReads / still considered connected
+                }
                 try
                 {
+                    if (multilineMessageReceiver.HandleLine(line))
+                        continue;
+
                     var (numbers, status) = TryParseAsDoubleList(board, line);
                     if (numbers != null)
                     {
@@ -497,7 +506,11 @@ namespace CA_DataUploaderLib
                     }
 
                     if (status != _lastStatus && (status & 0x80000000) != 0) //Was there a change in status and is the most significant bit set?
+                    {
                         LowFrequencyLogError((args, skipMessage) => LogError(args.board, $"Board responded with error status 0x{args.status:X}{skipMessage}"), (board, status));
+                        if (_boardCustomCommands.TryGetValue(board, out var customCommandsChannel))
+                            customCommandsChannel.Writer.TryWrite("Status");
+                    }
                     _lastStatus = status;
                 }
                 catch (Exception ex)
@@ -685,6 +698,61 @@ namespace CA_DataUploaderLib
         private void LogError(Board board, string message) => CALog.LogErrorAndConsoleLn(LogID.A, $"{message} - {Title} - {board.ToShortDescription()}");
         private void LogData(Board board, string message) => CALog.LogData(LogID.B, $"{message} - {Title} - {board.ToShortDescription()}");
         private void LogInfo(Board board, string message) => CALog.LogInfoAndConsoleLn(LogID.B, $"{message} - {Title} - {board.ToShortDescription()}");
+
+
+        /// <summary>
+        /// Receives and logs lines part of a multiline message delimited by "Start of" and "End of".
+        /// </summary>
+        public class MultilineMessageReceiver(Action<string> log)
+        {
+            private StringBuilder multilineMessage = new();
+            private bool multilineMessageMode = false;
+            private int multilineMessageLineCount = 0;
+            private const int maxMultilineMessageLineCount = 30;
+            private const string startTag = "Start of";
+            private const string endTag = "End of";
+
+            /// <summary>
+            /// Detects and logs multiline messages.
+            /// </summary>
+            /// <param name="line"></param>
+            /// <returns>True, if the line is part of a multiline message and should be considered handled.</returns>
+            public bool HandleLine(string line)
+            {
+                if (line.StartsWith(startTag, StringComparison.InvariantCultureIgnoreCase) || multilineMessageMode)
+                {
+                    multilineMessageMode = true;
+                    multilineMessage.AppendLine(line);
+                    if (line.StartsWith(endTag, StringComparison.InvariantCultureIgnoreCase) ||
+                        multilineMessageLineCount++ >= maxMultilineMessageLineCount)
+                    {
+                        LogMessage();
+                    }
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Logs any incomplete multiline message.
+            /// </summary>
+            public void LogPossibleIncompleteMessage()
+            {
+                if (!multilineMessageMode)
+                    return;
+
+                multilineMessage.AppendLine("*Incomplete*");
+                LogMessage();
+            }
+
+            private void LogMessage()
+            {
+                log($"{multilineMessage}");
+                multilineMessage = new();
+                multilineMessageMode = false;
+                multilineMessageLineCount = 0;
+            }
+        }
 
         public class AllBoardsState : IEnumerable<(string sensorName, ConnectionState State)>
         {

--- a/UnitTests/MultilineMessageReceiverTests.cs
+++ b/UnitTests/MultilineMessageReceiverTests.cs
@@ -1,0 +1,135 @@
+﻿#nullable enable
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using static CA_DataUploaderLib.BaseSensorBox;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class MultilineMessageReceiverTests
+    {
+        private static readonly string completeMultilineMessage = """
+Start of board Status:
+The board is operating normally.
+Port 1 measures voltage[0 - 5V]
+Port 2 measures voltage[0 - 5V]
+Port 3 measures voltage[0 - 5V]
+Port 4 measures voltage[0 - 5V]
+Port 5 measures voltage[0 - 5V]
+Port 6 measures voltage[0 - 5V]
+
+End of board status.
+""";
+
+        private static readonly string incompleteMultilineMessage = """
+Start of board Status:
+The board is operating normally.
+Port 1 measures voltage[0 - 5V]
+Port 2 measures voltage[0 - 5V]
+
+""";
+
+        private readonly List<string> linesWithCompleteMessage = [
+"4.650325, 3543.687988, 4.639473, 4.656060, 4.628024, 4.629683, 0x0",
+"4.650254, 3543.561768, 4.639433, 4.655966, 4.627975, 4.629673, 0x0",
+..completeMultilineMessage.Split(Environment.NewLine),
+"4.650369, 3543.680420, 4.639513, 4.656144, 4.627993, 4.629726, 0x0",
+"4.650223, 3543.606201, 4.639447, 4.656077, 4.627962, 4.629629, 0x0" ];
+
+        private readonly List<string> linesWithIncompleteMessage = [
+"4.650325, 3543.687988, 4.639473, 4.656060, 4.628024, 4.629683, 0x0",
+"4.650254, 3543.561768, 4.639433, 4.655966, 4.627975, 4.629673, 0x0",
+..incompleteMultilineMessage.Split(Environment.NewLine),
+"4.650369, 3543.680420, 4.639513, 4.656144, 4.627993, 4.629726, 0x0",
+"4.650223, 3543.606201, 4.639447, 4.656077, 4.627962, 4.629629, 0x0" ];
+
+        [TestMethod]
+        public void HandleLine_CompleteInfoBlock_Logged()
+        {
+            // Arrange
+            var logCount = 0;
+            var log = "";
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; });
+
+            // Act
+            foreach (var line in linesWithCompleteMessage)
+                sut.HandleLine(line);
+
+            // Assert
+            Assert.AreEqual(1, logCount);
+            Assert.IsTrue(log.Contains(completeMultilineMessage));
+        }
+
+        [TestMethod]
+        public void HandleLine_IncompleteInfoBlock_NothingIsLoggedImmediately()
+        {
+            // Arrange
+            var logCount = 0;
+            var log = "";
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; });
+
+            // Act
+            foreach (var line in linesWithIncompleteMessage)
+                sut.HandleLine(line);
+
+            // Assert
+            Assert.AreEqual(0, logCount);
+        }
+
+        [TestMethod]
+        public void HandleLine_IncompleteInfoBlock_LoggedAfterLineCountExceeded()
+        {
+            // Arrange
+            var logCount = 0;
+            var log = "";
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; });
+
+            // Act
+            foreach (var line in linesWithIncompleteMessage)
+                sut.HandleLine(line);
+            for (var i = 0; i < 123; i++) //Some large number of value lines
+                sut.HandleLine("4.650369, 3543.680420, 4.639513, 4.656144, 4.627993, 4.629726, 0x0");
+
+            // Assert
+            Assert.AreEqual(1, logCount);
+            Assert.IsTrue(log.Contains(incompleteMultilineMessage));
+        }
+
+        [TestMethod]
+        public void LogPossibleIncompleteMessage_CompleteMessage_NothingIsLogged()
+        {
+            // Arrange
+            var logCount = 0;
+            var log = "";
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; });
+            foreach (var line in linesWithCompleteMessage)
+                sut.HandleLine(line);
+            logCount = 0;
+
+            // Act
+            sut.LogPossibleIncompleteMessage();
+
+            // Assert
+            Assert.AreEqual(0, logCount);
+        }
+
+        [TestMethod]
+        public void LogPossibleIncompleteMessage_IncompleteMessage_Logged()
+        {
+            // Arrange
+            var logCount = 0;
+            var log = "";
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; });
+            foreach (var line in linesWithIncompleteMessage)
+                sut.HandleLine(line);
+
+            // Act
+            sut.LogPossibleIncompleteMessage();
+
+            // Assert
+            Assert.AreEqual(1, logCount);
+            Assert.IsTrue(log.Contains(incompleteMultilineMessage));
+        }
+    }
+}


### PR DESCRIPTION
+ Implemented new class MultilineMessageReceiver for handling messages from the board (e.g. in response to "Status") spanning multiple lines. The lines are delimited by "Start of" and "End of" and logged as one message. While receiving a multiline message, no value lines can be received.