### PR TITLE
The "Version" of a plugin/Code is now just a string.

### DIFF
--- a/CA_DataUploaderLib/CommandHandler.cs
+++ b/CA_DataUploaderLib/CommandHandler.cs
@@ -237,10 +237,6 @@ namespace CA_DataUploaderLib
                 {
                     if (!decisionsIndexes.TryGetValue(conf.Name, out var decisionAndIndex)) 
                         throw new FormatException($"Decision listed in IO.conf (line {conf.LineNumber + 1}) was not found: '{conf.Row}'");
-                    var decisionVersion = decisionAndIndex.decision.GetType().Assembly.GetName().Version ?? throw new FormatException($"Failed to retrieve assembly version for decision '{conf.Row}' (line {conf.LineNumber + 1})");
-                    if (decisionVersion.Major != conf.Version.Major || decisionVersion.Minor != conf.Version.Minor || decisionVersion.Build != conf.Version.Build )
-                        //the 3 digits the user sees/configures does not match the 4 digits the scxmltocode tool produces, so we compare the 3 digits explicitly above i.e. 1.0.2.0 vs. 1.0.2
-                        throw new FormatException($"Decision listed in IO.conf (line {conf.LineNumber + 1}) did not match expected version: {conf.Version} - Actual: {decisionVersion} - '{conf.Row}'");
                     decisionsIndexes[conf.Name] = (decisionAndIndex.decision, decisions.Count + conf.Index); 
                 }
 

--- a/CA_DataUploaderLib/IOconf/IOconfCode.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfCode.cs
@@ -15,8 +15,7 @@ namespace CA_DataUploaderLib.IOconf
             Format = "Code; [RepoName/]Name; Version; [InstanceName]";
             var list = ToList();
             if (list.Count < 3) throw new FormatException($"Missing version in Code line in IO.conf: {row} {Environment.NewLine}{Format}");
-            if (!Version.TryParse(list[2], out var v)) throw new FormatException($"Invalid version format in Code line in IO.conf: {row} {Environment.NewLine}{Format}");
-            Version = v;
+            Version = list[2];
             if (list[1].Contains('/'))
             {
                 ClassName = Name = list[1][(list[1].LastIndexOf('/') + 1)..];
@@ -37,7 +36,7 @@ namespace CA_DataUploaderLib.IOconf
             private set => codeRepo = value;
         }
         public int Index { get; private set; }
-        public Version Version { get; }
+        public string Version { get; }
 
         public override void ValidateDependencies(IIOconf ioconf)
         {


### PR DESCRIPTION
CommandHandler: Removed version check of plugins, which was deemed unnecessary.

This was done in order to support the download of PR builds of plugins.