### PR TITLE
InputBased.Clone(): don't clone the timestamp, but use the current time

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -790,7 +790,7 @@ namespace CA_DataUploaderLib
             NodeUnreachable = -1, // can be used by distributed deployments to indicate the node that has the board is unreachable
             Disconnected = 0, // we are not currently connected to the board
             Connecting = 1, // we are attempting to reconnect to the board
-            Connected = 2, // we have succesfully connected to the board and will soon be attempting to read from it
+            Connected = 2, // we have successfully connected to the board and will soon be attempting to read from it
             ReadError = 3, // there are unexpected exceptions communicating with the board
             NoDataAvailable = 4, // we are connected to the box, but we have not received for 150ms+
             ReturningNonValues = 5, // we are getting data from the box, but these are not values lines

--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -248,14 +248,7 @@ namespace CA_DataUploaderLib
         {
             var subsystem = args[0].ToLower();
             var isMainCommand = subsystem == mainSubsystem;
-            StringBuilder sb;
-            if (isMainCommand)
-            {
-                sb = new StringBuilder($"NAME      {GetAvgLoopTime(),4:N0}           ");
-                sb.AppendLine();
-            }
-            else
-                sb = new StringBuilder();
+            StringBuilder sb = new();
             foreach (var t in _localValues)
             {
                 string? subsystemOverride = t.Input.SubsystemOverride;
@@ -267,7 +260,6 @@ namespace CA_DataUploaderLib
             _cmd.Logger.LogInfo(LogID.A, sb.ToString());
         }
 
-        private double GetAvgLoopTime() => _values.Average(x => x.ReadSensor_LoopTime);
         private async Task RunBoardLoops((IOconfMap map, SensorSample.InputBased[] values, int boardStateIndexInFullVector)[] boards, CancellationToken token)
         {
             long start = _cmd.Time.GetTimestamp();

--- a/CA_DataUploaderLib/SensorSample.cs
+++ b/CA_DataUploaderLib/SensorSample.cs
@@ -21,7 +21,6 @@ namespace CA_DataUploaderLib
             get => _timeStamp;
             set => _timeStamp = value;
         } 
-        public double ReadSensor_LoopTime { get; private set; }  // in milliseconds. 
         internal int InvalidReadsRemainingAttempts { get; set; } = 3000; //3k attempts = 5 (mins) x 60 (seconds) x 10 (cycles x second). The attempts are reset whenever we get valid values
 
         public SensorSample(IOconfInput input, double value = 0)

--- a/CA_DataUploaderLib/SensorSample.cs
+++ b/CA_DataUploaderLib/SensorSample.cs
@@ -19,7 +19,7 @@ namespace CA_DataUploaderLib
         public DateTime TimeStamp 
         { 
             get => _timeStamp;
-            set { ReadSensor_LoopTime = value.Subtract(_timeStamp).TotalMilliseconds; _timeStamp = value; }
+            set => _timeStamp = value;
         } 
         public double ReadSensor_LoopTime { get; private set; }  // in milliseconds. 
         internal int InvalidReadsRemainingAttempts { get; set; } = 3000; //3k attempts = 5 (mins) x 60 (seconds) x 10 (cycles x second). The attempts are reset whenever we get valid values

--- a/CA_DataUploaderLib/SensorSample.cs
+++ b/CA_DataUploaderLib/SensorSample.cs
@@ -18,7 +18,7 @@ namespace CA_DataUploaderLib
         private DateTime _timeStamp;
         public DateTime TimeStamp 
         { 
-            get { return _timeStamp; }
+            get => _timeStamp;
             set { ReadSensor_LoopTime = value.Subtract(_timeStamp).TotalMilliseconds; _timeStamp = value; }
         } 
         public double ReadSensor_LoopTime { get; private set; }  // in milliseconds. 
@@ -45,14 +45,7 @@ namespace CA_DataUploaderLib
             public new IOconfInput Input => base.Input!;
 
             public bool HasSpecialDisconnectValue() => Input.IsSpecialDisconnectValue(Value);
-            public InputBased Clone()
-            {
-                return new InputBased(Input, Value)
-                {
-                    _timeStamp = TimeStamp,
-                    ReadSensor_LoopTime = ReadSensor_LoopTime
-                };
-            }
+            public InputBased Clone() => new(Input, Value);
         }
     }
 }


### PR DESCRIPTION
Otherwise `LegacyFilter` is not able to remove old samples from its queue causing a memory leak in the case where no new samples are read (sensor disconnected).