### PR TITLE
BaseSensorBox.ReadSensors: reduce "Status" send frequency

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -494,9 +494,13 @@ namespace CA_DataUploaderLib
                             timeBetweenReads = TimeSpan.FromMilliseconds(board.ConfigSettings.MillisecondsBetweenReads * 1.5);
                         if (status != _lastStatus && (status & 0x80000000) != 0) // Error?
                         {
-                            LowFrequencyLogError((args, skipMessage) => LogError(args.board, $"Board responded with error status 0x{args.status:X}{skipMessage}"), (board, status));
-                            if (_boardCustomCommands.TryGetValue(board, out var customCommandsChannel))
-                                customCommandsChannel.Writer.TryWrite("Status");
+                            LowFrequencyLogError((args, skipMessage) =>
+                            { 
+                                LogError(args.board, $"Board responded with error status 0x{args.status:X}{skipMessage}");
+                                if (_boardCustomCommands.TryGetValue(board, out var customCommandsChannel))
+                                    customCommandsChannel.Writer.TryWrite("Status");
+                            }, (board, status));
+                            
                         }
                         _lastStatus = status;
                     }


### PR DESCRIPTION
Only send "Status" to the board - as a response to seeing the error bit being set in the status byte - when we also log that it happened - to reduce the frequency of sending "Status" to a failing board.