### PR TITLE
LastAction: accessing the Targets property before the first vector has been received should not result in exception

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -222,7 +222,7 @@ namespace CA_DataUploaderLib
             async Task WriteAction(DataVector? vector, MCUBoard board, CancellationToken token)
             {
                 vectorIndices ??= getIndices();
-                lastAction ??= new LastAction(vectorIndices, repeatMilliseconds);
+                lastAction ??= new LastAction(vectorIndices, repeatMilliseconds, defaultTarget);
                 defaultTargets ??= vectorIndices.Select(i => defaultTarget).ToList();
 
                 if (vector == null)

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -95,12 +95,12 @@ namespace CA_DataUploaderLib.IOconf
         private void CheckMapLineUniquenessRules()
         {
             var errorMessage = string.Empty;
-            // No two map lines can have the same serial number
-            foreach (var mapLine in GetMap().GroupBy(m => m.SerialNumber).Where(x => x.Key is not null && x.Count() > 1))
-                errorMessage += (!string.IsNullOrEmpty(errorMessage) ? Environment.NewLine : "") + $"Two Map-lines cannot use the same serial number. Lines involved:{Environment.NewLine}{string.Join(Environment.NewLine, mapLine.Select(y => y.Row))}";
+            // No two map lines on the same node can have the same serial number
+            foreach (var mapLine in GetMap().GroupBy(m => new { m.DistributedNode, m.SerialNumber }).Where(x => x.Key.SerialNumber is not null && x.Count() > 1))
+                errorMessage += (!string.IsNullOrEmpty(errorMessage) ? Environment.NewLine : "") + $"Two Map-lines for the same node cannot use the same serial number. Lines involved:{Environment.NewLine}{string.Join(Environment.NewLine, mapLine.Select(y => y.Row))}";
             // No two map lines on the same node can have the same port
             foreach (var mapLine in GetMap().GroupBy(m => new { m.DistributedNode, m.USBPort }).Where(x => x.Key.USBPort is not null && x.Count() > 1))
-            errorMessage += (!string.IsNullOrEmpty(errorMessage) ? Environment.NewLine : "") + $"Two Map-lines for the same node cannot use the same port. Lines involved:{Environment.NewLine}{string.Join(Environment.NewLine, mapLine.Select(y => y.Row))}";
+                errorMessage += (!string.IsNullOrEmpty(errorMessage) ? Environment.NewLine : "") + $"Two Map-lines for the same node cannot use the same port. Lines involved:{Environment.NewLine}{string.Join(Environment.NewLine, mapLine.Select(y => y.Row))}";
             if (!string.IsNullOrEmpty(errorMessage))
                 throw new FormatException(errorMessage);
         }

--- a/CA_DataUploaderLib/LastAction.cs
+++ b/CA_DataUploaderLib/LastAction.cs
@@ -8,23 +8,25 @@ namespace CA_DataUploaderLib
     {
         private readonly int repeatMilliseconds;
         private readonly TimeProvider timeProvider;
+        private readonly double defaultTarget;
         private long lastActionExecutedTime;
 
-        public LastAction(int targetIndex, int repeatMilliseconds) : this(targetIndex, repeatMilliseconds, TimeProvider.System) { }
-        public LastAction(int targetIndex, int repeatMilliseconds, TimeProvider timeProvider) : this([targetIndex], repeatMilliseconds, timeProvider) { }
-        public LastAction(IEnumerable<int> targetIndices, int repeatMilliseconds) : this(targetIndices, repeatMilliseconds, TimeProvider.System) { }
-        public LastAction(IEnumerable<int> targetIndices, int repeatMilliseconds, TimeProvider timeProvider)
+        public LastAction(int targetIndex, int repeatMilliseconds, double defaultTarget = 0.0) : this(targetIndex, repeatMilliseconds, TimeProvider.System, defaultTarget) { }
+        public LastAction(int targetIndex, int repeatMilliseconds, TimeProvider timeProvider, double defaultTarget = 0.0) : this([targetIndex], repeatMilliseconds, timeProvider, defaultTarget) { }
+        public LastAction(IEnumerable<int> targetIndices, int repeatMilliseconds, double defaultTarget = 0.0) : this(targetIndices, repeatMilliseconds, TimeProvider.System, defaultTarget) { }
+        public LastAction(IEnumerable<int> targetIndices, int repeatMilliseconds, TimeProvider timeProvider, double defaultTarget = 0.0)
         {
             Indices = [.. targetIndices];
             this.repeatMilliseconds = repeatMilliseconds;
             this.timeProvider = timeProvider;
+            this.defaultTarget = defaultTarget;
         }
 
         private double[] Vector { get; set; } = [];
         private int[] Indices { get; set; }
         private DateTime TimeToRepeat { get; set; }
 
-        public IEnumerable<double> Targets => Indices.Select(i => Vector[i]);
+        public IEnumerable<double> Targets => Indices.Select(i => Vector.Length == 0 ? defaultTarget : Vector[i]);
 
         /// <remarks>
         /// We determine whether the last action has expired (should be repeated) by checking the time passed in 2 different ways,

--- a/CA_DataUploaderLib/PluginsLoader.cs
+++ b/CA_DataUploaderLib/PluginsLoader.cs
@@ -40,7 +40,7 @@ namespace CA_DataUploaderLib
                 return;
             }
 
-            CALog.LogData(LogID.A, $"Loaded plugins from {assemblyFullPath} - {string.Join(",", decisions.Select(e => e.GetType().Name))}");
+            CALog.LogData(LogID.A, $"Loaded plugins from {assemblyFullPath} - {string.Join(", ", decisions.Select(e => e.GetType().Name))}");
             handler.AddDecisions(decisions);
         }
 

--- a/UnitTests/IOconfFileTests.cs
+++ b/UnitTests/IOconfFileTests.cs
@@ -38,7 +38,7 @@ namespace UnitTests
             var ex = Assert.Throws<FormatException>(() => new IOconfFile([
                 "Map; 1234567890; tm01",
                 "Map; 1234567890; tm02" ]));
-            Assert.StartsWith("Two Map-lines cannot use the same serial number", ex.Message);
+            Assert.StartsWith("Two Map-lines for the same node cannot use the same serial number", ex.Message);
         }
 
         [TestMethod]
@@ -73,18 +73,17 @@ namespace UnitTests
                 "Node; node1; 1.2.3.4",
                 "Map; 1234567890; tm01; node1",
                 "Map; 1234567890; tm02; node1" ]));
-            Assert.StartsWith("Two Map-lines cannot use the same serial number", ex.Message);
+            Assert.StartsWith("Two Map-lines for the same node cannot use the same serial number", ex.Message);
         }
 
         [TestMethod]
-        public void WhenTwoMapLinesForDifferentNodesHaveTheSameSerial_MultiPiSystem_ThenAnExceptionIsThrown()
+        public void WhenTwoMapLinesForDifferentNodesHaveTheSameSerial_MultiPiSystem_ThenNoException()
         {
-            var ex = Assert.Throws<FormatException>(() => new IOconfFile([
+            var _ = new IOconfFile([
                 "Node; node1; 1.2.3.4",
                 "Node; node2; 1.2.3.5",
                 "Map; 1234567890; tm01; node1",
-                "Map; 1234567890; tm02; node2" ]));
-            Assert.StartsWith("Two Map-lines cannot use the same serial number", ex.Message);
+                "Map; 1234567890; tm02; node2" ]);
         }
 
         [TestMethod]

--- a/UnitTests/LastActionTests.cs
+++ b/UnitTests/LastActionTests.cs
@@ -70,12 +70,12 @@ namespace UnitTests
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.1, 0.2, 0.3, 1.0], now), "expiration is expected before executing the first action");
             now = now.AddSeconds(1);
             action.ExecutedNewAction([0.0, 0.2, 0.3, 0.4, 1.0], now);
-            CollectionAssert.AreEqual(new double[] { 0.2, 0.3, 0.4 }, action.Targets.ToArray());
+            CollectionAssert.AreEqual(new [] { 0.2, 0.3, 0.4 }, action.Targets.ToArray());
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.2, 0.3, 0.4, 1.0], now), "2: no expiration expected at 0s");
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.2, 0.3, 0.4, 1.0], now.AddYears(10)), "2: no expiration expected at 10 years");
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now.AddMilliseconds(100)), "2: target change must be detected");
             action.ExecutedNewAction([0.0, 0.3, 0.4, 0.5, 1.0], now);
-            CollectionAssert.AreEqual(new double[] { 0.3, 0.4, 0.5 }, action.Targets.ToArray());
+            CollectionAssert.AreEqual(new [] { 0.3, 0.4, 0.5 }, action.Targets.ToArray());
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now), "3: no expiration expected at 0s");
             Assert.IsFalse(action.ChangedOrExpired([0.0, 0.3, 0.4, 0.5, 1.0], now.AddDays(30)), "3: no expiration expected at 30 days");
             Assert.IsTrue(action.ChangedOrExpired([0.0, 0.3, 0.2, 0.5, 1.0], now.AddMilliseconds(100)), "3: target change must be detected");
@@ -95,6 +95,21 @@ namespace UnitTests
             action.ResetVectorBasedTimeout(now);//we can only test the time passing after a timeout if we reset the vector based timeout (even passing DateTime.MinValue as now would not skip the vector based comparison). 
             time.Advance(TimeSpan.FromMilliseconds(500));
             Assert.IsTrue(action.ChangedOrExpired([0.2], now), "expiration expected resuming after a timeout (based on time passing)");
+        }
+
+        [TestMethod()]
+        public void ReadingTargetsBeforeFirstVectorDoesNotThrowException()
+        {
+            var action = new LastAction([5], 500);
+            _ = action.Targets.First();
+        }
+
+        [TestMethod()]
+        public void ReadingTargetsBeforeFirstVectorReturnsDefaultTarget()
+        {
+            var defaultTarget = -1.0;
+            var action = new LastAction([5, 6], 500, defaultTarget);
+            CollectionAssert.AreEqual(new [] { defaultTarget, defaultTarget }, action.Targets.ToArray());
         }
     }
 }


### PR DESCRIPTION
Changes in this PR:
- LastAction: accessing the Targets property before the first vector has been received should not result in exception.
- Allowing Map-lines from different nodes to have the same serial number. This is very useful when replacing a pihat.
    - This adjusts what was done in https://github.com/copenhagenatomics/CA_DataUploader/pull/403