### PR TITLE
improved a couple log messages + improved testability

### DIFF
--- a/CA_DataUploader/Program.cs
+++ b/CA_DataUploader/Program.cs
@@ -68,7 +68,7 @@ namespace CA_DataUploader
             }
             else
             {
-                CALog.LogException(LogID.A, ex);
+                CALog.LogErrorAndConsoleLn(LogID.A, $"Stopping due to unexpected error: {ex.Message}.", ex);
             }
         }
     }

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -542,7 +542,7 @@ namespace CA_DataUploaderLib
             var readLineTask = board.SafeReadLine(token);
             var noDataAvailableTask = Task.Delay(timeBetweenReads, _cmd.Time, token);
             long noDataDetectedTime = 0;
-            if (await Task.WhenAny(readLineTask, noDataAvailableTask) == noDataAvailableTask && !readLineTask.IsCompleted && !token.IsCancellationRequested)
+            if (await Task.WhenAny(readLineTask, noDataAvailableTask) == noDataAvailableTask && !token.IsCancellationRequested)
             {
                 LogData(board, $"No data available ({readLineTask.IsCompleted})");
                 noDataDetectedTime = _cmd.Time.GetTimestamp();

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -542,7 +542,7 @@ namespace CA_DataUploaderLib
             var readLineTask = board.SafeReadLine(token);
             var noDataAvailableTask = Task.Delay(timeBetweenReads, _cmd.Time, token);
             long noDataDetectedTime = 0;
-            if (await Task.WhenAny(readLineTask, noDataAvailableTask) == noDataAvailableTask)
+            if (await Task.WhenAny(readLineTask, noDataAvailableTask) == noDataAvailableTask && !readLineTask.IsCompleted && !token.IsCancellationRequested)
             {
                 LogData(board, $"No data available ({readLineTask.IsCompleted})");
                 noDataDetectedTime = _cmd.Time.GetTimestamp();
@@ -555,6 +555,10 @@ namespace CA_DataUploaderLib
                 if (noDataDetectedTime != 0)
                     LogData(board, $"Time from no data available to data available: {_cmd.Time.GetElapsedTime(noDataDetectedTime).TotalMilliseconds}ms");
                 return line;
+            }
+            catch (OperationCanceledException ex) when (ex.CancellationToken == token) 
+            {
+                throw;
             }
             catch (ObjectDisposedException)
             {

--- a/CA_DataUploaderLib/CALog.cs
+++ b/CA_DataUploaderLib/CALog.cs
@@ -15,20 +15,20 @@ namespace CA_DataUploaderLib
         A, B, C, D, E, F, G, H
     }
 
-    public class CALog : ICALogger
+    public class CALog : ILog
     {
         private static Dictionary<LogID, DateTime>? _nextSizeCheck;
         private static readonly string _logDir = Directory.GetCurrentDirectory();
-        internal static readonly ICALogger Default = new CALog();
+        internal static readonly ILog Default = new CALog();
 
         /// <remarks>any output before a custom logger is set is written to the console.</remarks>
         public static ISimpleLogger LoggerForUserOutput { get; set; } = new ConsoleLogger();
         public static int MaxLogSizeMB { get; set; } = 100;
 
-        void ICALogger.LogData(LogID id, string msg) => LogData(id, msg);
-        void ICALogger.LogError(LogID id, string msg, Exception ex) => LogErrorAndConsoleLn(id, msg, ex);
-        void ICALogger.LogError(LogID id, string msg) => LogErrorAndConsoleLn(id, msg);
-        void ICALogger.LogInfo(LogID id, string msg) => LogInfoAndConsoleLn(id, msg);
+        void ILog.LogData(LogID id, string msg) => LogData(id, msg);
+        void ILog.LogError(LogID id, string msg, Exception ex) => LogErrorAndConsoleLn(id, msg, ex);
+        void ILog.LogError(LogID id, string msg) => LogErrorAndConsoleLn(id, msg);
+        void ILog.LogInfo(LogID id, string msg) => LogInfoAndConsoleLn(id, msg);
         public static void LogData(LogID logID, string msg) => WriteToFile(logID, msg);
 
         public static void LogInfoAndConsoleLn(LogID logID, string msg)

--- a/CA_DataUploaderLib/CALog.cs
+++ b/CA_DataUploaderLib/CALog.cs
@@ -15,22 +15,21 @@ namespace CA_DataUploaderLib
         A, B, C, D, E, F, G, H
     }
 
-    public static class CALog
+    public class CALog : ICALogger
     {
         private static Dictionary<LogID, DateTime>? _nextSizeCheck;
         private static readonly string _logDir = Directory.GetCurrentDirectory();
+        internal static readonly ICALogger Default = new CALog();
 
         /// <remarks>any output before a custom logger is set is written to the console.</remarks>
         public static ISimpleLogger LoggerForUserOutput { get; set; } = new ConsoleLogger();
         public static int MaxLogSizeMB { get; set; } = 100;
 
+        void ICALogger.LogData(LogID id, string msg) => LogData(id, msg);
+        void ICALogger.LogError(LogID id, string msg, Exception ex) => LogErrorAndConsoleLn(id, msg, ex);
+        void ICALogger.LogError(LogID id, string msg) => LogErrorAndConsoleLn(id, msg);
+        void ICALogger.LogInfo(LogID id, string msg) => LogInfoAndConsoleLn(id, msg);
         public static void LogData(LogID logID, string msg) => WriteToFile(logID, msg);
-        public static void LogException(LogID logID, Exception ex)
-        {
-            var msg = ex.ToString();
-            LoggerForUserOutput.LogError(ex);
-            WriteToFile(logID, msg);
-        }
 
         public static void LogInfoAndConsoleLn(LogID logID, string msg)
         {

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -59,7 +59,7 @@ namespace CA_DataUploaderLib
         public TimeProvider Time { get; }
         public ICALogger Logger { get; }
 
-        public CommandHandler(IIOconf ioconf, SerialNumberMapper? mapper = null, ICommandRunner? runner = null, bool runCommandLoop = true, TimeProvider? time = null, ICALogger logger = null)
+        public CommandHandler(IIOconf ioconf, SerialNumberMapper? mapper = null, ICommandRunner? runner = null, bool runCommandLoop = true, TimeProvider? time = null, ICALogger? logger = null)
         {
             Time = time ?? TimeProvider.System;
             Logger = logger ?? CALog.Default;

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -56,9 +56,13 @@ namespace CA_DataUploaderLib
         public CancellationToken StopToken => _exitCts.Token;
         public Task RunningTask => _runningTaskTcs.Task;
         public IReadOnlyList<LoopControlDecision> Decisions => _decisions;
+        public TimeProvider Time { get; }
+        public ICALogger Logger { get; }
 
-        public CommandHandler(IIOconf ioconf, SerialNumberMapper? mapper = null, ICommandRunner? runner = null, bool runCommandLoop = true)
+        public CommandHandler(IIOconf ioconf, SerialNumberMapper? mapper = null, ICommandRunner? runner = null, bool runCommandLoop = true, TimeProvider? time = null, ICALogger logger = null)
         {
+            Time = time ?? TimeProvider.System;
+            Logger = logger ?? CALog.Default;
             _exitCts.Token.Register(() =>
             {
                 _runningTaskTcs.TrySetCanceled();
@@ -113,7 +117,7 @@ namespace CA_DataUploaderLib
                     }
                     catch (Exception ex)
                     {
-                        CALog.LogErrorAndConsoleLn(LogID.A, $"Error running command: {e.Data}", ex);
+                        Logger.LogError(LogID.A, $"Error running command: {e.Data}", ex);
                     }
                 }
             });
@@ -206,7 +210,7 @@ namespace CA_DataUploaderLib
             OrderDecisionsBasedOnIOconf(_decisions);
             var decisions = _decisions.Concat(_safetydecisions);
             SetConfigBasedOnIOconf(decisions);
-            CALog.LogData(LogID.A, $"Decisions order: {string.Join(',', decisions.Select(d => d.Name))}");
+            Logger.LogData(LogID.A, $"Decisions order: {string.Join(',', decisions.Select(d => d.Name))}");
             var outputs = decisions.SelectMany(d => d.PluginFields.Select(f => new VectorDescriptionItem("double", f.Name, (DataTypeEnum)f.Type) { Upload = f.Upload })).ToList();
             var desc = new ExtendedVectorDescription(_ioconf, inputsPerNode, globalInputs, outputs);
             CA.LoopControlPluginBase.VectorDescription inmutableVectorDesc = new(desc.VectorDescription._items.Select(i => i.Descriptor).ToArray());
@@ -312,11 +316,11 @@ namespace CA_DataUploaderLib
                 }
                 catch (Exception ex)
                 {
-                    CALog.LogErrorAndConsoleLn(LogID.A, ex.ToString());
+                    Logger.LogError(LogID.A, ex.ToString());
                 }
             }
 
-            CALog.LogInfoAndConsoleLn(LogID.A, "Exiting CommandHandler.LoopForever() " + DateTime.UtcNow.Subtract(_start));
+            Logger.LogInfo(LogID.A, "Exiting CommandHandler.LoopForever() " + DateTime.UtcNow.Subtract(_start));
         }
 
         private void HandleCommand(string cmdString, bool isUserCommand)
@@ -353,7 +357,7 @@ namespace CA_DataUploaderLib
                     var confirmedStop = Console.ReadKey().KeyChar == 'y';
                     var msg = confirmedStop ? "Stop sequence initiated" : "Stop sequence aborted";
                     Console.WriteLine(msg); //ensure there is console output for this interactive local action regardless of the logger
-                    CALog.LogData(LogID.A, msg); //no need to write the line to the screen again + no need to show it in remote logging, as confirmed stops show as the "escape" command.
+                    Logger.LogData(LogID.A, msg); //no need to write the line to the screen again + no need to show it in remote logging, as confirmed stops show as the "escape" command.
                     if (confirmedStop)
                         return "escape";
                 }
@@ -406,22 +410,22 @@ namespace CA_DataUploaderLib
 
         private bool HelpMenu(List<string> args)
         {
-            CALog.LogInfoAndConsoleLn(LogID.A, "-------------------------------------");
-            CALog.LogInfoAndConsoleLn(LogID.A, "Commands: ");
-            CALog.LogInfoAndConsoleLn(LogID.A, "Esc                       - press Esc key to shut down");
-            CALog.LogInfoAndConsoleLn(LogID.A, "help                      - print the full list of available commands");
-            CALog.LogInfoAndConsoleLn(LogID.A, "up                        - print how long the service has been running");
-            CALog.LogInfoAndConsoleLn(LogID.A, "version                   - print the software version and hardware of this system");
+            Logger.LogInfo(LogID.A, "-------------------------------------");
+            Logger.LogInfo(LogID.A, "Commands: ");
+            Logger.LogInfo(LogID.A, "Esc                       - press Esc key to shut down");
+            Logger.LogInfo(LogID.A, "help                      - print the full list of available commands");
+            Logger.LogInfo(LogID.A, "up                        - print how long the service has been running");
+            Logger.LogInfo(LogID.A, "version                   - print the software version and hardware of this system");
             return true;
         }
 
         public void Uptime(List<string> _) => 
-            CALog.LogInfoAndConsoleLn(LogID.A, $"{DateTime.UtcNow.Subtract(_start)}");
+            Logger.LogInfo(LogID.A, $"{DateTime.UtcNow.Subtract(_start)}");
 
         public void GetVersion(List<string> _)
         {
             var connInfo = _ioconf.GetConnectionInfo();
-            CALog.LogInfoAndConsoleLn(LogID.A, 
+            Logger.LogInfo(LogID.A, 
 $@"{RpiVersion.GetSoftware()}
 {RpiVersion.GetHardware()}
 {connInfo.LoopName} - {connInfo.Email}

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -57,9 +57,9 @@ namespace CA_DataUploaderLib
         public Task RunningTask => _runningTaskTcs.Task;
         public IReadOnlyList<LoopControlDecision> Decisions => _decisions;
         public TimeProvider Time { get; }
-        public ICALogger Logger { get; }
+        public ILog Logger { get; }
 
-        public CommandHandler(IIOconf ioconf, SerialNumberMapper? mapper = null, ICommandRunner? runner = null, bool runCommandLoop = true, TimeProvider? time = null, ICALogger? logger = null)
+        public CommandHandler(IIOconf ioconf, SerialNumberMapper? mapper = null, ICommandRunner? runner = null, bool runCommandLoop = true, TimeProvider? time = null, ILog? logger = null)
         {
             Time = time ?? TimeProvider.System;
             Logger = logger ?? CALog.Default;

--- a/CA_DataUploaderLib/Extensions/ChannelReaderExtensions.cs
+++ b/CA_DataUploaderLib/Extensions/ChannelReaderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Channels;
+﻿using System;
+using System.Threading.Channels;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,10 +8,10 @@ namespace CA_DataUploaderLib.Extensions
     public static class ChannelReaderExtensions
     {
         /// <returns><c>null</c> if it timed out, otherwise the read value.</returns>
-        public static async Task<T?> ReadWithSoftTimeout<T>(this ChannelReader<T> reader, int timeoutMs, CancellationToken token)
+        public static async Task<T?> ReadWithSoftTimeout<T>(this ChannelReader<T> reader, int timeoutMs, TimeProvider time, CancellationToken token)
         {
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token);
-            linkedCts.CancelAfter(timeoutMs);
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs), time);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, timeoutCts.Token);
             var nextVectorTask = await Task.WhenAny(reader.ReadAsync(linkedCts.Token).AsTask()); //Task.Any avoids an exception so we can return null on timeouts instead
             return nextVectorTask.IsCompletedSuccessfully ? await nextVectorTask : default;
         }

--- a/CA_DataUploaderLib/ICALogger.cs
+++ b/CA_DataUploaderLib/ICALogger.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CA_DataUploaderLib
+{
+    public interface ICALogger
+    {
+        void LogData(LogID id, string msg);
+        void LogError(LogID id, string msg, Exception ex);
+        void LogError(LogID id, string msg);
+        void LogInfo(LogID id, string msg);
+    }
+}

--- a/CA_DataUploaderLib/ILog.cs
+++ b/CA_DataUploaderLib/ILog.cs
@@ -2,7 +2,7 @@
 
 namespace CA_DataUploaderLib
 {
-    public interface ICALogger
+    public interface ILog
     {
         void LogData(LogID id, string msg);
         void LogError(LogID id, string msg, Exception ex);

--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -26,7 +26,7 @@ namespace CA_DataUploaderLib.IOconf
             return (list, ParseLines(Loader, list));
         }
 
-        internal static IEnumerable<IOconfRow> ParseLines(IIOconfLoader loader, IEnumerable<string> lines)
+        public static IEnumerable<IOconfRow> ParseLines(IIOconfLoader loader, IEnumerable<string> lines)
         {
             IOconfNode.ResetIndex();
             IOconfCode.ResetIndex();

--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -23,10 +23,10 @@ namespace CA_DataUploaderLib.IOconf
             }
 
             var list = File.ReadAllLines("IO.conf").ToList();
-            return (list, ParseLines(list));
+            return (list, ParseLines(Loader, list));
         }
 
-        public static IEnumerable<IOconfRow> ParseLines(IEnumerable<string> lines)
+        internal static IEnumerable<IOconfRow> ParseLines(IIOconfLoader loader, IEnumerable<string> lines)
         {
             IOconfNode.ResetIndex();
             IOconfCode.ResetIndex();
@@ -34,7 +34,7 @@ namespace CA_DataUploaderLib.IOconf
             var linesList = lines.Select(x => x.Trim()).ToList();
             // remove empty lines and commented out lines
             var lines2 = linesList.Where(x => !x.StartsWith("//") && x.Length > 2).ToList();
-            return lines2.Select(x => CreateType(x, linesList.IndexOf(x) + 1));
+            return lines2.Select(x => CreateType(loader, x, linesList.IndexOf(x) + 1));
         }
 
         /// <summary>
@@ -60,13 +60,13 @@ namespace CA_DataUploaderLib.IOconf
             File.WriteAllText(filename, ioconf);
         }
 
-        private static IOconfRow CreateType(string row, int lineNum)
+        private static IOconfRow CreateType(IIOconfLoader confLoader, string row, int lineNum)
         {
             try
             {
                 var separatorIndex = row.IndexOf(';');
                 var rowType = separatorIndex > -1 ? row.AsSpan()[..separatorIndex].Trim() : row;
-                var loader = Loader.GetLoader(rowType) ?? ((r, l) => new IOconfRow(r, l, "Unknown", true));
+                var loader = confLoader.GetLoader(rowType) ?? ((r, l) => new IOconfRow(r, l, "Unknown", true));
                 return loader(row, lineNum);
             }
             catch (Exception ex)

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -20,8 +20,10 @@ namespace CA_DataUploaderLib.IOconf
         }
 
         public IOconfFile(List<string> rawLines, bool performCheck = true)
+            : this(IOconfFileLoader.Loader, rawLines, performCheck) { }
+        public IOconfFile(IIOconfLoader loader, List<string> rawLines, bool performCheck = true)
         {
-            Table.AddRange(IOconfFileLoader.ParseLines(rawLines));
+            Table.AddRange(IOconfFileLoader.ParseLines(loader, rawLines));
             RawLines = rawLines;
             EnsureRPiTempEntry();
             if (performCheck)

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -594,26 +594,17 @@ namespace CA_DataUploaderLib
             }
         }
 
-        public class Dependencies(
-            TimeProvider timeProvider, Action<LogID, string> logInfo, Action<LogID, string> logError, 
-            Action<LogID, string, Exception> logException, Action<LogID, string> logData,
-            IConnectionManager connectionManager)
+        public class Dependencies(TimeProvider timeProvider, ILog logger, IConnectionManager connectionManager)
         {
-            public Dependencies(TimeProvider timeProvider, Action<LogID, string> log, IConnectionManager connectionManager) :
-                this(timeProvider, log, log, (id, msg, ex) => log(id, $"{msg}{Environment.NewLine}{ex}"), log, connectionManager)
-            { 
-            }
-            public static Dependencies Default { get; } = new(
-                TimeProvider.System, CALog.LogInfoAndConsoleLn, CALog.LogErrorAndConsoleLn, CALog.LogErrorAndConsoleLn, CALog.LogData,
-                SerialPortConnectionManager.Default);
+            public static Dependencies Default { get; } = new(TimeProvider.System, CALog.Default, SerialPortConnectionManager.Default);
 
             public TimeProvider TimeProvider { get; } = timeProvider;
             public IConnectionManager ConnectionManager { get; } = connectionManager;
 
-            internal void LogError(LogID logId, string message) => logError(logId, message);
-            internal void LogException(LogID logId, string message, Exception exception) => logException(logId, message, exception);
-            internal void LogInfo(LogID logId, string message) => logInfo(logId, message);
-            internal void LogData(LogID logId, string message) => logData(logId, message);
+            internal void LogError(LogID logId, string message) => logger.LogError(logId, message);
+            internal void LogException(LogID logId, string message, Exception exception) => logger.LogError(logId, message, exception);
+            internal void LogInfo(LogID logId, string message) => logger.LogInfo(logId, message);
+            internal void LogData(LogID logId, string message) => logger.LogData(logId, message);
         }
 
         public interface IConnectionManager

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -360,8 +360,10 @@ namespace CA_DataUploaderLib
             }
             catch (OperationCanceledException ex)
             {
-                if (ex.CancellationToken == token)
+                if (cts.IsCancellationRequested)
                     throw new TimeoutException("Timed out (while reading)");
+                if (cancellationToken.IsCancellationRequested)
+                    throw new OperationCanceledException("The read operation has been canceled", ex, cancellationToken);
                 throw;
             }
 

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -53,7 +53,8 @@ namespace CA_DataUploaderLib
         private readonly AsyncReaderWriterLock _reconnectionLock = new();
 
         public BoardSettings ConfigSettings { get; set; } = BoardSettings.Default;
-        private readonly SerialPort port;
+        private readonly IConnection port;
+        private readonly Dependencies dependencies;
         private PipeReader? pipeReader;
         public delegate bool TryReadLineDelegate(ref ReadOnlySequence<byte> buffer, [NotNullWhen(true)]out string? line);
         private TryReadLineDelegate TryReadLine;
@@ -63,28 +64,21 @@ namespace CA_DataUploaderLib
 
         public bool Closed { get; private set; }
 
-        private MCUBoard(SerialPort port) : base(port.PortName, null)
+        private MCUBoard(IConnection port, string portName, Dependencies dependencies) : base(portName, null)
         {
             this.port = port;
+            this.dependencies = dependencies;
             TryReadLine = TryReadAsciiLine; //this is the default which can be changed in ReadSerial based on the ThirdPartyProtocolDetection
         }
 
-        private async static Task<MCUBoard?> Create(IIOconf? ioconf, string name, int baudrate, bool skipBoardAutoDetection, bool enableDtrRts = true)
+        private async static Task<MCUBoard?> Create(Dependencies dependencies, IIOconf? ioconf, string name, int baudrate, bool skipBoardAutoDetection, bool enableDtrRts = true)
         {
             MCUBoard? board = null;
             try
             {
-                var port = new SerialPort(name);
-                board = new MCUBoard(port);
-                port.BaudRate = 1;
-                port.DtrEnable = enableDtrRts;
-                port.RtsEnable = enableDtrRts;
-                port.BaudRate = baudrate;
-                port.ReadTimeout = 2000;
-                port.WriteTimeout = 2000;
-                port.Open();
-                board.pipeReader = PipeReader.Create(port.BaseStream);
-                Thread.Sleep(100); // it needs to await that the board registers that the COM port has been opened before sending commands (work arounds issue when first opening the connection and sending serial).
+                var port = dependencies.ConnectionManager.NewConnection(name, baudrate, enableDtrRts);
+                board = new MCUBoard(port, name, dependencies);
+                board.pipeReader = port.GetPipeReader();
                 board.ProductType = "NA";
                 board.InitialConnectionSucceeded = skipBoardAutoDetection || await board.ReadSerialNumber(board.pipeReader);
 
@@ -107,7 +101,7 @@ namespace CA_DataUploaderLib
             }
             catch (Exception ex)
             {
-                CALog.LogException(LogID.A, ex);
+                dependencies.LogException(LogID.A, $"Unexpected error connecting to {name}({baudrate})", ex);
             }
 
             if (board != null && !board.InitialConnectionSucceeded)
@@ -127,12 +121,12 @@ namespace CA_DataUploaderLib
                 return default; // ignore if there is no calibration in configuration or if the board already had the expected configuration
             if (Calibration == default && configSettings.SkipCalibrationWhenHeaderIsMissing)
             {
-                CALog.LogInfoAndConsoleLn(LogID.A, $"Skipped detected board without calibration support - {ToShortDescription()}");
+                dependencies.LogInfo(LogID.A, $"Skipped detected board without calibration support - {ToShortDescription()}");
                 return default;
             }
 
             var calibrationMessage = $"Replaced board calibration '{Calibration}' with '{newCalibration}";
-            CALog.LogInfoAndConsoleLn(LogID.A, $"{calibrationMessage}' - {ToShortDescription()}");
+            dependencies.LogInfo(LogID.A, $"{calibrationMessage}' - {ToShortDescription()}");
             await SafeWriteLine(newCalibration, CancellationToken.None);
             UpdatedCalibration = newCalibration;
             return calibrationMessage;
@@ -176,28 +170,28 @@ namespace CA_DataUploaderLib
                     await pipeReader.CompleteAsync();
                 if (port.IsOpen)
                 {
-                    CALog.LogData(LogID.B, $"(Reopen) Closing port {PortName} {ProductType} {SerialNumber}");
+                    dependencies.LogData(LogID.B, $"(Reopen) Closing port {PortName} {ProductType} {SerialNumber}");
                     port.Close();
-                    await Task.Delay(500, token);
+                    await Task.Delay(TimeSpan.FromMilliseconds(500), dependencies.TimeProvider, token);
                 }
 
-                CALog.LogData(LogID.B, $"(Reopen) opening port {PortName} {ProductType} {SerialNumber}");
-                port.Open();
-                pipeReader = PipeReader.Create(port.BaseStream);
+                dependencies.LogData(LogID.B, $"(Reopen) opening port {PortName} {ProductType} {SerialNumber}");
+                pipeReader = port.GetPipeReader();
                 reconnectedLine = await ReadOptionalNonEmptyLine(
-                    pipeReader, PortName, ConfigSettings.MaxMillisecondsWithoutNewValues, TryReadLine, l => l.StartsWith("reconnected", StringComparison.OrdinalIgnoreCase));
+                    dependencies, pipeReader, PortName, ConfigSettings.MaxMillisecondsWithoutNewValues, TryReadLine, l => l.StartsWith("reconnected", StringComparison.OrdinalIgnoreCase));
             }
             catch (Exception ex)
             {
-                CALog.LogError(LogID.B, $"Failure reopening port {PortName} {ProductType} {SerialNumber}.",ex);
+                dependencies.LogException(LogID.B, $"Failure reopening port {PortName} {ProductType} {SerialNumber}.",ex);
                 return (false, string.Empty);
             }
 
-            CALog.LogData(LogID.B, $"Reopened port {PortName} {ProductType} {SerialNumber}.");
+            dependencies.LogData(LogID.B, $"Reopened port {PortName} {ProductType} {SerialNumber}.");
             return (true, reconnectedLine);
         }
 
-        public async static Task<MCUBoard?> OpenDeviceConnection(IIOconf? ioconf, string name)
+        public static Task<MCUBoard?> OpenDeviceConnection(IIOconf? ioconf, string name) => OpenDeviceConnection(Dependencies.Default, SerialPortConnectionManager.Default, ioconf, name, true);
+        public async static Task<MCUBoard?> OpenDeviceConnection(Dependencies dependencies, IConnectionManager connectionManager, IIOconf? ioconf, string name, bool useDmsgIfTypeUnknown)
         {
             // note this map is only found by usb, for map entries configured by serial we use auto detection with standard baud rates instead.
             var map = ioconf?.GetMap().SingleOrDefault(m => m.IsLocalBoard && m.USBPort == name);
@@ -205,17 +199,17 @@ namespace CA_DataUploaderLib
             var isVport = IOconfMap.IsVirtualPortName(name);
             bool skipAutoDetection = isVport || (map?.BoardSettings ?? BoardSettings.Default).SkipBoardAutoDetection;
             if (skipAutoDetection)
-                CALog.LogInfoAndConsoleLn(LogID.A, $"Device detection disabled for {name}({map})");
-            var mcu = await Create(ioconf, name, initialBaudrate, skipAutoDetection, !isVport);
+                dependencies.LogInfo(LogID.A, $"Device detection disabled for {name}({map})");
+            var mcu = await Create(dependencies, ioconf, name, initialBaudrate, skipAutoDetection, !isVport);
             if (mcu == null || !mcu.InitialConnectionSucceeded)
-                mcu = await OpenWithAutoDetection(ioconf, name, initialBaudrate);
+                mcu = await OpenWithAutoDetection(dependencies, ioconf, name, initialBaudrate);
             if (mcu == null)
                 return null; //we normally only get here if the SerialPort(usbport) constructor failed, which might be due to a wrong port
             if (mcu.SerialNumber.IsNullOrEmpty())
                 mcu.SerialNumber = "unknown" + Interlocked.Increment(ref _detectedUnknownBoards);
             if (mcu.InitialConnectionSucceeded && map != null && map.BaudRate != 0 && mcu.port.BaudRate != map.BaudRate)
-                CALog.LogErrorAndConsoleLn(LogID.A, $"Unexpected baud rate for {map}. Board info {mcu}");
-            mcu.ProductType ??= GetStringFromDmesg(mcu.PortName);
+                dependencies.LogError(LogID.A, $"Unexpected baud rate for {map}. Board info {mcu}");
+            mcu.ProductType ??= useDmsgIfTypeUnknown ? GetStringFromDmesg(mcu.PortName) : mcu.ProductType;
             return mcu;
         }
 
@@ -234,21 +228,21 @@ namespace CA_DataUploaderLib
             return result.FirstOrDefault(x => x.EndsWith(portName))?.StringBetween(": ", " to ttyUSB");
         }
 
-        private async static Task<MCUBoard?> OpenWithAutoDetection(IIOconf? ioconf, string name, int previouslyAttemptedBaudRate)
+        private async static Task<MCUBoard?> OpenWithAutoDetection(Dependencies dependencies, IIOconf? ioconf, string name, int previouslyAttemptedBaudRate)
         {
             var skipAutoDetection = false;
             if (previouslyAttemptedBaudRate == 115200)
-                return await Create(ioconf, name, 9600, skipAutoDetection);
+                return await Create(dependencies, ioconf, name, 9600, skipAutoDetection);
             if (previouslyAttemptedBaudRate == 9600)
-                return await Create(ioconf, name, 115200, skipAutoDetection);
-            var board = await Create(ioconf, name, 115200, skipAutoDetection);
-            return board != null && board.InitialConnectionSucceeded ? board : await Create(ioconf, name, 9600, skipAutoDetection);
+                return await Create(dependencies, ioconf, name, 115200, skipAutoDetection);
+            var board = await Create(dependencies, ioconf, name, 115200, skipAutoDetection);
+            return board != null && board.InitialConnectionSucceeded ? board : await Create(dependencies, ioconf, name, 9600, skipAutoDetection);
         }
 
         /// <returns><c>true</c> if we were able to read</returns>
         private async Task<bool> ReadSerialNumber(PipeReader pipeReader)
         {
-            var detectedInfo = await DetectThirdPartyProtocol(pipeReader);
+            var detectedInfo = await DetectThirdPartyProtocol(pipeReader, dependencies);
             if (detectedInfo != default)
             {
                 SerialNumber = detectedInfo.SerialNumber;
@@ -258,21 +252,21 @@ namespace CA_DataUploaderLib
             }
 
             port.WriteLine("Serial");
-            var header = new Header();
+            var header = new Header(dependencies);
             var ableToRead = await header.DetectBoardHeader(pipeReader, TryReadLine, () => port.WriteLine("Serial"), $"{PortName} ({port.BaudRate})");
             header.CopyTo(this);
             return ableToRead;
         }
 
         /// <summary>detects if we are talking with a supported third party device</summary>
-        private Task<BoardInfo?> DetectThirdPartyProtocol(PipeReader pipeReader) =>
-            DetectThirdPartyProtocol(port.BaudRate, PortName, pipeReader);
+        private Task<BoardInfo?> DetectThirdPartyProtocol(PipeReader pipeReader, Dependencies dependencies) =>
+            DetectThirdPartyProtocol(port.BaudRate, PortName, pipeReader, dependencies);
 
         public static void AddCustomProtocol(CustomProtocolDetectionDelegate detector) => customProtocolDetectors.Add(detector ?? throw new ArgumentNullException(nameof(detector)));
 
         /// <summary>detects if we are talking with a supported third party device</summary>
         public static async Task<BoardInfo?> DetectThirdPartyProtocol(
-            int baudRate, string portName, PipeReader pipeReader)
+            int baudRate, string portName, PipeReader pipeReader, Dependencies? dependencies = null)
         {
             if (baudRate != 9600)
                 return default; //all the third party devices currently supported are running at 9600<
@@ -280,7 +274,7 @@ namespace CA_DataUploaderLib
             // A cancellation token is made here rather than a simple timer since the ReadAsync function can hang
             // if a device never sends a line for it to read.
             int millisecondsTimeout = 3000;
-            using var cts = new CancellationTokenSource(millisecondsTimeout);
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(millisecondsTimeout), (dependencies ?? Dependencies.Default).TimeProvider);
             var token = cts.Token;
             foreach (var detector in customProtocolDetectors)
             {
@@ -317,12 +311,12 @@ namespace CA_DataUploaderLib
         }
 
         private Task<string> ReadLine() =>
-            ReadLine(pipeReader ?? throw new ObjectDisposedException("Closed connection detected (null pipeReader)"), PortName, ConfigSettings.MaxMillisecondsWithoutNewValues, TryReadLine);
+            ReadLine(dependencies, pipeReader ?? throw new ObjectDisposedException("Closed connection detected (null pipeReader)"), PortName, ConfigSettings.MaxMillisecondsWithoutNewValues, TryReadLine);
         //exposing this one for testing purposes
         public static async Task<string> ReadLine(
-            PipeReader pipeReader, string portName, int millisecondsTimeout, TryReadLineDelegate tryReadLine)
+            Dependencies dependencies, PipeReader pipeReader, string portName, int millisecondsTimeout, TryReadLineDelegate tryReadLine)
         {
-            using var cts = new CancellationTokenSource(millisecondsTimeout);
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(millisecondsTimeout), dependencies.TimeProvider);
             var token = cts.Token;
             try
             {
@@ -392,9 +386,9 @@ namespace CA_DataUploaderLib
 
         /// <summary>advances the reader past any empty lines and returns + advances the next line if it <paramref name="matches"/> returns <c>true</c>.</summary>
         /// <remarks>returns <c>string.Empty</c> if <paramref name="matches"/> returns <c>false</c>.</remarks>
-        static Task<string> ReadOptionalNonEmptyLine(PipeReader? pipeReader, string portName, int timeoutMilliseconds, TryReadLineDelegate tryReadLine, Func<string, bool> matches)
+        static Task<string> ReadOptionalNonEmptyLine(Dependencies dependencies, PipeReader? pipeReader, string portName, int timeoutMilliseconds, TryReadLineDelegate tryReadLine, Func<string, bool> matches)
         {
-            return ReadLine(pipeReader ?? throw new ObjectDisposedException("Closed connection detected (null pipeReader)"), portName, timeoutMilliseconds, TryOptionalRead);
+            return ReadLine(dependencies, pipeReader ?? throw new ObjectDisposedException("Closed connection detected (null pipeReader)"), portName, timeoutMilliseconds, TryOptionalRead);
 
             bool TryOptionalRead(ref ReadOnlySequence<byte> buffer, out string matchingLine) => TryReadOptionalNonEmptyLine(ref buffer, tryReadLine, matches, out matchingLine);
         }
@@ -422,7 +416,7 @@ namespace CA_DataUploaderLib
             return true;
         }
 
-        static Task<string> SkipEmptyLines(PipeReader? pipeReader, string portName, int timeoutMilliseconds, TryReadLineDelegate tryReadLine) => ReadOptionalNonEmptyLine(pipeReader, portName, timeoutMilliseconds, tryReadLine, _ => false);
+        static Task<string> SkipEmptyLines(Dependencies dependencies, PipeReader? pipeReader, string portName, int timeoutMilliseconds, TryReadLineDelegate tryReadLine) => ReadOptionalNonEmptyLine(dependencies, pipeReader, portName, timeoutMilliseconds, tryReadLine, _ => false);
         ///<returns>true if a non empty line was found, or false if more data is needed</returns>
 
         private async Task<TResult> RunWaitingForAnyOngoingReconnect<TResult>(Func<TResult> action, CancellationToken token)
@@ -467,10 +461,10 @@ namespace CA_DataUploaderLib
             public string? Calibration { get; private set; }
             public string? UpdatedCalibration { get; private set; }
 
-            private readonly HeaderDependencies Dependencies;
+            private readonly Dependencies Dependencies;
 
-            public Header() : this(HeaderDependencies.Default) { }
-            public Header(HeaderDependencies dependencies)
+            public Header() : this(Dependencies.Default) { }
+            public Header(Dependencies dependencies)
             {
                 Dependencies = dependencies;
             }
@@ -567,7 +561,7 @@ namespace CA_DataUploaderLib
                     }
                 }
 
-                await SkipEmptyLines(pipeReader, port, 2000, tryReadLine);//avoid any extra empty lines just after the full header from getting read by callers
+                await SkipEmptyLines(Dependencies, pipeReader, port, 2000, tryReadLine);//avoid any extra empty lines just after the full header from getting read by callers
                 return true;
 
                 void LogMissingHeader(string reason) => 
@@ -600,15 +594,80 @@ namespace CA_DataUploaderLib
             }
         }
 
-        public class HeaderDependencies(TimeProvider timeProvider, Action<LogID, string> logInfo, Action<LogID, string> logError, Action<LogID, string, Exception> logException)
+        public class Dependencies(
+            TimeProvider timeProvider, Action<LogID, string> logInfo, Action<LogID, string> logError, 
+            Action<LogID, string, Exception> logException, Action<LogID, string> logData,
+            IConnectionManager connectionManager)
         {
-            internal static readonly HeaderDependencies Default = new(TimeProvider.System, CALog.LogInfoAndConsoleLn, CALog.LogErrorAndConsoleLn, CALog.LogErrorAndConsoleLn);
+            public Dependencies(TimeProvider timeProvider, Action<LogID, string> log, IConnectionManager connectionManager) :
+                this(timeProvider, log, log, (id, msg, ex) => log(id, $"{msg}{Environment.NewLine}{ex}"), log, connectionManager)
+            { 
+            }
+            internal static Dependencies Default { get; } = new(
+                TimeProvider.System, CALog.LogInfoAndConsoleLn, CALog.LogErrorAndConsoleLn, CALog.LogErrorAndConsoleLn, CALog.LogData,
+                SerialPortConnectionManager.Default);
 
             public TimeProvider TimeProvider { get; } = timeProvider;
+            public IConnectionManager ConnectionManager { get; } = connectionManager;
 
             internal void LogError(LogID logId, string message) => logError(logId, message);
             internal void LogException(LogID logId, string message, Exception exception) => logException(logId, message, exception);
             internal void LogInfo(LogID logId, string message) => logInfo(logId, message);
+            internal void LogData(LogID logId, string message) => logData(logId, message);
+        }
+
+        public interface IConnectionManager
+        {
+            public IConnection NewConnection(string name, int baudRate, bool enableDtrRts);
+        }
+
+        public interface IConnection
+        {
+            int ReadTimeout { get; set; }
+            bool IsOpen { get; }
+            int BaudRate { get; }
+
+            void Close();
+            PipeReader GetPipeReader();
+            void WriteLine(string msg);
+        }
+
+        private class SerialPortConnectionManager() : IConnectionManager
+        {
+            public static IConnectionManager Default { get; } = new SerialPortConnectionManager();
+
+            public IConnection NewConnection(string name, int baudRate, bool enableDtrRts) => new SerialPortConnection(name, baudRate, enableDtrRts);
+
+            private class SerialPortConnection : IConnection
+            {
+                private readonly SerialPort port;
+
+                public SerialPortConnection(string name, int baudRate, bool enableDtrRts)
+                {
+                    port = new(name);
+                    port.BaudRate = 1;
+                    port.DtrEnable = enableDtrRts;
+                    port.RtsEnable = enableDtrRts;
+                    port.BaudRate = baudRate;
+                    port.ReadTimeout = 2000;
+                    port.WriteTimeout = 2000;
+                }
+
+                public int ReadTimeout { get => port.ReadTimeout; set => port.ReadTimeout = value; }
+                public bool IsOpen => port.IsOpen;
+                public int BaudRate => port.BaudRate;
+
+                public void Close() => port.Close();
+                public PipeReader GetPipeReader()
+                {
+                    port.Open();
+                    var reader = PipeReader.Create(port.BaseStream);
+                    Thread.Sleep(100); // it needs to wait that the board registers that the COM port has been opened before sending commands (work arounds issue when first opening the connection and sending serial).
+                    return reader;
+                }
+
+                public void WriteLine(string msg) => port.WriteLine(msg);
+            }
         }
     }
 }

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -603,7 +603,7 @@ namespace CA_DataUploaderLib
                 this(timeProvider, log, log, (id, msg, ex) => log(id, $"{msg}{Environment.NewLine}{ex}"), log, connectionManager)
             { 
             }
-            internal static Dependencies Default { get; } = new(
+            public static Dependencies Default { get; } = new(
                 TimeProvider.System, CALog.LogInfoAndConsoleLn, CALog.LogErrorAndConsoleLn, CALog.LogErrorAndConsoleLn, CALog.LogData,
                 SerialPortConnectionManager.Default);
 

--- a/CA_DataUploaderLib/SingleNodeRunner.cs
+++ b/CA_DataUploaderLib/SingleNodeRunner.cs
@@ -25,9 +25,9 @@ namespace CA_DataUploaderLib
                     var commands = events?.Where(e => e.EventType == (byte)EventType.Command);
                     var stringCommands = commands is not null && commands.Any() ? commands.Select(e => e.Data).ToList() : emptyCommands;
                     cmdHandler.MakeDecision(cmdHandler.GetNodeInputs().Concat(cmdHandler.GetGlobalInputs()).ToList(), DateTime.UtcNow, ref vector, stringCommands);
-                    vector = new([.. vector.Data], vector.Timestamp, events);
                     cmdHandler.OnNewVectorReceived(vector);
-                    await Task.WhenAny(sendThrottle.WaitForNextTickAsync(token).AsTask());//whenany for no exceptions on cancel
+                    vector = new([.. vector.Data], vector.Timestamp, events); //we take a copy so no further changes are done to the vector shared via OnNewVectorReceived
+                    await Task.WhenAny(sendThrottle.WaitForNextTickAsync(token).AsTask());//Task.WhenAny for no exceptions on cancel
                 }
 
                 CALog.LogInfoAndConsoleLn(LogID.A, "Waiting for subsystems to stop");

--- a/UnitTests/ChannelReaderExtensionsTests.cs
+++ b/UnitTests/ChannelReaderExtensionsTests.cs
@@ -2,6 +2,7 @@
 using CA_DataUploaderLib;
 using CA_DataUploaderLib.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ namespace UnitTests
         public async Task ReadWithSoftTimeoutReturnsNull()
         {
             var channel = Channel.CreateUnbounded<DataVector>();
-            Assert.IsNull(await channel.Reader.ReadWithSoftTimeout(10, CancellationToken.None));
+            Assert.IsNull(await channel.Reader.ReadWithSoftTimeout(10, TimeProvider.System, CancellationToken.None));
         }
 
         [TestMethod]
@@ -23,14 +24,14 @@ namespace UnitTests
         {
             using var cts = new CancellationTokenSource();
             var channel = Channel.CreateUnbounded<DataVector>();
-            Assert.IsNull(await channel.Reader.ReadWithSoftTimeout(10, cts.Token));
+            Assert.IsNull(await channel.Reader.ReadWithSoftTimeout(10, TimeProvider.System, cts.Token));
         }
 
         [TestMethod]
         public async Task ReadBeforeTimeoutReturnsData()
         {
             var channel = Channel.CreateUnbounded<DataVector>();
-            var task = channel.Reader.ReadWithSoftTimeout(10, CancellationToken.None);
+            var task = channel.Reader.ReadWithSoftTimeout(10, TimeProvider.System, CancellationToken.None);
             channel.Writer.TryWrite(new(new[]{1d}, new(2021,1,1)));
             Assert.IsNotNull(await task);
         }

--- a/UnitTests/IOConfFileLoaderTests.cs
+++ b/UnitTests/IOConfFileLoaderTests.cs
@@ -1,16 +1,19 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CA_DataUploaderLib.IOconf;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace UnitTests
 {
     [TestClass]
     public class IOconfFileLoaderTests
     {
+        private static IEnumerable<IOconfRow> ParseLines(string[] lines) => IOconfFileLoader.ParseLines(IOconfFileLoader.Loader, lines);
+
         [TestMethod]
         public void CanLoadAccountLine()
         {
-            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "Account;john;john.doe@example.com;johndoepass" });
+            var rowsEnum = ParseLines(["Account;john;john.doe@example.com;johndoepass"]);
             var rows = rowsEnum.ToArray();
             Assert.AreEqual(1, rows.Length);
             Assert.IsInstanceOfType(rows[0], typeof(IOconfAccount));
@@ -21,7 +24,7 @@ namespace UnitTests
         [TestMethod]
         public void CanLoadMathLine()
         {
-            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "Math;mymath;heater1 + 5" });
+            var rowsEnum = ParseLines(["Math;mymath;heater1 + 5"]);
             var rows = rowsEnum.ToArray();
             Assert.AreEqual(1, rows.Length);
             Assert.IsInstanceOfType(rows[0], typeof(IOconfMath));
@@ -33,7 +36,7 @@ namespace UnitTests
         [TestMethod]
         public void CanLoadGenericOutputLine()
         {
-            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "GenericOutput;generic_ac_on;realacbox2;0;p1 $heater1_onoff 3" });
+            var rowsEnum = ParseLines(["GenericOutput;generic_ac_on;realacbox2;0;p1 $heater1_onoff 3"]);
             var rows = rowsEnum.ToArray();
             Assert.AreEqual(1, rows.Length);
             Assert.IsInstanceOfType(rows[0], typeof(IOconfGenericOutput));
@@ -47,7 +50,7 @@ namespace UnitTests
         [TestMethod]
         public void CanLoadGenericOutputLineWithBraces()
         {
-            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "GenericOutput;generic_ac_on;realacbox2;0;p1 on 3 ${heater1_onoff}00%" });
+            var rowsEnum = ParseLines(["GenericOutput;generic_ac_on;realacbox2;0;p1 on 3 ${heater1_onoff}00%"]);
             var rows = rowsEnum.ToArray();
             Assert.AreEqual(1, rows.Length);
             Assert.IsInstanceOfType(rows[0], typeof(IOconfGenericOutput));
@@ -62,7 +65,7 @@ namespace UnitTests
         public void CanLoadCustomConfigWithoutMixingPrefix()
         {
             IOconfFileLoader.Loader.AddLoader("Mathing", (row, lineIndex) => new IOConfMathing(row, lineIndex));
-            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "Mathing;mymath;heater1 + 5" });
+            var rowsEnum = ParseLines(["Mathing;mymath;heater1 + 5"]);
             var rows = rowsEnum.ToArray();
             Assert.AreEqual(1, rows.Length);
             Assert.IsInstanceOfType(rows[0], typeof(IOConfMathing));
@@ -71,7 +74,7 @@ namespace UnitTests
         [TestMethod]
         public void CanLoadCurrentLine()
         {
-            var rowsEnum = IOconfFileLoader.ParseLines(new[] { "Current;current_ct01;ct01;2;300" });
+            var rowsEnum = ParseLines(["Current;current_ct01;ct01;2;300"]);
             var rows = rowsEnum.ToArray();
             Assert.AreEqual(1, rows.Length);
             Assert.IsInstanceOfType(rows[0], typeof(IOconfCurrent));

--- a/UnitTests/MCUBoardTests.cs
+++ b/UnitTests/MCUBoardTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Pipelines;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using CA_DataUploaderLib;
 using Microsoft.Extensions.Time.Testing;
@@ -272,7 +273,7 @@ Some unexpected failure
 
 
 
-        private static Task<string> ReadLine(PipeReader reader) => MCUBoard.ReadLine(MCUBoard.Dependencies.Default, reader, "abc", 16, TryReadLine);
+        private static Task<string> ReadLine(PipeReader reader) => MCUBoard.ReadLine(MCUBoard.Dependencies.Default, reader, "abc", 16, TryReadLine, CancellationToken.None);
         private static ValueTask<FlushResult> Write(PipeWriter writer, string data) => Write(writer, Encoding.ASCII.GetBytes(data));
         private static ValueTask<FlushResult> Write(PipeWriter writer, byte[] bytes)
         {


### PR DESCRIPTION
- Fixed: message about missing board with custom writes enabled was logged regardless of the setting
- removed the redundant "Stale sensor detected" that happens on some cases where report that we lost connection to a board / are attempting to reconnect
- time and logging dependencies are now injected to the CommandHandler and MCUBoard. BaseSensorBox now uses these dependencies via the CommandHandler.
- the serial port connection dependency is now injected to the MCUBoard
- added IOconfFile ctor overload that does notuse the static IOconfFileLoader.Loader