### PR TITLE
Fix unexpected board response: '\nMISREAD: uptime'

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -551,7 +551,7 @@ namespace CA_DataUploaderLib
                     }
                     else if (!board.ConfigSettings.Parser.IsExpectedNonValuesLine(line))// mostly responses to commands or headers on reconnects.
                     {
-                        if (line.StartsWith("MISREAD: uptime"))
+                        if (line.Trim().StartsWith("MISREAD: uptime"))
                         {
                             LogData(board, "Uptime not supported");
                             _uptimeCancellationTokens[board].Cancel(); //Stop the uptime task

--- a/CA_DataUploaderLib/Extensions/StringExtensions.cs
+++ b/CA_DataUploaderLib/Extensions/StringExtensions.cs
@@ -32,7 +32,7 @@ namespace CA_DataUploaderLib.Extensions
         public static double ToDouble(this string s) => double.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
         public static bool TryToDouble(this string s, out double val) => double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out val);
         public static bool TryToDouble(this ReadOnlySpan<char> s, out double val) => double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out val);
-        public static List<string> SplitNewLine(this string s, StringSplitOptions options = StringSplitOptions.RemoveEmptyEntries) => [.. s.Split(new[] { Environment.NewLine }, options)];
+        public static List<string> SplitNewLine(this string s, StringSplitOptions options = StringSplitOptions.RemoveEmptyEntries) => [.. s.Split([Environment.NewLine], options)];
         private static bool TryGetIndex(string s, string match, out int pos) => (pos = s.IndexOf(match)) >= 0;
 
         /// <summary>

--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -13,7 +13,7 @@ namespace CA_DataUploaderLib.IOconf
             return File.Exists("IO.conf");
         }
 
-        public static (List<string>, List<IOconfRow> original, List<IOconfRow> expanded) Load(IIOconfLoader loader)
+        public static (List<string> raw, List<IOconfRow> original, List<IOconfRow> expanded) Load(IIOconfLoader loader)
         {
             if (!FileExists())
             {

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -99,7 +99,7 @@ namespace CA_DataUploaderLib.IOconf
             }
             catch (Exception ex)
             {
-                throw new Exception($"Did you forgot to include login information in top of {Directory.GetCurrentDirectory()}\\IO.conf ?", ex);
+                throw new FormatException($"Did you forget to include login information in top of {Directory.GetCurrentDirectory()}\\IO.conf ?", ex);
             }
         }
 

--- a/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOut230Vac.cs
@@ -28,7 +28,7 @@ namespace CA_DataUploaderLib.IOconf
         /// <remarks>This config is general for the board, so caller must make sure to use a single instance x board</remarks>
         public IOconfInput GetBoardTemperatureInputConf() => NewPortInput(Map.BoxName + "_temperature", 5);
         public static BoardSettings GetSwitchboardBoardSettings() => 
-            new() { Parser = SwitchBoardResponseParser.Default, ValuesEndOfLineChar = '\r' };
+            new() { Parser = SwitchBoardResponseParser.Default };
         public class SwitchBoardResponseParser : BoardSettings.LineParser
         {
             public new static SwitchBoardResponseParser Default { get; } = new SwitchBoardResponseParser();

--- a/UnitTests/MultilineMessageReceiverTests.cs
+++ b/UnitTests/MultilineMessageReceiverTests.cs
@@ -81,7 +81,7 @@ Port 2 measures voltage[0 - 5V]
             // Arrange
             var logCount = 0;
             var log = "";
-            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new Exception("No uptime should get logged"));
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new InvalidOperationException("No uptime should get logged"));
 
             // Act
             foreach (var line in linesWithCompleteMessage)
@@ -98,7 +98,7 @@ Port 2 measures voltage[0 - 5V]
             // Arrange
             var logCount = 0;
             var log = "";
-            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new Exception("No uptime should get logged"));
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new InvalidOperationException("No uptime should get logged"));
 
             // Act
             foreach (var line in linesWithIncompleteMessage)
@@ -114,7 +114,7 @@ Port 2 measures voltage[0 - 5V]
             // Arrange
             var logCount = 0;
             var log = "";
-            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new Exception("No uptime should get logged"));
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new InvalidOperationException("No uptime should get logged"));
 
             // Act
             foreach (var line in linesWithIncompleteMessage)
@@ -133,7 +133,7 @@ Port 2 measures voltage[0 - 5V]
             // Arrange
             var logCount = 0;
             var logUptime = "";
-            var sut = new MultilineMessageReceiver((_) => throw new Exception("No info block should get logged"), (s) => { logCount++; logUptime += s; });
+            var sut = new MultilineMessageReceiver((_) => throw new InvalidOperationException("No info block should get logged"), (s) => { logCount++; logUptime += s; });
 
             // Act
             foreach (var line in linesWithCompleteUptimeMessage)
@@ -150,7 +150,7 @@ Port 2 measures voltage[0 - 5V]
             // Arrange
             var logCount = 0;
             var log = "";
-            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new Exception("No uptime should get logged"));
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new InvalidOperationException("No uptime should get logged"));
             foreach (var line in linesWithCompleteMessage)
                 sut.HandleLine(line);
             logCount = 0;
@@ -168,7 +168,7 @@ Port 2 measures voltage[0 - 5V]
             // Arrange
             var logCount = 0;
             var log = "";
-            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new Exception("No uptime should get logged"));
+            var sut = new MultilineMessageReceiver((s) => { logCount++; log += s; }, (_) => throw new InvalidOperationException("No uptime should get logged"));
             foreach (var line in linesWithIncompleteMessage)
                 sut.HandleLine(line);
 


### PR DESCRIPTION
Removing custom configuration of special EOL char (\r instead of \n) for IOconfOut230Vac.