### PR TITLE
Fixed multiple IOconfOutput rows of the same type overriding the BoardSettings

### DIFF
--- a/CA_DataUploaderLib/IOconf/IOconfInput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfInput.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace CA_DataUploaderLib.IOconf
 {
@@ -73,18 +72,6 @@ namespace CA_DataUploaderLib.IOconf
                 return (false, false, 1);
         }
 
-        private static IOconfMap GetMap(IIOconf ioconf, string boxName, BoardSettings settings, bool skipBoardSettings)
-        {
-            var maps = ioconf.GetMap();
-            var map = maps.SingleOrDefault(x => x.BoxName == boxName) ?? 
-                throw new FormatException($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
-            // Map.BoardSettings == BoardSettings.Default is there since some boards need separate board settings, but have multiple sensor entries. 
-            // This check means a new BoardSettings instance will be created with first entry of board, but not updated (i.e. shared) among the rest of the board entries.    
-            if (!skipBoardSettings && map.BoardSettings == BoardSettings.Default)
-                map.BoardSettings = settings;
-            return map;
-        }
-
         public class Expandable : IOconfRow, IIOconfRowWithBoardState
         {
             private readonly BoardSettings _boardSettings;
@@ -104,7 +91,7 @@ namespace CA_DataUploaderLib.IOconf
 
             public override void ValidateDependencies(IIOconf ioconf)
             {
-                Map = GetMap(ioconf, BoxName, _boardSettings, false);
+                Map = GetMap(ioconf, BoxName, _boardSettings);
             }
 
             public virtual IEnumerable<IOconfInput> GetExpandedConf()

--- a/CA_DataUploaderLib/IOconf/IOconfOutput.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfOutput.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace CA_DataUploaderLib.IOconf
 {
@@ -40,16 +39,6 @@ namespace CA_DataUploaderLib.IOconf
         {
             get => _map ?? throw new InvalidOperationException($"Call {nameof(ValidateDependencies)} before accessing {nameof(Map)}.");
             private set => _map = value;
-        }
-
-        protected static IOconfMap GetMap(IIOconf ioconf, string boxName, BoardSettings settings)
-        {
-            var maps = ioconf.GetMap();
-            var map = maps.SingleOrDefault(x => x.BoxName == boxName);
-            if (map == null)
-                throw new FormatException($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
-            map.BoardSettings = settings;
-            return map;
         }
 
         protected IOconfInput NewPortInput(string name, int portNumber, bool upload = true) => new(Row, LineNumber, Type, Map, portNumber) { Name = name, Upload = upload };

--- a/CA_DataUploaderLib/IOconf/IOconfRow.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfRow.cs
@@ -93,6 +93,18 @@ namespace CA_DataUploaderLib.IOconf
         /// </summary>
         public virtual void ValidateDependencies(IIOconf ioconf) {}
 
+        protected static IOconfMap GetMap(IIOconf ioconf, string boxName, BoardSettings settings, bool skipBoardSettings = false)
+        {
+            var maps = ioconf.GetMap();
+            var map = maps.SingleOrDefault(x => x.BoxName == boxName) ??
+                throw new FormatException($"{boxName} not found in map: {string.Join(", ", maps.Select(x => x.BoxName))}");
+            // Map.BoardSettings == BoardSettings.Default is there since some boards need separate board settings, but have multiple sensor entries. 
+            // This check means a new BoardSettings instance will be created with first entry of board, but not updated (i.e. shared) among the rest of the board entries.    
+            if (!skipBoardSettings && map.BoardSettings == BoardSettings.Default)
+                map.BoardSettings = settings;
+            return map;
+        }
+
         protected virtual void ValidateName(string name)
         {
             if (!ValidateNameRegex.IsMatch(name))


### PR DESCRIPTION
IOconfInput and IOconfOutput now use the same GetMap-method (with the correct behavior).