### PR TITLE
fixed: system can run out of memory with high events rate

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -515,16 +515,16 @@ namespace CA_DataUploaderLib
                 }
             }
 
-            void LowFrequencyLogInfo<T>(Action<T, string> logAction, T args) => LowFrequencyLog(logAction, args, ref lastLogInfoTime, ref logInfoSkipped);
-            void LowFrequencyLogError<T>(Action<T, string> logAction, T args) => LowFrequencyLog(logAction, args, ref lastLogErrorTime, ref logErrorSkipped);
-            void LowFrequencyMultilineMessage<T>(Action<T, string> logAction, T args) => LowFrequencyLog(logAction, args, ref lastMultilineMessageTime, ref multilineMessageSkipped);
+            void LowFrequencyLogInfo<T>(Action<T, string> logAction, T args) => LowFrequencyLog(logAction, "info", args, ref lastLogInfoTime, ref logInfoSkipped);
+            void LowFrequencyLogError<T>(Action<T, string> logAction, T args) => LowFrequencyLog(logAction, "error", args, ref lastLogErrorTime, ref logErrorSkipped);
+            void LowFrequencyMultilineMessage<T>(Action<T, string> logAction, T args) => LowFrequencyLog(logAction, "multiline", args, ref lastMultilineMessageTime, ref multilineMessageSkipped);
 
-            void LowFrequencyLog<T>(Action<T, string> logAction, T args, ref long lastLogTime, ref int logSkipped)
+            void LowFrequencyLog<T>(Action<T, string> logAction, string logType, T args, ref long lastLogTime, ref int logSkipped)
             {
                 if (lastLogTime != 0 && _cmd.Time.GetElapsedTime(lastLogTime).TotalMinutes < 5)
                 {
                     if (logSkipped++ == 0)
-                        logAction(args, $"{Environment.NewLine}Skipping further messages for this board (max 2 messages every 5 minutes)");
+                        logAction(args, $"{Environment.NewLine}Skipping further messages for this board (max 2 {logType} messages every 5 minutes)");
                     return;
                 }
 

--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -290,7 +290,7 @@ namespace CA_DataUploaderLib
         /// <remarks>
         /// If events are created at a higher rate than the host processes some events will never been returned by this method.
         /// Subsystems normally throttle the error generation rate, but if some code path not doing that
-        /// sees repeating errors that causes more than 1k to be pending, the oldest events are dropped/skipped.
+        /// sees repeating errors that causes more than 200 events to be pending, the oldest events are dropped/skipped.
         /// </remarks>
         public List<EventFiredArgs>? DequeueEvents(int max = int.MaxValue)
         {


### PR DESCRIPTION
fixed: system can run out of memory when events are generated at a higher rate than they are processed

The most likely scenario is logging in cases of non throttled recurring failures that report errors at a high rate without any throttling), combined with distributed hosts that throttle the processing rate of events gathered from subsystems via CommandHandler.DequeueEvents.

Other changes:
- added the log type to the max 2 messages in 5 minutes message to make it clearer that it is a limit x type of message