### PR TITLE
fixes: actuations stop after some board reconnects

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -358,7 +358,9 @@ namespace CA_DataUploaderLib
                 catch (OperationCanceledException ex) when (ex.CancellationToken == token)
                 { }
                 catch (ObjectDisposedException)
-                {
+                { 
+                    // the board was intentionally and permanently closed until the next restart
+                    // e.g. typically due to unsupported configuration for a board or during autoconfig/firmware updates
                     LogData(board, "Detected closed connection (write loop)");
                     return;
                 }

--- a/CA_DataUploaderLib/MCUBoard.cs
+++ b/CA_DataUploaderLib/MCUBoard.cs
@@ -134,7 +134,7 @@ namespace CA_DataUploaderLib
         }
 
         public async Task<string> SafeReadLine(CancellationToken token) => await RunWaitingForAnyOngoingReconnect(ReadLine, token);
-        public Task SafeWriteLine(string msg, CancellationToken token) => RunWaitingForAnyOngoingReconnect(_ => { if (port.IsOpen) port.WriteLine(msg); else throw new ObjectDisposedException("Closed connection detected (port is closed)"); } , token);
+        public Task SafeWriteLine(string msg, CancellationToken token) => RunWaitingForAnyOngoingReconnect(_ => { if (!Closed) port.WriteLine(msg); else throw new ObjectDisposedException("Closed connection detected (port is closed)"); } , token);
 
         public async Task SafeClose(CancellationToken token)
         {


### PR DESCRIPTION
fixes: actuations stop after some board reconnects

Context: McuBoard.SafeWriteLine explicitely raised ObjectDisposedException when the force is explicitely disconnected. However, it did so by checking whether the underlying serial port was connected, which can also be the case on temporary and/or unintended disconnects.