### PR TITLE
Handle inf values in sensor output + low frequency log of rpi temperature error messages

### DIFF
--- a/CA_DataUploaderLib/BaseSensorBox.cs
+++ b/CA_DataUploaderLib/BaseSensorBox.cs
@@ -20,7 +20,7 @@ namespace CA_DataUploaderLib
         /// <summary>runs when the subsystem is about to stop running, but before all boards are closed</summary>
         /// <remarks>some boards might be closed, specially if the system is stopping due to losing connection to one of the boards</remarks>
         public event EventHandler? Stopping;
-        private readonly CommandHandler _cmd;
+        protected readonly CommandHandler _cmd;
         protected readonly List<SensorSample.InputBased> _values;
         protected readonly List<SensorSample.InputBased> _localValues;
         private readonly (IOconfMap map, SensorSample.InputBased[] values, DataVectorReader? vectorReader, int boardStateIndexInFullVector)[] _boards = [];

--- a/CA_DataUploaderLib/IOconf/BoardSettings.cs
+++ b/CA_DataUploaderLib/IOconf/BoardSettings.cs
@@ -50,7 +50,7 @@ namespace CA_DataUploaderLib.IOconf
                     uint.TryParse(lineMatch.Groups["Status"].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out status);
 
                 return (lineMatch.Groups["Values"].Value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                    .Select(x => x.ToDouble())
+                    .Select(ParseValue)
                     .ToList(), status);
             }
 
@@ -58,7 +58,14 @@ namespace CA_DataUploaderLib.IOconf
 
             public virtual bool IsExpectedNonValuesLine(string line) => false;
 
-            [GeneratedRegex(@"^\s*(?<Values>[+-]?(?:[0-9]*[.])?[0-9]+\s*(?:,\s*[+-]?(?:[0-9]*[.])?[0-9]+\s*)*)(?:,\s*0x(?<Status>[0-9a-fA-F]+))?,?\s*$")]
+            /// <remarks>supports the infinity values reported by boards as inf/-inf/+inf</remarks>
+            protected static double ParseValue(string value) => value switch
+            {
+                _ when value.EndsWith("inf", StringComparison.OrdinalIgnoreCase) => value.StartsWith('-') ? double.NegativeInfinity : double.PositiveInfinity,
+                _ => value.ToDouble()
+            };
+
+            [GeneratedRegex(@"^\s*(?<Values>[+-]?(?:inf|(?:[0-9]*[.])?[0-9]+)\s*(?:,\s*[+-]?(?:inf|(?:[0-9]*[.])?[0-9]+)\s*)*)(?:,\s*0x(?<Status>[0-9a-fA-F]+))?,?\s*$", RegexOptions.IgnoreCase)]
             private static partial Regex HasCommaSeparatedNumbersRegex();
         }
     }

--- a/CA_DataUploaderLib/ThermocoupleBox.cs
+++ b/CA_DataUploaderLib/ThermocoupleBox.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Threading;
-using System.Threading.Channels;
 
 namespace CA_DataUploaderLib
 {
@@ -15,6 +14,7 @@ namespace CA_DataUploaderLib
     {
         private readonly SensorSample? _rpiGpuSample;
         private readonly SensorSample? _rpiCpuSample;
+
         public ThermocoupleBox(IIOconf ioconf, CommandHandler cmd) : base(cmd, "Temperatures", GetSensors(ioconf)) 
         { // these are disabled / null when RpiTemp is disabled
             _rpiGpuSample = _values.FirstOrDefault(x => IOconfRPiTemp.IsLocalGpuSensor(x.Input));
@@ -29,8 +29,9 @@ namespace CA_DataUploaderLib
             return loops;
         }
 
-        private static async Task ReadRpiTemperaturesLoop(SensorSample gpuSample, SensorSample cpuSample, CancellationToken token)
+        private async Task ReadRpiTemperaturesLoop(SensorSample gpuSample, SensorSample cpuSample, CancellationToken token)
         {
+            LowFrequencyLog readError = new(_cmd.Time, "read error");
             var msBetweenReads = 1000; // waiting every second, for higher resolution.
             while (!token.IsCancellationRequested)
             {
@@ -47,11 +48,13 @@ namespace CA_DataUploaderLib
                 }
                 catch (Exception ex)
                 { 
-                    CALog.LogErrorAndConsoleLn(LogID.A, $"Unexpected error reading rpi temperatures", ex);
+                    readError.Log((ex, skipMessage) => LogError($"Unexpected error reading rpi temperatures{skipMessage}", ex), ex);
                 }
             }
-            
         }
+
+        private void LogError(string message, Exception ex) => _cmd.Logger.LogError(LogID.A, $"{message} - {Title}", ex);
+
 
         private static IEnumerable<IOconfInput> GetSensors(IIOconf ioconf)
         {

--- a/UnitTests/DefaultResponseParserTests.cs
+++ b/UnitTests/DefaultResponseParserTests.cs
@@ -15,6 +15,12 @@ namespace UnitTests
         [DataRow("0.01,-0.05,0.06,0xa,", 10U, 0.01, -0.05, 0.06)] //Comma after status supported, but not expected
         [DataRow("0.01,-0.05,0.06, 0xA", 10U, 0.01, -0.05, 0.06)]
         [DataRow("0.01,-0.05,0.06,0xffffffff", uint.MaxValue, 0.01, -0.05, 0.06)]
+        [DataRow("inf, -0.05, 0.06, 0xA", 10U, double.PositiveInfinity, -0.05, 0.06)]
+        [DataRow("-inf, -0.05, 0.06, 0xA", 10U, double.NegativeInfinity, -0.05, 0.06)]
+        [DataRow("0.01, inf, 0.06, 0xA", 10U, 0.01, double.PositiveInfinity, 0.06)]
+        [DataRow("0.01, -inf, 0.06, 0xA", 10U, 0.01, double.NegativeInfinity, 0.06)]
+        [DataRow("0.01, -0.05, inf, 0xA", 10U, 0.01, -0.05, double.PositiveInfinity)]
+        [DataRow("0.01, -0.05, -inf, 0xA", 10U, 0.01, -0.05, double.NegativeInfinity)]
         [TestMethod]
         public void DefaultSettingsParsesExpectedValuesFormat(string line, uint expectedStatus, params double[] expectedValues)
         {


### PR DESCRIPTION
Changes in this PR:

- LineParser: Handle "inf" values in sensor output.
- ThermocoupleBox: implement low frequency log of error messages.