### PR TITLE
Made GenericOutput able to reference multiple target fields in the command template

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -219,7 +219,7 @@ namespace CA_DataUploaderLib
             async Task WriteAction(DataVector? vector, MCUBoard board, CancellationToken token)
             {
                 vectorIndices ??= getIndices();
-                lastAction ??= new LastAction(vectorIndices, defaultTarget, repeatMilliseconds);
+                lastAction ??= new LastAction(vectorIndices, repeatMilliseconds);
                 defaultTargets ??= vectorIndices.Select(i => defaultTarget).ToList();
 
                 if (vector == null)

--- a/CA_DataUploaderLib/GenericSensorBox.cs
+++ b/CA_DataUploaderLib/GenericSensorBox.cs
@@ -10,7 +10,7 @@ namespace CA_DataUploaderLib
             var outputs = ioconf.GetGenericOutputs();
             foreach (var output in outputs.Where(o => o.Map.IsLocalBoard && o.Map.McuBoard != null))
                 RegisterBoardWriteActions(
-                    output.Map.McuBoard!, output, output.DefaultValue, output.TargetField, (_, v) => output.GetCommand(v), output.RepeatMilliseconds);
+                    output.Map.McuBoard!, output, output.DefaultValue, output.TargetFields, (_, v) => output.GetCommand(v), output.RepeatMilliseconds);
         }
     }
 }

--- a/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
@@ -40,11 +40,8 @@ namespace CA_DataUploaderLib.IOconf
         /// </summary>
         /// <param name="values">A list of values - the order corresponding to the order of TargetFields/TargetFieldsWithPrefix.</param>
         /// <returns>The generated command string.</returns>
-        public string GetCommand(List<double> values)
+        public string GetCommand(IEnumerable<double> values)
         {
-            if (TargetFieldsWithPrefix.Count != values.Count)
-                throw new ArgumentException($"Mismatch between number of target fields and values. Expected {TargetFieldsWithPrefix.Count}, got {values.Count}.");
-
             var command = CommandTemplate;
             var index = 0;
             foreach (var value in values)

--- a/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfGenericOutput.cs
@@ -1,6 +1,8 @@
 using CA_DataUploaderLib.Extensions;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace CA_DataUploaderLib.IOconf
@@ -8,7 +10,7 @@ namespace CA_DataUploaderLib.IOconf
     public class IOconfGenericOutput : IOconfOutput
     {
         private static readonly Regex CommandRegex = new(@"\$(?:{(\w*)}|(\w*))");
-        private readonly string targetFieldWithPrefix;
+        
         public IOconfGenericOutput(string row, int lineNum) : base(row, lineNum, "GenericOutput", false, BoardSettings.Default) 
         {
             Format = "GenericOutput;OutputName;BoxName;DefaultValue;command with $field;[RepeatMilliseconds]";
@@ -20,26 +22,59 @@ namespace CA_DataUploaderLib.IOconf
             DefaultValue = defaultValue;
 
             CommandTemplate = values[4];
-            var match = CommandRegex.Match(CommandTemplate);
-            if (!match.Success || match.Groups.Count != 3)
-                throw new FormatException($"Failed to find command $field in {Row}. Expected format: {Format}");
-            targetFieldWithPrefix = match.Groups[0].Value;
-            if (match.Groups[1].Success)
-                TargetField = match.Groups[1].Value;
-            else if (match.Groups[2].Success)
-                TargetField = match.Groups[2].Value;
-            else
-                throw new FormatException($"Failed to find command $field in {Row}. Expected format: {Format}");
+            (TargetFields, TargetFieldsWithPrefix) = ParseTargetFields(CommandTemplate);
 
             RepeatMilliseconds = values.Count < 6 
                 ? 1000 
                 : int.TryParse(values[5], out var repeatMs) ? repeatMs : throw new FormatException($"Failed to parse repeat milliseconds {Row}. Expected format: {Format}");
         }
+
         public double DefaultValue { get; }
-        public string TargetField { get; }
+        public List<string> TargetFields { get; }
+        private List<string> TargetFieldsWithPrefix { get; }
         public string CommandTemplate { get; }
         public int RepeatMilliseconds { get; }
 
-        public string GetCommand(double value) => CommandTemplate.Replace(targetFieldWithPrefix, value.ToString(CultureInfo.InvariantCulture));
+        /// <summary>
+        /// Generates the command by replacing all placeholders with their corresponding values.
+        /// </summary>
+        /// <param name="values">A list of values - the order corresponding to the order of TargetFields/TargetFieldsWithPrefix.</param>
+        /// <returns>The generated command string.</returns>
+        public string GetCommand(List<double> values)
+        {
+            if (TargetFieldsWithPrefix.Count != values.Count)
+                throw new ArgumentException($"Mismatch between number of target fields and values. Expected {TargetFieldsWithPrefix.Count}, got {values.Count}.");
+
+            var command = CommandTemplate;
+            var index = 0;
+            foreach (var value in values)
+                command = command.Replace(TargetFieldsWithPrefix[index++], value.ToString(CultureInfo.InvariantCulture));
+            return command;
+        }
+
+        /// <summary>
+        /// Parses the command template to extract all placeholders for target fields.
+        /// </summary>
+        /// <param name="template">The command template string.</param>
+        /// <returns>Two lists of the target fields: without and with prefix</returns>
+        private (List<string>, List<string> withPrefix) ParseTargetFields(string template)
+        {
+            var matches = CommandRegex.Matches(template);
+            var targetFields = new List<string>();
+            var targetFieldsWithPrefix = new List<string>();
+            foreach (var match in matches.Cast<Match>())
+            {
+                targetFieldsWithPrefix.Add(match.Groups[0].Value);
+                if (match.Groups[1].Success)
+                    targetFields.Add(match.Groups[1].Value); //with curly braces
+                else if (match.Groups[2].Success)
+                    targetFields.Add(match.Groups[2].Value); //without
+                else
+                    throw new FormatException($"Failed to find command $field in {Row}. Expected format: {Format}");
+            }
+            if (targetFields.Count == 0)
+                throw new FormatException($"Failed to find command $field in {Row}. Expected format: {Format}");
+            return (targetFields, targetFieldsWithPrefix);
+        }
     }
 }

--- a/CA_DataUploaderLib/LastAction.cs
+++ b/CA_DataUploaderLib/LastAction.cs
@@ -10,42 +10,42 @@ namespace CA_DataUploaderLib
         private readonly TimeProvider timeProvider;
         private long lastActionExecutedTime;
 
-        public LastAction(double target, int repeatMilliseconds) : this(target, repeatMilliseconds, TimeProvider.System) { }
-        public LastAction(double target, int repeatMilliseconds, TimeProvider timeProvider) : this([target], repeatMilliseconds, timeProvider) { }
-        public LastAction(IEnumerable<double> targets, int repeatMilliseconds) : this(targets, repeatMilliseconds, TimeProvider.System) { }
-        public LastAction(IEnumerable<double> targets, int repeatMilliseconds, TimeProvider timeProvider)
+        public LastAction(int targetIndex, double defaultValue, int repeatMilliseconds) : this(targetIndex, defaultValue, repeatMilliseconds, TimeProvider.System) { }
+        public LastAction(int targetIndex, double defaultValue, int repeatMilliseconds, TimeProvider timeProvider) : this([targetIndex], defaultValue, repeatMilliseconds, timeProvider) { }
+        public LastAction(IEnumerable<int> targetIndices, double defaultValue, int repeatMilliseconds) : this(targetIndices, defaultValue, repeatMilliseconds, TimeProvider.System) { }
+        public LastAction(IEnumerable<int> targetIndices, double defaultValue, int repeatMilliseconds, TimeProvider timeProvider)
         {
-            Targets = targets;
+            Indices = targetIndices;
+            Vector = [.. targetIndices.Select(i => defaultValue)];
             this.repeatMilliseconds = repeatMilliseconds;
             this.timeProvider = timeProvider;
         }
 
-        public IEnumerable<double> Targets { get; private set; }
-        public DateTime TimeToRepeat { get; private set; }
-        
+        private double[] Vector { get; set; }
+        private IEnumerable<int> Indices { get; set; }
+        private DateTime TimeToRepeat { get; set; }
+
+        public IEnumerable<double> Targets => Indices.Select(i => Vector[i]);
+
         /// <remarks>
         /// We determine whether the last action has expired (should be repeated) by checking the time passed in 2 different ways,
         /// one based purely on the vector times and another based on the local system time. We do this to avoid the related 
         /// actuator from stopping if either of these 2 mechanisms and related fields are affected by a radiation caused bit flip.
         /// Note however that there are many other ways that bit flips could affect related actuations and also the functioning of this very class.
         /// </remarks>
-        public bool ChangedOrExpired(double newTarget, DateTime currentVectorTime) => ChangedOrExpired([newTarget], currentVectorTime);
-        public bool ChangedOrExpired(IEnumerable<double> newTargets, DateTime currentVectorTime) =>
-            !Targets.SequenceEqual(newTargets) || (repeatMilliseconds > -1 && timeProvider.GetElapsedTime(lastActionExecutedTime).TotalMilliseconds >= repeatMilliseconds) || currentVectorTime >= TimeToRepeat;
-        
-        public void ExecutedNewAction(double target, DateTime currentVectorTime) => ExecutedNewAction([target], currentVectorTime);
-        public void ExecutedNewAction(IEnumerable<double> targets, DateTime currentVectorTime)
+        public bool ChangedOrExpired(double[] newVector, DateTime currentVectorTime) =>
+            Indices.Any(i => Vector[i] != newVector[i]) || (repeatMilliseconds > -1 && timeProvider.GetElapsedTime(lastActionExecutedTime).TotalMilliseconds >= repeatMilliseconds) || currentVectorTime >= TimeToRepeat;
+
+        public void ExecutedNewAction(double[] newVector, DateTime currentVectorTime)
         {
-            Targets = targets;
+            Vector = newVector;
             TimeToRepeat = repeatMilliseconds > -1 ? currentVectorTime.AddMilliseconds(repeatMilliseconds) : DateTime.MaxValue;
             lastActionExecutedTime = timeProvider.GetTimestamp();
         }
 
-        public void TimedOutWaitingForDecision(double target) => TimedOutWaitingForDecision([target]);
-        public void TimedOutWaitingForDecision(IEnumerable<double> targets)
+        public void TimedOutWaitingForDecision()
         {
             //DateTime.MinValue forces execution on the next vector / also note we don't restart time running for the same reason.
-            Targets = targets;
             TimeToRepeat = DateTime.MinValue;
         }
 

--- a/CA_DataUploaderLib/LastAction.cs
+++ b/CA_DataUploaderLib/LastAction.cs
@@ -10,18 +10,17 @@ namespace CA_DataUploaderLib
         private readonly TimeProvider timeProvider;
         private long lastActionExecutedTime;
 
-        public LastAction(int targetIndex, double defaultValue, int repeatMilliseconds) : this(targetIndex, defaultValue, repeatMilliseconds, TimeProvider.System) { }
-        public LastAction(int targetIndex, double defaultValue, int repeatMilliseconds, TimeProvider timeProvider) : this([targetIndex], defaultValue, repeatMilliseconds, timeProvider) { }
-        public LastAction(IEnumerable<int> targetIndices, double defaultValue, int repeatMilliseconds) : this(targetIndices, defaultValue, repeatMilliseconds, TimeProvider.System) { }
-        public LastAction(IEnumerable<int> targetIndices, double defaultValue, int repeatMilliseconds, TimeProvider timeProvider)
+        public LastAction(int targetIndex, int repeatMilliseconds) : this(targetIndex, repeatMilliseconds, TimeProvider.System) { }
+        public LastAction(int targetIndex, int repeatMilliseconds, TimeProvider timeProvider) : this([targetIndex], repeatMilliseconds, timeProvider) { }
+        public LastAction(IEnumerable<int> targetIndices, int repeatMilliseconds) : this(targetIndices, repeatMilliseconds, TimeProvider.System) { }
+        public LastAction(IEnumerable<int> targetIndices, int repeatMilliseconds, TimeProvider timeProvider)
         {
             Indices = [.. targetIndices];
-            Vector = [.. targetIndices.Select(i => defaultValue)];
             this.repeatMilliseconds = repeatMilliseconds;
             this.timeProvider = timeProvider;
         }
 
-        private double[] Vector { get; set; }
+        private double[] Vector { get; set; } = [];
         private int[] Indices { get; set; }
         private DateTime TimeToRepeat { get; set; }
 
@@ -34,7 +33,7 @@ namespace CA_DataUploaderLib
         /// Note however that there are many other ways that bit flips could affect related actuations and also the functioning of this very class.
         /// </remarks>
         public bool ChangedOrExpired(double[] newVector, DateTime currentVectorTime) =>
-            Indices.Any(i => Vector[i] != newVector[i]) || (repeatMilliseconds > -1 && timeProvider.GetElapsedTime(lastActionExecutedTime).TotalMilliseconds >= repeatMilliseconds) || currentVectorTime >= TimeToRepeat;
+            Indices.Any(i => Vector.Length == 0 || Vector[i] != newVector[i]) || (repeatMilliseconds > -1 && timeProvider.GetElapsedTime(lastActionExecutedTime).TotalMilliseconds >= repeatMilliseconds) || currentVectorTime >= TimeToRepeat;
 
         public void ExecutedNewAction(double[] newVector, DateTime currentVectorTime)
         {

--- a/CA_DataUploaderLib/LastAction.cs
+++ b/CA_DataUploaderLib/LastAction.cs
@@ -15,14 +15,14 @@ namespace CA_DataUploaderLib
         public LastAction(IEnumerable<int> targetIndices, double defaultValue, int repeatMilliseconds) : this(targetIndices, defaultValue, repeatMilliseconds, TimeProvider.System) { }
         public LastAction(IEnumerable<int> targetIndices, double defaultValue, int repeatMilliseconds, TimeProvider timeProvider)
         {
-            Indices = targetIndices;
+            Indices = [.. targetIndices];
             Vector = [.. targetIndices.Select(i => defaultValue)];
             this.repeatMilliseconds = repeatMilliseconds;
             this.timeProvider = timeProvider;
         }
 
         private double[] Vector { get; set; }
-        private IEnumerable<int> Indices { get; set; }
+        private int[] Indices { get; set; }
         private DateTime TimeToRepeat { get; set; }
 
         public IEnumerable<double> Targets => Indices.Select(i => Vector[i]);

--- a/CA_DataUploaderLib/LastAction.cs
+++ b/CA_DataUploaderLib/LastAction.cs
@@ -33,7 +33,9 @@ namespace CA_DataUploaderLib
         /// Note however that there are many other ways that bit flips could affect related actuations and also the functioning of this very class.
         /// </remarks>
         public bool ChangedOrExpired(double[] newVector, DateTime currentVectorTime) =>
-            Indices.Any(i => Vector.Length == 0 || Vector[i] != newVector[i]) || (repeatMilliseconds > -1 && timeProvider.GetElapsedTime(lastActionExecutedTime).TotalMilliseconds >= repeatMilliseconds) || currentVectorTime >= TimeToRepeat;
+            Vector.Length != newVector.Length
+            || Indices.Any(i => Vector[i] != newVector[i]) || (repeatMilliseconds > -1 && timeProvider.GetElapsedTime(lastActionExecutedTime).TotalMilliseconds >= repeatMilliseconds)
+            || currentVectorTime >= TimeToRepeat;
 
         public void ExecutedNewAction(double[] newVector, DateTime currentVectorTime)
         {

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -19,9 +19,9 @@ namespace CA_DataUploaderLib
         {
             //we ignore remote boards and boards missing during the start sequence (as we don't have auto reconnect logic yet for those). Note the BaseSensorBox already reports the missing local boards.
             foreach (var port in ioconf.GetEntries<IOconfOut230Vac>().Where(p => p.Map.IsLocalBoard && p.Map.McuBoard != null))
-                RegisterBoardWriteActions(port.Map.McuBoard!, port, 0, port.Name + "_onoff", GetCommand);
+                RegisterBoardWriteActions(port.Map.McuBoard!, port, 0, [port.Name + "_onoff"], GetCommand);
 
-            static string GetCommand(int portNumber, double target) => target > 0.0 ? $"p{portNumber} on 2 {target:0%}" : $"p{portNumber} off";
+            static string GetCommand(int portNumber, List<double> targets) => targets[0] > 0.0 ? $"p{portNumber} on 2 {targets[0]:0%}" : $"p{portNumber} off";
         }
 
         public static void Initialize(IIOconf ioconf, CommandHandler cmd)

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -21,7 +21,7 @@ namespace CA_DataUploaderLib
             foreach (var port in ioconf.GetEntries<IOconfOut230Vac>().Where(p => p.Map.IsLocalBoard && p.Map.McuBoard != null))
                 RegisterBoardWriteActions(port.Map.McuBoard!, port, 0, [port.Name + "_onoff"], GetCommand);
 
-            static string GetCommand(int portNumber, List<double> targets) => targets[0] > 0.0 ? $"p{portNumber} on 2 {targets[0]:0%}" : $"p{portNumber} off";
+            static string GetCommand(int portNumber, IEnumerable<double> targets) => targets.ElementAtOrDefault(0) > 0.0 ? $"p{portNumber} on 2 {targets.ElementAtOrDefault(0):0%}" : $"p{portNumber} off";
         }
 
         public static void Initialize(IIOconf ioconf, CommandHandler cmd)

--- a/CA_DataUploaderLib/SwitchBoardController.cs
+++ b/CA_DataUploaderLib/SwitchBoardController.cs
@@ -21,7 +21,7 @@ namespace CA_DataUploaderLib
             foreach (var port in ioconf.GetEntries<IOconfOut230Vac>().Where(p => p.Map.IsLocalBoard && p.Map.McuBoard != null))
                 RegisterBoardWriteActions(port.Map.McuBoard!, port, 0, [port.Name + "_onoff"], GetCommand);
 
-            static string GetCommand(int portNumber, IEnumerable<double> targets) => targets.ElementAtOrDefault(0) > 0.0 ? $"p{portNumber} on 2 {targets.ElementAtOrDefault(0):0%}" : $"p{portNumber} off";
+            static string GetCommand(int portNumber, IEnumerable<double> targets) => targets.SingleOrDefault() > 0.0 ? $"p{portNumber} on 2 {targets.SingleOrDefault():0%}" : $"p{portNumber} off";
         }
 
         public static void Initialize(IIOconf ioconf, CommandHandler cmd)

--- a/UnitTests/IOconfFileTests.cs
+++ b/UnitTests/IOconfFileTests.cs
@@ -190,8 +190,8 @@ RedundantSensors;redundant;expandtag{ovenheaters}
             var output = (IOconfGenericOutput)rows[1];
             Assert.AreEqual("generic_ac_on", output.Name);
             Assert.AreEqual(0, output.DefaultValue);
-            Assert.AreEqual("heater1_onoff", output.TargetField);
-            Assert.AreEqual("p1 5 3", output.GetCommand(5));
+            CollectionAssert.AreEqual(new List<string> { "heater1_onoff" }, output.TargetFields);
+            Assert.AreEqual("p1 5 3", output.GetCommand([5]));
         }
 
         [TestMethod]
@@ -204,8 +204,8 @@ RedundantSensors;redundant;expandtag{ovenheaters}
             var output = (IOconfGenericOutput)rows[0];
             Assert.AreEqual("generic_ac_on", output.Name);
             Assert.AreEqual(0, output.DefaultValue);
-            Assert.AreEqual("heater1_onoff", output.TargetField);
-            Assert.AreEqual("p1 on 3 100%", output.GetCommand(1));
+            CollectionAssert.AreEqual(new List<string> { "heater1_onoff" }, output.TargetFields);
+            Assert.AreEqual("p1 on 3 100%", output.GetCommand([1]));
         }
 
         [TestMethod]

--- a/UnitTests/IOconfGenericOutputTests.cs
+++ b/UnitTests/IOconfGenericOutputTests.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CA_DataUploaderLib.IOconf;
+using System.Collections.Generic;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class IOconfGenericOutputTests
+    {
+
+        [TestMethod]
+        public void TargetFieldsTest()
+        {
+            // Arrange + act
+            var sut = new IOconfGenericOutput("GenericOutput; genericTest; box; 0; ${field_1} p1 $field_2 field_2 $field_1 ${field_3}; -1", 0);
+
+            // Assert
+            CollectionAssert.AreEqual(new List<string> { "field_1", "field_2", "field_1", "field_3" }, sut.TargetFields);
+        }
+
+        [TestMethod]
+        public void GetCommandTest()
+        {
+            // Arrange
+            var sut = new IOconfGenericOutput("GenericOutput; genericTest; box; 0; ${field_1} p1 $field_2 field_2 $field_1 1; -1", 0);
+            
+            // Act
+            var command = sut.GetCommand([2.1, 3.2, 2.1]);
+            
+            // Assert
+            Assert.AreEqual("2.1 p1 3.2 field_2 2.1 1", command);
+        }
+    }
+}

--- a/UnitTests/IOconfGenericOutputTests.cs
+++ b/UnitTests/IOconfGenericOutputTests.cs
@@ -9,24 +9,47 @@ namespace UnitTests
     {
 
         [TestMethod]
-        public void TargetFieldsTest()
+        public void TargetFields_SingleTarget()
         {
             // Arrange + act
-            var sut = new IOconfGenericOutput("GenericOutput; genericTest; box; 0; ${field_1} p1 $field_2 field_2 $field_1 ${field_3}; -1", 0);
+            var sut = new IOconfGenericOutput("GenericOutput; genericTest; box; 0; p1 $field; -1", 0);
 
             // Assert
-            CollectionAssert.AreEqual(new List<string> { "field_1", "field_2", "field_1", "field_3" }, sut.TargetFields);
+            CollectionAssert.AreEqual(new List<string> { "field" }, sut.TargetFields);
         }
 
         [TestMethod]
-        public void GetCommandTest()
+        public void TargetFields_MultiTarget()
+        {
+            // Arrange + act
+            var sut = new IOconfGenericOutput("GenericOutput; genericTest; box; 0; ${field_1} p1 $field_2 field_2 $field_1 $field_3; -1", 0);
+
+            // Assert
+            CollectionAssert.AreEqual(new List<string> { "field_1", "field_2", "field_1", "field_3" }, sut.TargetFields, string.Join(", ", sut.TargetFields));
+        }
+
+        [TestMethod]
+        public void GetCommand_SingleTarget()
+        {
+            // Arrange
+            var sut = new IOconfGenericOutput("GenericOutput; genericTest; box; 0; p1 $field; -1", 0);
+            
+            // Act
+            var command = sut.GetCommand([3.14]);
+            
+            // Assert
+            Assert.AreEqual("p1 3.14", command);
+        }
+
+        [TestMethod]
+        public void GetCommand_MultiTarget()
         {
             // Arrange
             var sut = new IOconfGenericOutput("GenericOutput; genericTest; box; 0; ${field_1} p1 $field_2 field_2 $field_1 1; -1", 0);
-            
+
             // Act
             var command = sut.GetCommand([2.1, 3.2, 2.1]);
-            
+
             // Assert
             Assert.AreEqual("2.1 p1 3.2 field_2 2.1 1", command);
         }

--- a/UnitTests/LastActionTests.cs
+++ b/UnitTests/LastActionTests.cs
@@ -60,6 +60,23 @@ namespace UnitTests
         }
 
         [TestMethod()]
+        public void VectorOnlyMultipleTargetsNoRepeatTest()
+        {
+            var now = DateTime.UtcNow;
+            var action = new LastAction([0.1, 0.2, 0.3], -1);
+            Assert.IsTrue(action.ChangedOrExpired([0.1, 0.2, 0.3], now), "expiration is expected before executing the first action");
+            now = now.AddSeconds(1);
+            action.ExecutedNewAction([0.2, 0.3, 0.4], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.2, 0.3, 0.4], now), "2: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.2, 0.3, 0.4], now.AddYears(10)), "2: no expiration expected at 10 years");
+            Assert.IsTrue(action.ChangedOrExpired([0.3, 0.4, 0.5], now.AddMilliseconds(100)), "2: target change must be detected");
+            action.ExecutedNewAction([0.3, 0.4, 0.5], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.3, 0.4, 0.5], now), "3: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.3, 0.4, 0.5], now.AddDays(30)), "3: no expiration expected at 30 days");
+            Assert.IsTrue(action.ChangedOrExpired([0.4, 0.5, 0.6], now.AddMilliseconds(100)), "3: target change must be detected");
+        }
+
+        [TestMethod()]
         public void TimedOutWaitingForDecisionTest()
         {
             var now = DateTime.UtcNow;

--- a/UnitTests/LastActionTests.cs
+++ b/UnitTests/LastActionTests.cs
@@ -12,19 +12,19 @@ namespace UnitTests
         public void VectorOnlyChangeAndExpirationTest()
         {
             var now = DateTime.UtcNow;
-            var action = new LastAction(0, 0, 500);
-            Assert.IsTrue(action.ChangedOrExpired([0.1], now), "expiration is expected before executing the first action");
+            var action = new LastAction(2, 500);
+            Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.1, 1.0, 1.0], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
-            action.ExecutedNewAction([0.2], now);
-            Assert.IsFalse(action.ChangedOrExpired([0.2], now), "2: no expiration expected at 0s");
-            Assert.IsFalse(action.ChangedOrExpired([0.2], now.AddMilliseconds(500).AddTicks(-1)), "2: no expiration expected at 0.5s - 1 tick");
-            Assert.IsTrue(action.ChangedOrExpired([0.2], now.AddMilliseconds(500)), "2: expiration expected at 0.5s");
-            Assert.IsTrue(action.ChangedOrExpired([0.3], now.AddMilliseconds(100)), "2: target change must be detected");
-            action.ExecutedNewAction([0.3], now);
-            Assert.IsFalse(action.ChangedOrExpired([0.3], now), "3: no expiration expected at 0s");
-            Assert.IsFalse(action.ChangedOrExpired([0.3], now.AddMilliseconds(500).AddTicks(-1)), "3: no expiration expected at 0.5s - 1 tick");
-            Assert.IsTrue(action.ChangedOrExpired([0.3], now.AddMilliseconds(500)), "3: expiration expected at 0.5s");
-            Assert.IsTrue(action.ChangedOrExpired([0.4], now.AddMilliseconds(100)), "3: target change must be detected");
+            action.ExecutedNewAction([0.0, 0.0, 0.2, 1.0, 1.0], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.0, 0.0, 0.2, 1.0, 1.0], now), "2: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.0, 0.0, 0.2, 1.0, 1.0], now.AddMilliseconds(500).AddTicks(-1)), "2: no expiration expected at 0.5s - 1 tick");
+            Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.2, 1.0, 1.0], now.AddMilliseconds(500)), "2: expiration expected at 0.5s");
+            Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.3, 1.0, 1.0], now.AddMilliseconds(100)), "2: target change must be detected");
+            action.ExecutedNewAction([0.0, 0.0, 0.3, 0.0, 0.0], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.0, 0.0, 0.3, 1.0, 1.0], now), "3: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.0, 0.0, 0.3, 1.0, 1.0], now.AddMilliseconds(500).AddTicks(-1)), "3: no expiration expected at 0.5s - 1 tick");
+            Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.3, 1.0, 1.0], now.AddMilliseconds(500)), "3: expiration expected at 0.5s");
+            Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.4, 1.0, 1.0], now.AddMilliseconds(100)), "3: target change must be detected");
         }
 
         [TestMethod()]
@@ -32,7 +32,7 @@ namespace UnitTests
         {
             var now = DateTime.UtcNow;
             var time = new FakeTimeProvider();
-            var action = new LastAction(0, 0, 100, time);
+            var action = new LastAction(0, 100, time);
             Assert.IsTrue(action.ChangedOrExpired([0.1], now), "expiration is expected before executing the first action");
             action.ExecutedNewAction([0.2], now);
             Assert.IsFalse(action.ChangedOrExpired([0.2], now), "no expiration expected at 0s");
@@ -46,7 +46,7 @@ namespace UnitTests
         public void VectorOnlyNoRepeatTest()
         {
             var now = DateTime.UtcNow;
-            var action = new LastAction(0, 0, -1);
+            var action = new LastAction(0, -1);
             Assert.IsTrue(action.ChangedOrExpired([0.1], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
             action.ExecutedNewAction([0.2], now);
@@ -63,17 +63,17 @@ namespace UnitTests
         public void VectorOnlyMultipleTargetsNoRepeatTest()
         {
             var now = DateTime.UtcNow;
-            var action = new LastAction([0, 1, 2], 0, -1);
-            Assert.IsTrue(action.ChangedOrExpired([0.1, 0.2, 0.3], now), "expiration is expected before executing the first action");
+            var action = new LastAction([1, 2, 3], -1);
+            Assert.IsTrue(action.ChangedOrExpired([0.0, 0.1, 0.2, 0.3, 1.0], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
-            action.ExecutedNewAction([0.2, 0.3, 0.4], now);
-            Assert.IsFalse(action.ChangedOrExpired([0.2, 0.3, 0.4], now), "2: no expiration expected at 0s");
-            Assert.IsFalse(action.ChangedOrExpired([0.2, 0.3, 0.4], now.AddYears(10)), "2: no expiration expected at 10 years");
-            Assert.IsTrue(action.ChangedOrExpired([0.3, 0.4, 0.5], now.AddMilliseconds(100)), "2: target change must be detected");
-            action.ExecutedNewAction([0.3, 0.4, 0.5], now);
-            Assert.IsFalse(action.ChangedOrExpired([0.3, 0.4, 0.5], now), "3: no expiration expected at 0s");
-            Assert.IsFalse(action.ChangedOrExpired([0.3, 0.4, 0.5], now.AddDays(30)), "3: no expiration expected at 30 days");
-            Assert.IsTrue(action.ChangedOrExpired([0.3, 0.2, 0.5], now.AddMilliseconds(100)), "3: target change must be detected");
+            action.ExecutedNewAction([0.0, 0.2, 0.3, 0.4, 1.0], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.0, 0.2, 0.3, 0.4, 1.0], now), "2: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.0, 0.2, 0.3, 0.4, 1.0], now.AddYears(10)), "2: no expiration expected at 10 years");
+            Assert.IsTrue(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now.AddMilliseconds(100)), "2: target change must be detected");
+            action.ExecutedNewAction([0.0, 0.3, 0.4, 0.5, 1.0], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now), "3: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now.AddDays(30)), "3: no expiration expected at 30 days");
+            Assert.IsTrue(action.ChangedOrExpired([0.0, 0.3, 0.2, 0.5, 1.0], now.AddMilliseconds(100)), "3: target change must be detected");
         }
 
         [TestMethod()]
@@ -81,7 +81,7 @@ namespace UnitTests
         {
             var now = DateTime.UtcNow;
             var time = new FakeTimeProvider();
-            var action = new LastAction(0, 0, 500, time);
+            var action = new LastAction(0, 500, time);
             Assert.IsTrue(action.ChangedOrExpired([0.1], now), "expiration is expected before executing the first action");
             action.ExecutedNewAction([0.2], now);
             Assert.IsFalse(action.ChangedOrExpired([0.2], now), "no expiration expected at 0s");

--- a/UnitTests/LastActionTests.cs
+++ b/UnitTests/LastActionTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Time.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
 
 namespace UnitTests
 {
@@ -16,11 +17,13 @@ namespace UnitTests
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.1, 1.0, 1.0], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
             action.ExecutedNewAction([0.0, 0.0, 0.2, 1.0, 1.0], now);
+            CollectionAssert.AreEqual(new double[] { 0.2 }, action.Targets.ToArray());
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.0, 0.2, 1.0, 1.0], now), "2: no expiration expected at 0s");
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.0, 0.2, 1.0, 1.0], now.AddMilliseconds(500).AddTicks(-1)), "2: no expiration expected at 0.5s - 1 tick");
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.2, 1.0, 1.0], now.AddMilliseconds(500)), "2: expiration expected at 0.5s");
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.3, 1.0, 1.0], now.AddMilliseconds(100)), "2: target change must be detected");
             action.ExecutedNewAction([0.0, 0.0, 0.3, 0.0, 0.0], now);
+            CollectionAssert.AreEqual(new double[] { 0.3 }, action.Targets.ToArray());
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.0, 0.3, 1.0, 1.0], now), "3: no expiration expected at 0s");
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.0, 0.3, 1.0, 1.0], now.AddMilliseconds(500).AddTicks(-1)), "3: no expiration expected at 0.5s - 1 tick");
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.0, 0.3, 1.0, 1.0], now.AddMilliseconds(500)), "3: expiration expected at 0.5s");
@@ -67,10 +70,12 @@ namespace UnitTests
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.1, 0.2, 0.3, 1.0], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
             action.ExecutedNewAction([0.0, 0.2, 0.3, 0.4, 1.0], now);
+            CollectionAssert.AreEqual(new double[] { 0.2, 0.3, 0.4 }, action.Targets.ToArray());
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.2, 0.3, 0.4, 1.0], now), "2: no expiration expected at 0s");
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.2, 0.3, 0.4, 1.0], now.AddYears(10)), "2: no expiration expected at 10 years");
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now.AddMilliseconds(100)), "2: target change must be detected");
             action.ExecutedNewAction([0.0, 0.3, 0.4, 0.5, 1.0], now);
+            CollectionAssert.AreEqual(new double[] { 0.3, 0.4, 0.5 }, action.Targets.ToArray());
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now), "3: no expiration expected at 0s");
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now.AddDays(30)), "3: no expiration expected at 30 days");
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.3, 0.2, 0.5, 1.0], now.AddMilliseconds(100)), "3: target change must be detected");

--- a/UnitTests/LastActionTests.cs
+++ b/UnitTests/LastActionTests.cs
@@ -12,19 +12,19 @@ namespace UnitTests
         public void VectorOnlyChangeAndExpirationTest()
         {
             var now = DateTime.UtcNow;
-            var action = new LastAction(0.1, 500);
-            Assert.IsTrue(action.ChangedOrExpired(0.1, now), "expiration is expected before executing the first action");
+            var action = new LastAction(0, 0, 500);
+            Assert.IsTrue(action.ChangedOrExpired([0.1], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
-            action.ExecutedNewAction(0.2, now);
-            Assert.IsFalse(action.ChangedOrExpired(0.2, now), "2: no expiration expected at 0s");
-            Assert.IsFalse(action.ChangedOrExpired(0.2, now.AddMilliseconds(500).AddTicks(-1)), "2: no expiration expected at 0.5s - 1 tick");
-            Assert.IsTrue(action.ChangedOrExpired(0.2, now.AddMilliseconds(500)), "2: expiration expected at 0.5s");
-            Assert.IsTrue(action.ChangedOrExpired(0.3, now.AddMilliseconds(100)), "2: target change must be detected");
-            action.ExecutedNewAction(0.3, now);
-            Assert.IsFalse(action.ChangedOrExpired(0.3, now), "3: no expiration expected at 0s");
-            Assert.IsFalse(action.ChangedOrExpired(0.3, now.AddMilliseconds(500).AddTicks(-1)), "3: no expiration expected at 0.5s - 1 tick");
-            Assert.IsTrue(action.ChangedOrExpired(0.3, now.AddMilliseconds(500)), "3: expiration expected at 0.5s");
-            Assert.IsTrue(action.ChangedOrExpired(0.4, now.AddMilliseconds(100)), "3: target change must be detected");
+            action.ExecutedNewAction([0.2], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.2], now), "2: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.2], now.AddMilliseconds(500).AddTicks(-1)), "2: no expiration expected at 0.5s - 1 tick");
+            Assert.IsTrue(action.ChangedOrExpired([0.2], now.AddMilliseconds(500)), "2: expiration expected at 0.5s");
+            Assert.IsTrue(action.ChangedOrExpired([0.3], now.AddMilliseconds(100)), "2: target change must be detected");
+            action.ExecutedNewAction([0.3], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.3], now), "3: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.3], now.AddMilliseconds(500).AddTicks(-1)), "3: no expiration expected at 0.5s - 1 tick");
+            Assert.IsTrue(action.ChangedOrExpired([0.3], now.AddMilliseconds(500)), "3: expiration expected at 0.5s");
+            Assert.IsTrue(action.ChangedOrExpired([0.4], now.AddMilliseconds(100)), "3: target change must be detected");
         }
 
         [TestMethod()]
@@ -32,38 +32,38 @@ namespace UnitTests
         {
             var now = DateTime.UtcNow;
             var time = new FakeTimeProvider();
-            var action = new LastAction(0.1, 100, time);
-            Assert.IsTrue(action.ChangedOrExpired(0.1, now), "expiration is expected before executing the first action");
-            action.ExecutedNewAction(0.2, now);
-            Assert.IsFalse(action.ChangedOrExpired(0.2, now), "no expiration expected at 0s");
+            var action = new LastAction(0, 0, 100, time);
+            Assert.IsTrue(action.ChangedOrExpired([0.1], now), "expiration is expected before executing the first action");
+            action.ExecutedNewAction([0.2], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.2], now), "no expiration expected at 0s");
             time.Advance(TimeSpan.FromMilliseconds(60));
-            Assert.IsFalse(action.ChangedOrExpired(0.2, now), "no expiration expected at 0.06s clock time");
+            Assert.IsFalse(action.ChangedOrExpired([0.2], now), "no expiration expected at 0.06s clock time");
             time.Advance(TimeSpan.FromMilliseconds(60));
-            Assert.IsTrue(action.ChangedOrExpired(0.2, now), "expiration expected at 0.12s clock time");
+            Assert.IsTrue(action.ChangedOrExpired([0.2], now), "expiration expected at 0.12s clock time");
         }
 
         [TestMethod()]
         public void VectorOnlyNoRepeatTest()
         {
             var now = DateTime.UtcNow;
-            var action = new LastAction(0.1, -1);
-            Assert.IsTrue(action.ChangedOrExpired(0.1, now), "expiration is expected before executing the first action");
+            var action = new LastAction(0, 0, -1);
+            Assert.IsTrue(action.ChangedOrExpired([0.1], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
-            action.ExecutedNewAction(0.2, now);
-            Assert.IsFalse(action.ChangedOrExpired(0.2, now), "2: no expiration expected at 0s");
-            Assert.IsFalse(action.ChangedOrExpired(0.2, now.AddYears(10)), "2: no expiration expected at 10 years");
-            Assert.IsTrue(action.ChangedOrExpired(0.3, now.AddMilliseconds(100)), "2: target change must be detected");
-            action.ExecutedNewAction(0.3, now);
-            Assert.IsFalse(action.ChangedOrExpired(0.3, now), "3: no expiration expected at 0s");
-            Assert.IsFalse(action.ChangedOrExpired(0.3, now.AddDays(30)), "3: no expiration expected at 30 days");
-            Assert.IsTrue(action.ChangedOrExpired(0.4, now.AddMilliseconds(100)), "3: target change must be detected");
+            action.ExecutedNewAction([0.2], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.2], now), "2: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.2], now.AddYears(10)), "2: no expiration expected at 10 years");
+            Assert.IsTrue(action.ChangedOrExpired([0.3], now.AddMilliseconds(100)), "2: target change must be detected");
+            action.ExecutedNewAction([0.3], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.3], now), "3: no expiration expected at 0s");
+            Assert.IsFalse(action.ChangedOrExpired([0.3], now.AddDays(30)), "3: no expiration expected at 30 days");
+            Assert.IsTrue(action.ChangedOrExpired([0.4], now.AddMilliseconds(100)), "3: target change must be detected");
         }
 
         [TestMethod()]
         public void VectorOnlyMultipleTargetsNoRepeatTest()
         {
             var now = DateTime.UtcNow;
-            var action = new LastAction([0.1, 0.2, 0.3], -1);
+            var action = new LastAction([0, 1, 2], 0, -1);
             Assert.IsTrue(action.ChangedOrExpired([0.1, 0.2, 0.3], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
             action.ExecutedNewAction([0.2, 0.3, 0.4], now);
@@ -73,7 +73,7 @@ namespace UnitTests
             action.ExecutedNewAction([0.3, 0.4, 0.5], now);
             Assert.IsFalse(action.ChangedOrExpired([0.3, 0.4, 0.5], now), "3: no expiration expected at 0s");
             Assert.IsFalse(action.ChangedOrExpired([0.3, 0.4, 0.5], now.AddDays(30)), "3: no expiration expected at 30 days");
-            Assert.IsTrue(action.ChangedOrExpired([0.4, 0.5, 0.6], now.AddMilliseconds(100)), "3: target change must be detected");
+            Assert.IsTrue(action.ChangedOrExpired([0.3, 0.2, 0.5], now.AddMilliseconds(100)), "3: target change must be detected");
         }
 
         [TestMethod()]
@@ -81,15 +81,15 @@ namespace UnitTests
         {
             var now = DateTime.UtcNow;
             var time = new FakeTimeProvider();
-            var action = new LastAction(0.1, 500, time);
-            Assert.IsTrue(action.ChangedOrExpired(0.1, now), "expiration is expected before executing the first action");
-            action.ExecutedNewAction(0.2, now);
-            Assert.IsFalse(action.ChangedOrExpired(0.2, now), "no expiration expected at 0s");
-            action.TimedOutWaitingForDecision(0);
-            Assert.IsTrue(action.ChangedOrExpired(0, now), "expiration expected resuming after a timeout (based on vector date comparisson)");
-            action.ResetVectorBasedTimeout(now);//we can only test the time passing after a timeout if we reset the vector based timeout (even passing DateTime.MinValue as now would not skip the vector based comparisson). 
+            var action = new LastAction(0, 0, 500, time);
+            Assert.IsTrue(action.ChangedOrExpired([0.1], now), "expiration is expected before executing the first action");
+            action.ExecutedNewAction([0.2], now);
+            Assert.IsFalse(action.ChangedOrExpired([0.2], now), "no expiration expected at 0s");
+            action.TimedOutWaitingForDecision();
+            Assert.IsTrue(action.ChangedOrExpired([0.2], now), "expiration expected resuming after a timeout (based on vector date comparison)");
+            action.ResetVectorBasedTimeout(now);//we can only test the time passing after a timeout if we reset the vector based timeout (even passing DateTime.MinValue as now would not skip the vector based comparison). 
             time.Advance(TimeSpan.FromMilliseconds(500));
-            Assert.IsTrue(action.ChangedOrExpired(0, now), "expiration expected resuming after a timeout (based on time passing)");
+            Assert.IsTrue(action.ChangedOrExpired([0.2], now), "expiration expected resuming after a timeout (based on time passing)");
         }
     }
 }


### PR DESCRIPTION
Make GenericOutput + LastAction able to handle multiple targets / target values.

Breaking changes:
- The signature of `BaseSensorBox.RegisterBoardWriteActions` has been modified to work with multiple target names and target values.
- The LastAction has been modified to work with indices (into the data vector) instead of individual values (from the data vector).