### PR TITLE
MultilineMessageReceiver: trim away any white-space characters.

### DIFF
--- a/CA_DataUploaderLib/Alerts.cs
+++ b/CA_DataUploaderLib/Alerts.cs
@@ -75,7 +75,7 @@ namespace CA_DataUploaderLib
                             }
                             catch (Exception ex)
                             {//note that a distributed host might postpone the execution of the command above, but it would then be responsible of logging information about any error.
-                                CALog.LogError(LogID.A, $"unexpected error running command for alert {alert.Name}", ex);
+                                CALog.LogError(LogID.A, $"Unexpected error running command for alert {alert.Name}", ex);
                             }
                         }
                     }

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -719,6 +719,7 @@ namespace CA_DataUploaderLib
             /// <returns>True, if the line is part of a multiline message and should be considered handled.</returns>
             public bool HandleLine(string line)
             {
+                line = line.Trim();
                 if (line.StartsWith(startTag, StringComparison.InvariantCultureIgnoreCase) || multilineMessageMode)
                 {
                     multilineMessageMode = true;

--- a/CA_DataUploaderLib/CA_DataUploaderLib.csproj
+++ b/CA_DataUploaderLib/CA_DataUploaderLib.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreCLR-NCalc" Version="2.2.101" />
+    <PackageReference Include="CoreCLR-NCalc" Version="3.1.253" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.2" />
     <PackageReference Include="MinVer" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CA_DataUploaderLib/IOconf/IOconfAlert.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfAlert.cs
@@ -93,7 +93,7 @@ namespace CA_DataUploaderLib.IOconf
         {
             var match = comparisonRegex.Match(expression);
             if (!match.Success)
-                throw new Exception(formatErrorMessage + " Supported comparisons: =,!=, >, <, >=, <=");
+                throw new Exception(formatErrorMessage + " Supported comparisons: =, !=, >, <, >=, <=");
             return ParseExpression(name, expression, match);
         }
 
@@ -118,7 +118,7 @@ namespace CA_DataUploaderLib.IOconf
                 "<" => AlertCompare.SmallerThan,
                 ">=" => AlertCompare.BiggerOrEqualTo,
                 "<=" => AlertCompare.SmallerOrEqualTo,
-                _ => throw new Exception("alert expression - wrong format: " + expression),
+                _ => throw new Exception("Alert expression - wrong format: " + expression),
             };
 
             return (sensor, value, messageTemplate, type);

--- a/UnitTests/IOconfAlertTests.cs
+++ b/UnitTests/IOconfAlertTests.cs
@@ -82,7 +82,7 @@ namespace UnitTests
         public void AlertRejectsInvalidConfiguration(string row)
         {
             var ex = Assert.ThrowsException<Exception>(() => new IOconfAlert(row, 0));
-            Assert.AreEqual($"IOconfAlert: wrong format: {row}. Format: Alert;Name;SensorName comparison value;[rateMinutes];[command]. Supported comparisons: =,!=, >, <, >=, <=", ex.Message);
+            Assert.AreEqual($"IOconfAlert: wrong format: {row}. Format: Alert;Name;SensorName comparison value;[rateMinutes];[command]. Supported comparisons: =, !=, >, <, >=, <=", ex.Message);
         }
     }
 }

--- a/UnitTests/IOconfMathTests.cs
+++ b/UnitTests/IOconfMathTests.cs
@@ -28,6 +28,8 @@ namespace UnitTests
         [DataRow("Math;MyName;Abs(MyValue % 1)", 123.6542, 0.654200000000003d)]
         [DataRow("Math;MyName;Sqrt(MyValue)", 4, 2)]
         [DataRow("Math;MyName;Sqrt(MyValue)", -1, double.NaN)]
+        [DataRow("Math;MyName;MyValue ** 8", 2d, 256d)] // ** = Pow = exponential
+        [DataRow("Math;MyName;Pow(MyValue, 8)", 2d, 256d)]
         [DataTestMethod]
         public void CalculatesExpectedValue(string row, double value, double expectedResult) 
         {

--- a/UnitTests/MultilineMessageReceiverTests.cs
+++ b/UnitTests/MultilineMessageReceiverTests.cs
@@ -54,7 +54,7 @@ Port 2 measures voltage[0 - 5V]
 
             // Act
             foreach (var line in linesWithCompleteMessage)
-                sut.HandleLine(line);
+                sut.HandleLine($"\n{line}"); // Added extra newline-character which should get ignored
 
             // Assert
             Assert.AreEqual(1, logCount);


### PR DESCRIPTION
The fault info that we receive from the board, for some reason had extra newline characters at the beginning of each line. Now, such white-space characters are trimmed away by the MultilineMessageReceiver.

+update NCalc to newest version.