### PR TITLE
MCUBoard: store the header lines of a board. 

### DIFF
--- a/CA_DataUploaderLib/Board.cs
+++ b/CA_DataUploaderLib/Board.cs
@@ -29,6 +29,7 @@ namespace CA_DataUploaderLib
         public string? GitSha { get; protected set; }
         public string? Calibration { get; protected set; }
         public string? UpdatedCalibration { get; protected set; }
+        public string? HeaderLines { get; protected set; }
 
         public bool TrySetMap(IOconfMap map)
         {

--- a/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfCurrent.cs
@@ -56,7 +56,7 @@ namespace CA_DataUploaderLib.IOconf
                 }
                 else
                 {
-                    CALog.LogErrorAndConsoleLn(LogID.A, $"Error: old current board {Map.Name} cannot use new format for sensor {Name}. Disconnecting board.");
+                    CALog.LogErrorAndConsoleLn(LogID.A, $"Error: old current board {Map.Name} cannot use new format for sensor {Name}. Disconnecting board. Received header:{Environment.NewLine}{Map.Board.HeaderLines}");
                     Map.ForceDisconnectBoard().Wait();
                 }
             }


### PR DESCRIPTION
Add these stored lines to the log in case a current board in being force closed due to missing/incompatible calibration. #379