### PR TITLE
Fix IO.conf data loss during power cut (#1370)

### DIFF
--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -61,7 +61,7 @@ namespace CA_DataUploaderLib.IOconf
                 while (File.Exists(newFilename));
 
                 File.Copy(filename, newFilename);
-                using var backupFs = new FileStream(newFilename, FileMode.Open, FileAccess.ReadWrite);
+                using var backupFs = new FileStream(newFilename, FileMode.Open, FileAccess.Write);
                 backupFs.Flush(flushToDisk: true);
             }
 
@@ -73,7 +73,6 @@ namespace CA_DataUploaderLib.IOconf
                 fs.Flush(flushToDisk: true);
             }
             File.Move(temp, filename, true);
-
         }
 
         private static IOconfRow CreateType(IIOconfLoader confLoader, string row, int lineNum)

--- a/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
+++ b/CA_DataUploaderLib/IOconf/IOConfFileLoader.cs
@@ -61,10 +61,19 @@ namespace CA_DataUploaderLib.IOconf
                 while (File.Exists(newFilename));
 
                 File.Copy(filename, newFilename);
+                using var backupFs = new FileStream(newFilename, FileMode.Open, FileAccess.ReadWrite);
+                backupFs.Flush(flushToDisk: true);
             }
-            var temp = Path.GetTempFileName();
-            File.WriteAllText(temp, ioconf);
+
+            var temp = filename + ".tmp";
+            using (var fs = new FileStream(temp, FileMode.Create, FileAccess.Write))
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(ioconf);
+                fs.Write(bytes, 0, bytes.Length);
+                fs.Flush(flushToDisk: true);
+            }
             File.Move(temp, filename, true);
+
         }
 
         private static IOconfRow CreateType(IIOconfLoader confLoader, string row, int lineNum)

--- a/CA_DataUploaderLib/IOconf/IOconfCodeRepo.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfCodeRepo.cs
@@ -104,9 +104,16 @@ namespace CA_DataUploaderLib.IOconf
 
             if (repoURLs.Count == 0)
                 return;
-            
+
             var jsonOut = JsonSerializer.Serialize(repoURLs, jsonSerializerOptions);
-            File.WriteAllText(RepoUrlJsonFile, jsonOut);
+            var temp = RepoUrlJsonFile + ".tmp";
+            using (var fs = new FileStream(temp, FileMode.Create, FileAccess.Write))
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(jsonOut);
+                fs.Write(bytes, 0, bytes.Length);
+                fs.Flush(flushToDisk: true);
+            }
+            File.Move(temp, RepoUrlJsonFile, true);
         }
 
         /// <summary>

--- a/CA_DataUploaderLib/IOconf/IOconfFile.cs
+++ b/CA_DataUploaderLib/IOconf/IOconfFile.cs
@@ -58,8 +58,8 @@ namespace CA_DataUploaderLib.IOconf
         /// <param name="ioconf"></param>
         public void WriteToDisk()
         {
-            IOconfFileLoader.WriteToDisk(GetRawFile());
             IOconfCodeRepo.WriteURLsToFile(CodeRepoURLs, Directory.GetCurrentDirectory());
+            IOconfFileLoader.WriteToDisk(GetRawFile());
         }
 
         public void CheckConfig()


### PR DESCRIPTION
Fixes #1370.

Reproduced the bug reliably by adding 3.5k comments to IO.conf and pulling the plug about 5 sec after, both IO.conf and IO.conf.backup ended up empty. So the existing backup mechanism was not actually protecting us: we had a second issue where IO.conf.backup would also be empty, not just IO.conf.

The fix:
- **Flushes (fsync) after making the backup**, so once we move on we are guaranteed never to lose the previous IO.conf even if power dies mid-write of the new one.
- **Writes the new IO.conf via a temp file in the same directory** (instead of Path.GetTempFileName() which lives in /tmp). /tmp can be a different filesystem depending on configuration, which turns File.Move into a copy+delete rather than an atomic rename.
- **fsyncs the temp file before the rename**, so the new contents are physically on the disk/card before the directory entry changes. 

