### PR TITLE
added $tagvalue support

### DIFF
--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -31,7 +31,7 @@ namespace CA_DataUploaderLib.IOconf
             // remove empty lines and commented out lines
             var lines2 = linesList.Where(x => !x.StartsWith("//") && x.Length > 2).Select((x,i) => (row: x,line: i)).ToList();
             var rows = lines2.Select(x => CreateType(loader, x.row, x.line + 1)).ToList();
-            var tags = rows.SelectMany(r => r.Tags.Select(t => (tag: t, row: r))).ToLookup(r => r.tag, r=> r.row);
+            var tags = rows.SelectMany(r => r.Tags.Select(t => (tag: t, row: r))).ToLookup(r => r.tag.name, r=> r.row);
             foreach (var row in rows)
                 row.UseTags(tags);
             var expanded = rows.Concat(

--- a/CA_DataUploaderLib/IOconf/IOconfExpandTagLines.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfExpandTagLines.cs
@@ -12,7 +12,7 @@ namespace CA_DataUploaderLib.IOconf
         private readonly List<string> expandedLines = [];
         public IOconfExpandTagLines(string row, int lineNum) : base(row, lineNum, ConfigName, false, false)
         {
-            Format = $"{ConfigName};mytag;row with $name or $matchingtag(tag1 tag2 tag3)";
+            Format = $"{ConfigName};mytag;row with $name or $tagvalue(othertag)";
             var list = ToList();
             if (list.Count < 3 || string.IsNullOrEmpty(list[2]))
                 throw new FormatException($"Wrong format: {Row}.{Environment.NewLine}{Format}");

--- a/UnitTests/IOconfFileTests.cs
+++ b/UnitTests/IOconfFileTests.cs
@@ -94,9 +94,9 @@ Math; temperature_tm01_01_math; temperature_tm01_01 + 1
 Map;fakeserial;ac01
 Map;fakeserial;ac02
 Map;fakeserial;ac03
-Heater; LeftHeater16; ac01;01;850; tags:phase1 ovenarea4 ovenheaters // Freely choose tags to assign config entries to groups
-Heater; LeftHeater17; ac02;01;850; tags:phase2 ovenarea4 ovenheaters
-Heater; LeftHeater18; ac02;02;850; tags:phase2 ovenarea4 ovenheaters
+Heater; LeftHeater16; ac01;01;850; tags:phase1 ovenarea4 ovenheaters area=2 // Freely choose tags to assign config entries to groups
+Heater; LeftHeater17; ac02;01;850; tags:phase2 ovenarea4 ovenheaters area=4
+Heater; LeftHeater18; ac02;02;850; tags:phase2 ovenarea4 ovenheaters area=5
 Heater; ExternalHeater01; ac03;01;850; tags:phase3 bsarea
 
 Code;power_control;0.1190.0;pc2
@@ -111,6 +111,7 @@ RowWithList; mylist; LeftHeater16;LeftHeater17;LeftHeater18
 RowWithList; mylist2; expandtag{ovenheaters} //should be equivalent to the previous one (note it uses the default expression $name)
 RowWithList; mylist3; expandtag{ovenheaters,$name_$matchingtag(phase1 phase2 phase3)}//each matchingtag outputs whichever of those tags the item has e.g. LeftHeater16_phase1, LeftHeater17_phase2, LeftHeater18_phase2
 RowWithList; mylist4; expandtag{ovenheaters,$name_current;$name_onoff} //should be equivalent to the previous one (note it uses the default expression $name)
+RowWithList; mylist5; expandtag{ovenheaters,prefix$tagvalue(area)suffix} //produces prefix2suffix,prefix4suffix,prefix5suffix
 
 ExpandLines;math1,math2,math3;Math;$name;$name // Creates a new line for all labels (the empty - separates the list from the command)
 ExpandTagLines;phase2;Math;$name_sampledcurrent;$name_sampledcurrent //also creates multiple math lines
@@ -133,6 +134,7 @@ RedundantSensors;redundant;expandtag{ovenheaters}
             AssertRowValuesByName(ioconf, "mylist2", "LeftHeater16,LeftHeater17,LeftHeater18");
             AssertRowValuesByName(ioconf, "mylist3", "LeftHeater16_phase1,LeftHeater17_phase2,LeftHeater18_phase2");
             AssertRowValuesByName(ioconf, "mylist4", "LeftHeater16_current,LeftHeater16_onoff,LeftHeater17_current,LeftHeater17_onoff,LeftHeater18_current,LeftHeater18_onoff");
+            AssertRowValuesByName(ioconf, "mylist5", "prefix2suffix,prefix4suffix,prefix5suffix");
             AssertRowValuesByNameAndType(ioconf, "Math", "math1", "math1");
             AssertRowValuesByNameAndType(ioconf, "Math", "math2", "math2");
             AssertRowValuesByNameAndType(ioconf, "Math", "math3", "math3");


### PR DESCRIPTION
This feature expands tags support to optionally assign a value to a tag, which can then be used with expandtag and expandtaglines features.

Without the new feature, advanced configurations needed to use the matchingtags feature like below to find the first target in the specified sets of target:

```
Heater;Heater01;ac01;01;tags:phase1 ovenarea2 //example heater in phase 1 with ovenarea2_target
...
pcs1; Heaters_oventarget; expandtag{phase1,$matchingtags(ovenarea1 ovenarea2 ovenarea3 ovenarea4 ovenarea5)_target}
...
pcs2; Heaters_oventarget; expandtag{phase2,$matchingtags(ovenarea1 ovenarea2 ovenarea3 ovenarea4 ovenarea5)_target}
...
pcs3; Heaters_oventarget; expandtag{phase3,$matchingtags(ovenarea1 ovenarea2 ovenarea3 ovenarea4 ovenarea5)_target}
```

With the new feature, its possible to write this instead, avoiding having to specify the whole list of areas everywhere one needs to refer to the oven area target related to a heater.
```
Heater;Heater01;ac01;01;tags:phase1 area=2//example heater in phase 1 and area 2
pcs1; Heaters_oventarget; expandtag{phase1,ovenarea$tagvalue(area)_target}
```